### PR TITLE
feat(home): 브리더 마이홈 페이지 구현

### DIFF
--- a/src/app/(main)/home/_ui/MyHomeContent.tsx
+++ b/src/app/(main)/home/_ui/MyHomeContent.tsx
@@ -2,8 +2,14 @@
 
 import { useState } from 'react'
 import { BookmarkIcon } from '@/shared/assets/icons'
-import { Container, Separator } from '@/shared/ui'
-import { MOCK_MY_HOME_PROFILE, MOCK_MY_HOME_POSTS } from '@/shared/mocks/myHome'
+import { Container, Separator, SectionHeader } from '@/shared/ui'
+import {
+  MOCK_MY_HOME_PROFILE,
+  MOCK_BREEDER_PROFILE,
+  MOCK_MY_HOME_POSTS,
+} from '@/shared/mocks/myHome'
+import { createMockListings } from '@/shared/mocks/adoption'
+import { AdoptionCard } from '@/entities/adoption'
 import { ProfileCard } from './ProfileCard'
 import { HomeTabs, TabsContent } from './HomeTabs'
 import { HomeTitle } from './HomeTitle'
@@ -11,12 +17,20 @@ import { PostList } from './PostList'
 import { FooterPlaceholder } from './FooterPlaceholder'
 import { PostCreateBar } from './PostCreateBar'
 import { FavoriteBreedersContent } from './FavoriteBreedersContent'
-import { MY_HOME_TABS } from './constants'
+import { BreederListingCard } from './BreederListingCard'
+import { MY_HOME_TABS, BREEDER_MY_HOME_TABS } from './constants'
+
+// TODO: 실제 유저 정보에서 브리더 여부 판단
+const IS_BREEDER = true
 
 const MyHomeContent = () => {
-  const [activeTab, setActiveTab] = useState('posts')
-  const profile = MOCK_MY_HOME_PROFILE
+  const isBreeder = IS_BREEDER
+  const tabs = isBreeder ? BREEDER_MY_HOME_TABS : MY_HOME_TABS
+  const defaultTab = isBreeder ? 'listings' : 'posts'
+
+  const [activeTab, setActiveTab] = useState(defaultTab)
   const posts = MOCK_MY_HOME_POSTS
+  const listings = isBreeder ? createMockListings() : []
 
   return (
     <div className="flex w-full flex-col">
@@ -30,15 +44,51 @@ const MyHomeContent = () => {
       />
 
       <Container className="pc:px-[10rem]">
-        <ProfileCard profile={profile} />
+        {isBreeder ? (
+          <ProfileCard profile={MOCK_BREEDER_PROFILE} mode="mine-breeder" />
+        ) : (
+          <ProfileCard profile={MOCK_MY_HOME_PROFILE} />
+        )}
       </Container>
 
-      <HomeTabs tabs={MY_HOME_TABS} activeTab={activeTab} onTabChange={setActiveTab}>
+      <HomeTabs tabs={tabs} activeTab={activeTab} onTabChange={setActiveTab}>
+        {/* 브리더: 분양글 작성 바 / 일반: 게시글 작성 바 */}
         <div className="px-[1.25rem] tab:px-[6.25rem]">
-          <PostCreateBar />
+          {isBreeder ? (
+            <PostCreateBar label="분양글 작성하기" href="/adoption/create" />
+          ) : (
+            <PostCreateBar />
+          )}
         </div>
 
         <Separator className="bg-border-light" />
+
+        {/* 분양목록 탭 (브리더만) */}
+        {isBreeder && (
+          <TabsContent value="listings" className="mt-0">
+            <Container className="pc:px-[10rem]">
+              <div className="pt-5 tab:pt-8">
+                <SectionHeader
+                  title="분양목록"
+                  linkText="분양페이지 가기"
+                  linkHref="/adoption"
+                />
+              </div>
+              {/* Mobile */}
+              <div className="grid grid-cols-2 gap-[0.625rem] py-[1.25rem] tab:hidden">
+                {listings.map((listing) => (
+                  <BreederListingCard key={listing.listingId} listing={listing} />
+                ))}
+              </div>
+              {/* Desktop */}
+              <div className="hidden tab:mt-6 tab:grid tab:grid-cols-3 tab:gap-6">
+                {listings.map((listing) => (
+                  <AdoptionCard key={listing.listingId} listing={listing} />
+                ))}
+              </div>
+            </Container>
+          </TabsContent>
+        )}
 
         <TabsContent value="posts" className="mt-0">
           <Container className="pc:px-[10rem]">

--- a/src/app/(main)/home/_ui/PostCreateBar.tsx
+++ b/src/app/(main)/home/_ui/PostCreateBar.tsx
@@ -1,13 +1,21 @@
 import Link from 'next/link'
 
-const PostCreateBar = () => {
+interface PostCreateBarProps {
+  label?: string
+  href?: string
+}
+
+const PostCreateBar = ({
+  label = '게시글을 작성해보세요',
+  href = '/post/create',
+}: PostCreateBarProps) => {
   return (
     <div className="flex items-center justify-between py-[0.531rem]">
       <p className="text-sm font-medium leading-[1.375rem] text-text-primary tab:text-base">
-        게시글을 작성해보세요
+        {label}
       </p>
       <Link
-        href="/post/create"
+        href={href}
         className="flex h-8 w-[4.4375rem] items-center justify-center rounded-full bg-fill-muted text-base font-semibold text-white tab:h-12 tab:w-[7.125rem]"
       >
         작성

--- a/src/app/(main)/home/_ui/ProfileCard.tsx
+++ b/src/app/(main)/home/_ui/ProfileCard.tsx
@@ -8,7 +8,7 @@ import { cn } from '@/shared/lib/Cn'
 import { LocationIcon } from '@/shared/assets/icons'
 import type { MyHomeProfile, BreederProfile } from '@/shared/mocks/myHome'
 
-type ProfileMode = 'mine' | 'other' | 'breeder'
+type ProfileMode = 'mine' | 'mine-breeder' | 'other' | 'breeder'
 
 interface ProfileCardBaseProps {
   profile: MyHomeProfile
@@ -17,7 +17,7 @@ interface ProfileCardBaseProps {
 
 interface ProfileCardBreederProps {
   profile: BreederProfile
-  mode: 'breeder'
+  mode: 'breeder' | 'mine-breeder'
 }
 
 type ProfileCardProps = ProfileCardBaseProps | ProfileCardBreederProps
@@ -144,6 +144,7 @@ const OtherActions = () => (
 
 const ACTION_MAP = {
   mine: MineActions,
+  'mine-breeder': MineActions,
   breeder: BreederActions,
   other: OtherActions,
 } satisfies Record<ProfileMode, ComponentType>
@@ -152,7 +153,8 @@ const ACTION_MAP = {
 
 const ProfileCard = ({ profile, mode = 'mine' }: ProfileCardProps) => {
   const Actions = ACTION_MAP[mode]
-  const breederLocation = mode === 'breeder' ? (profile as BreederProfile).location : null
+  const isBreederProfile = mode === 'breeder' || mode === 'mine-breeder'
+  const breederLocation = isBreederProfile ? (profile as BreederProfile).location : null
 
   return (
     <div className="tab:overflow-hidden tab:rounded-2xl tab:bg-surface-primary">
@@ -161,7 +163,7 @@ const ProfileCard = ({ profile, mode = 'mine' }: ProfileCardProps) => {
         {/* Section 1: Badges + Nickname + Bio */}
         <div className="flex flex-col gap-2 tab:flex-1 tab:gap-0">
           <div className="flex items-center gap-1 tab:gap-3">
-            {mode === 'breeder' && (
+            {isBreederProfile && (
               <Badge variant="outline" className="h-6 text-xs leading-[1.375rem] tab:text-sm">
                 브리더
               </Badge>
@@ -176,7 +178,7 @@ const ProfileCard = ({ profile, mode = 'mine' }: ProfileCardProps) => {
             {profile.nickname}
           </p>
           {/* Location — breeder, mobile only */}
-          {mode === 'breeder' && (
+          {isBreederProfile && (
             <LocationInfo location={breederLocation!} className="mt-1 tab:hidden" />
           )}
           <Bio text={profile.bio} className="mt-3 hidden max-w-[26.1rem] tab:block" />
@@ -210,7 +212,7 @@ const ProfileCard = ({ profile, mode = 'mine' }: ProfileCardProps) => {
       />
 
       {/* Location — breeder, desktop only */}
-      {mode === 'breeder' && (
+      {isBreederProfile && (
         <LocationInfo location={breederLocation!} className="hidden py-2 tab:flex tab:px-10" />
       )}
 

--- a/src/app/(main)/home/_ui/constants.ts
+++ b/src/app/(main)/home/_ui/constants.ts
@@ -11,4 +11,10 @@ const BREEDER_HOME_TABS: HomeTabConfig[] = [
   { id: 'posts', label: '게시글' },
 ]
 
-export { MY_HOME_TABS, BREEDER_HOME_TABS }
+const BREEDER_MY_HOME_TABS: HomeTabConfig[] = [
+  { id: 'listings', label: '분양목록' },
+  { id: 'posts', label: '게시글' },
+  { id: 'breeders', label: '즐겨찾는 브리더', Icon: LockIcon },
+]
+
+export { MY_HOME_TABS, BREEDER_HOME_TABS, BREEDER_MY_HOME_TABS }


### PR DESCRIPTION
## Summary
- 브리더 회원이 `/home`에서 보는 마이홈 페이지 구현
- `MyHomeContent`에서 브리더 여부에 따라 탭/콘텐츠 분기
- `ProfileCard`에 `mine-breeder` 모드 추가 (프로필 편집 + 브리더 뱃지 + Location)

## 변경 내용
- `constants.ts`: `BREEDER_MY_HOME_TABS` 추가 (분양목록 | 게시글 | 즐겨찾는 브리더+잠금)
- `PostCreateBar`: `label`/`href` props 추가하여 분양글 작성 바로 재활용
- `ProfileCard`: `mine-breeder` 모드 추가
- `MyHomeContent`: 브리더 분기 (분양목록 섹션 + SectionHeader + AdoptionCard 그리드)

## Test plan
- [ ] `/home` 접속 시 브리더 마이홈 UI 확인 (IS_BREEDER=true)
- [ ] 3탭(분양목록, 게시글, 즐겨찾는 브리더) 전환 동작 확인
- [ ] 분양글 작성하기 바 표시 확인
- [ ] 분양목록 섹션 + "분양페이지 가기>" 링크 확인
- [ ] IS_BREEDER=false 시 기존 일반 유저 마이홈 정상 동작 확인

Closes #24