### PR TITLE
feat(explore): 브리더 탐색 페이지 구현

### DIFF
--- a/src/app/(main)/explore/_lib/constants.ts
+++ b/src/app/(main)/explore/_lib/constants.ts
@@ -1,0 +1,20 @@
+export type ExploreType = 'adoption' | 'breeder'
+
+export const EXPLORE_TABS: Array<{ type: ExploreType; label: string }> = [
+  { type: 'adoption', label: '입양 탐색' },
+  { type: 'breeder', label: '브리더 탐색' },
+]
+
+export const SEARCH_PLACEHOLDERS: Record<
+  ExploreType,
+  { mobile: string; desktop: string }
+> = {
+  adoption: {
+    mobile: '검색해서 원하는 동물 찾기',
+    desktop: '검색해서 원하는 아이 찾기',
+  },
+  breeder: {
+    mobile: '아무거나 검색해보세요',
+    desktop: '브리더를 통해 알고싶은게 있나요?',
+  },
+}

--- a/src/app/(main)/explore/_ui/BreederCardHorizontal.tsx
+++ b/src/app/(main)/explore/_ui/BreederCardHorizontal.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import Image from 'next/image'
+import Link from 'next/link'
 import { Badge, FavoriteButton, ListingStats } from '@/shared/ui'
 import type { ExploreBreeder } from '@/shared/mocks/breederExplore'
 
@@ -9,8 +10,9 @@ interface BreederCardHorizontalProps {
 }
 
 const BreederCardHorizontal = ({ breeder }: BreederCardHorizontalProps) => {
+  // TODO: API 연동 후 실제 브리더 홈 경로로 변경
   return (
-    <div className="flex items-center gap-[0.563rem] rounded-[0.375rem] bg-[#f0f0f0] px-[0.5rem] py-[0.438rem]">
+    <Link href={`/home/${breeder.id}`} className="flex items-center gap-[0.563rem] rounded-[0.375rem] bg-[#f0f0f0] px-[0.5rem] py-[0.438rem]">
       {/* 이미지 100x100 */}
       <div className="relative size-[6.25rem] shrink-0 overflow-hidden">
         {breeder.imageUrl && (
@@ -65,7 +67,7 @@ const BreederCardHorizontal = ({ breeder }: BreederCardHorizontalProps) => {
           <FavoriteButton size="sm" />
         </div>
       </div>
-    </div>
+    </Link>
   )
 }
 

--- a/src/app/(main)/explore/_ui/BreederCardHorizontal.tsx
+++ b/src/app/(main)/explore/_ui/BreederCardHorizontal.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Image from 'next/image'
-import { Badge, ListingStats } from '@/shared/ui'
+import { Badge, FavoriteButton, ListingStats } from '@/shared/ui'
 import type { ExploreBreeder } from '@/shared/mocks/breederExplore'
 
 interface BreederCardHorizontalProps {
@@ -62,15 +62,7 @@ const BreederCardHorizontal = ({ breeder }: BreederCardHorizontalProps) => {
             size="sm"
             className="w-full justify-end"
           />
-          <button
-            type="button"
-            className="flex items-center gap-1 rounded-full"
-          >
-            <Image src="/star.svg" alt="즐겨찾기" width={24} height={24} />
-            <span className="text-xs font-medium text-[#5d5d5d]">
-              즐겨찾기
-            </span>
-          </button>
+          <FavoriteButton size="sm" />
         </div>
       </div>
     </div>

--- a/src/app/(main)/explore/_ui/BreederCardHorizontal.tsx
+++ b/src/app/(main)/explore/_ui/BreederCardHorizontal.tsx
@@ -1,0 +1,80 @@
+'use client'
+
+import Image from 'next/image'
+import { Badge, ListingStats } from '@/shared/ui'
+import type { ExploreBreeder } from '@/shared/mocks/breederExplore'
+
+interface BreederCardHorizontalProps {
+  breeder: ExploreBreeder
+}
+
+const BreederCardHorizontal = ({ breeder }: BreederCardHorizontalProps) => {
+  return (
+    <div className="flex items-center gap-[0.563rem] rounded-[0.375rem] bg-[#f0f0f0] px-[0.5rem] py-[0.438rem]">
+      {/* 이미지 100x100 */}
+      <div className="relative size-[6.25rem] shrink-0 overflow-hidden">
+        {breeder.imageUrl && (
+          <Image
+            src={breeder.imageUrl}
+            alt={breeder.nickname}
+            fill
+            className="object-cover"
+          />
+        )}
+      </div>
+
+      {/* 정보 */}
+      <div className="flex min-w-0 flex-1 flex-col gap-[0.438rem]">
+        {/* 이름 + 분양중 + 뱃지 */}
+        <div className="flex flex-col gap-px">
+          <p className="line-clamp-1 text-sm font-bold leading-[1.5] text-[#5d5d5d]">
+            {breeder.nickname}
+          </p>
+          <div className="flex items-center gap-[0.313rem]">
+            {breeder.isBreeding && (
+              <Badge
+                variant="status"
+                className="h-[1.375rem] px-[0.5rem] py-[0.125rem] text-xs leading-[1.375rem]"
+              >
+                분양중
+              </Badge>
+            )}
+            <div className="flex items-center gap-1">
+              {breeder.badges.map((badge) => (
+                <Badge
+                  key={badge}
+                  variant="outline"
+                  className="h-6 text-xs leading-[1.375rem]"
+                >
+                  {badge}
+                </Badge>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* 문의/관심/조회 + 즐겨찾기 */}
+        <div className="flex flex-col items-end">
+          <ListingStats
+            inquiryCount={breeder.inquiryCount}
+            favoriteCount={breeder.favoriteCount}
+            viewCount={breeder.viewCount}
+            size="sm"
+            className="w-full justify-end"
+          />
+          <button
+            type="button"
+            className="flex items-center gap-1 rounded-full"
+          >
+            <Image src="/star.svg" alt="즐겨찾기" width={24} height={24} />
+            <span className="text-xs font-medium text-[#5d5d5d]">
+              즐겨찾기
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export { BreederCardHorizontal }

--- a/src/app/(main)/explore/_ui/BreederExploreContent.tsx
+++ b/src/app/(main)/explore/_ui/BreederExploreContent.tsx
@@ -67,6 +67,9 @@ const BreederExploreContent = () => {
           </div>
         )}
       </section>
+
+      {/* 하단 여백 */}
+      <div className="h-[4rem]" />
     </>
   )
 }

--- a/src/app/(main)/explore/_ui/BreederExploreContent.tsx
+++ b/src/app/(main)/explore/_ui/BreederExploreContent.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import { SectionHeader } from '@/shared/ui'
 import { SearchBar, PopularKeywords } from '@/features/search'
+import { SEARCH_PLACEHOLDERS } from '../_lib/constants'
 import { BreederCard } from '@/app/(main)/home/_ui/BreederCard'
 import { BreederCardHorizontal } from './BreederCardHorizontal'
 import {
@@ -23,12 +24,7 @@ const BreederExploreContent = () => {
 
       {/* 검색바 + 인기 검색어 */}
       <div className="w-full tab:mx-auto tab:mt-[1.25rem] tab:max-w-[42.5rem]">
-        <SearchBar
-          placeholder={{
-            mobile: '아무거나 검색해보세요',
-            desktop: '브리더를 통해 알고싶은게 있나요?',
-          }}
-        />
+        <SearchBar placeholder={SEARCH_PLACEHOLDERS.breeder} />
         <PopularKeywords />
       </div>
 

--- a/src/app/(main)/explore/_ui/BreederExploreContent.tsx
+++ b/src/app/(main)/explore/_ui/BreederExploreContent.tsx
@@ -1,8 +1,6 @@
 'use client'
 
 import { useState } from 'react'
-import { cn } from '@/shared/lib/Cn'
-import { cafe24Proup } from '@/shared/lib/fonts'
 import { SectionHeader } from '@/shared/ui'
 import { SearchBar, PopularKeywords } from '@/features/search'
 import { BreederCard } from '@/app/(main)/home/_ui/BreederCard'
@@ -18,15 +16,7 @@ const BreederExploreContent = () => {
 
   return (
     <>
-      {/* 타이틀 — 모바일: cafe24 14px, 데스크탑: Pretendard Bold 20px */}
-      <p
-        className={cn(
-          cafe24Proup.className,
-          'py-5 text-center font-cafe24 text-[0.875rem] leading-[1.5] text-[#5d5d5d] tab:hidden',
-        )}
-      >
-        신뢰있는 브리더들을 만나보세요
-      </p>
+      {/* 데스크탑 타이틀 */}
       <p className="hidden px-[6.25rem] py-[0.625rem] text-center text-[1.25rem] font-bold leading-[1.375rem] text-[#5d5d5d] tab:mt-[2.188rem] tab:block">
         신뢰있는 브리더들을 만나보세요
       </p>

--- a/src/app/(main)/explore/_ui/BreederExploreContent.tsx
+++ b/src/app/(main)/explore/_ui/BreederExploreContent.tsx
@@ -1,0 +1,74 @@
+'use client'
+
+import { useState } from 'react'
+import { SectionHeader } from '@/shared/ui'
+import { SearchBar, PopularKeywords } from '@/features/search'
+import { BreederCard } from '@/app/(main)/home/_ui/BreederCard'
+import {
+  MOCK_FEATURED_BREEDERS,
+  MOCK_EXPLORE_BREEDERS,
+} from '@/shared/mocks/breederExplore'
+
+const BreederExploreContent = () => {
+  const [featuredCollapsed, setFeaturedCollapsed] = useState(false)
+  const [exploreCollapsed, setExploreCollapsed] = useState(false)
+
+  return (
+    <>
+      {/* 타이틀 */}
+      <p className="hidden px-[6.25rem] py-[0.625rem] text-center text-[1.25rem] font-bold leading-[1.375rem] text-[#5d5d5d] tab:mt-[2.188rem] tab:block">
+        신뢰있는 브리더들을 만나보세요
+      </p>
+      <p className="py-5 text-center text-[0.875rem] font-semibold leading-[1.5] text-[#5d5d5d] tab:hidden">
+        신뢰있는 브리더들을 만나보세요
+      </p>
+
+      {/* 검색바 + 인기 검색어 */}
+      <div className="w-full tab:mx-auto tab:mt-[1.25rem] tab:max-w-[42.5rem]">
+        <SearchBar
+          placeholder={{
+            mobile: '브리더를 통해 알고싶은게 있나요?',
+            desktop: '브리더를 통해 알고싶은게 있나요?',
+          }}
+        />
+        <PopularKeywords />
+      </div>
+
+      {/* 주목할 브리더 */}
+      <section className="mt-[2.063rem] flex flex-col gap-[0.75rem] tab:mt-[4rem] tab:gap-[1.25rem]">
+        <SectionHeader
+          title="주목할 브리더"
+          collapsible
+          collapsed={featuredCollapsed}
+          onToggle={() => setFeaturedCollapsed((prev) => !prev)}
+        />
+        {!featuredCollapsed && (
+          <div className="flex gap-3 overflow-x-auto tab:grid tab:grid-cols-3 tab:gap-[1.156rem] tab:overflow-visible">
+            {MOCK_FEATURED_BREEDERS.map((breeder) => (
+              <BreederCard key={breeder.id} breeder={breeder} showPopularBadge />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* 브리더 탐색 */}
+      <section className="mt-[1.25rem] flex flex-col gap-[0.75rem] tab:mt-[4rem] tab:gap-[1.25rem]">
+        <SectionHeader
+          title={`브리더 탐색 ${MOCK_EXPLORE_BREEDERS.length}`}
+          collapsible
+          collapsed={exploreCollapsed}
+          onToggle={() => setExploreCollapsed((prev) => !prev)}
+        />
+        {!exploreCollapsed && (
+          <div className="grid grid-cols-2 gap-[0.97rem] tab:grid-cols-3 tab:gap-[1.156rem]">
+            {MOCK_EXPLORE_BREEDERS.map((breeder) => (
+              <BreederCard key={breeder.id} breeder={breeder} />
+            ))}
+          </div>
+        )}
+      </section>
+    </>
+  )
+}
+
+export { BreederExploreContent }

--- a/src/app/(main)/explore/_ui/BreederExploreContent.tsx
+++ b/src/app/(main)/explore/_ui/BreederExploreContent.tsx
@@ -1,9 +1,12 @@
 'use client'
 
 import { useState } from 'react'
+import { cn } from '@/shared/lib/Cn'
+import { cafe24Proup } from '@/shared/lib/fonts'
 import { SectionHeader } from '@/shared/ui'
 import { SearchBar, PopularKeywords } from '@/features/search'
 import { BreederCard } from '@/app/(main)/home/_ui/BreederCard'
+import { BreederCardHorizontal } from './BreederCardHorizontal'
 import {
   MOCK_FEATURED_BREEDERS,
   MOCK_EXPLORE_BREEDERS,
@@ -15,11 +18,16 @@ const BreederExploreContent = () => {
 
   return (
     <>
-      {/* 타이틀 */}
-      <p className="hidden px-[6.25rem] py-[0.625rem] text-center text-[1.25rem] font-bold leading-[1.375rem] text-[#5d5d5d] tab:mt-[2.188rem] tab:block">
+      {/* 타이틀 — 모바일: cafe24 14px, 데스크탑: Pretendard Bold 20px */}
+      <p
+        className={cn(
+          cafe24Proup.className,
+          'py-5 text-center font-cafe24 text-[0.875rem] leading-[1.5] text-[#5d5d5d] tab:hidden',
+        )}
+      >
         신뢰있는 브리더들을 만나보세요
       </p>
-      <p className="py-5 text-center text-[0.875rem] font-semibold leading-[1.5] text-[#5d5d5d] tab:hidden">
+      <p className="hidden px-[6.25rem] py-[0.625rem] text-center text-[1.25rem] font-bold leading-[1.375rem] text-[#5d5d5d] tab:mt-[2.188rem] tab:block">
         신뢰있는 브리더들을 만나보세요
       </p>
 
@@ -27,7 +35,7 @@ const BreederExploreContent = () => {
       <div className="w-full tab:mx-auto tab:mt-[1.25rem] tab:max-w-[42.5rem]">
         <SearchBar
           placeholder={{
-            mobile: '브리더를 통해 알고싶은게 있나요?',
+            mobile: '아무거나 검색해보세요',
             desktop: '브리더를 통해 알고싶은게 있나요?',
           }}
         />
@@ -37,24 +45,37 @@ const BreederExploreContent = () => {
       {/* 주목할 브리더 */}
       <section className="mt-[2.063rem] flex flex-col gap-[0.75rem] tab:mt-[4rem] tab:gap-[1.25rem]">
         <SectionHeader
-          title="주목할 브리더"
+          title={`주목할 브리더 ${MOCK_FEATURED_BREEDERS.length}`}
           collapsible
           collapsed={featuredCollapsed}
           onToggle={() => setFeaturedCollapsed((prev) => !prev)}
         />
         {!featuredCollapsed && (
-          <div className="flex gap-3 overflow-x-auto tab:grid tab:grid-cols-3 tab:gap-[1.156rem] tab:overflow-visible">
-            {MOCK_FEATURED_BREEDERS.map((breeder) => (
-              <BreederCard key={breeder.id} breeder={breeder} showPopularBadge />
-            ))}
-          </div>
+          <>
+            {/* 모바일: 가로형 카드 리스트 */}
+            <div className="flex flex-col gap-[0.75rem] tab:hidden">
+              {MOCK_FEATURED_BREEDERS.map((breeder) => (
+                <BreederCardHorizontal key={breeder.id} breeder={breeder} />
+              ))}
+            </div>
+            {/* 데스크탑: 3열 세로형 카드 */}
+            <div className="hidden tab:grid tab:grid-cols-3 tab:gap-[1.156rem]">
+              {MOCK_FEATURED_BREEDERS.map((breeder) => (
+                <BreederCard
+                  key={breeder.id}
+                  breeder={breeder}
+                  showPopularBadge
+                />
+              ))}
+            </div>
+          </>
         )}
       </section>
 
-      {/* 브리더 탐색 */}
+      {/* 전체 입양 소식 */}
       <section className="mt-[1.25rem] flex flex-col gap-[0.75rem] tab:mt-[4rem] tab:gap-[1.25rem]">
         <SectionHeader
-          title={`브리더 탐색 ${MOCK_EXPLORE_BREEDERS.length}`}
+          title={`전체 입양 소식 ${MOCK_EXPLORE_BREEDERS.length}`}
           collapsible
           collapsed={exploreCollapsed}
           onToggle={() => setExploreCollapsed((prev) => !prev)}

--- a/src/app/(main)/explore/_ui/ExploreContent.tsx
+++ b/src/app/(main)/explore/_ui/ExploreContent.tsx
@@ -96,7 +96,7 @@ const ExploreContent = () => {
       </div>
 
       {/* ══════ 모바일: 타이틀 + 카테고리 ══════ */}
-      <div className="flex flex-col gap-[0.75rem] p-5 tab:hidden">
+      <div className="flex flex-col gap-[0.75rem] py-5 tab:hidden">
         <p
           className={cn(
             cafe24Proup.className,

--- a/src/app/(main)/explore/_ui/ExploreContent.tsx
+++ b/src/app/(main)/explore/_ui/ExploreContent.tsx
@@ -96,7 +96,7 @@ const ExploreContent = () => {
       </div>
 
       {/* ══════ 모바일: 타이틀 + 카테고리 ══════ */}
-      <div className="flex flex-col items-center gap-[0.75rem] p-5 tab:hidden">
+      <div className="flex flex-col gap-[0.75rem] p-5 tab:hidden">
         <p
           className={cn(
             cafe24Proup.className,

--- a/src/app/(main)/explore/_ui/ExploreContent.tsx
+++ b/src/app/(main)/explore/_ui/ExploreContent.tsx
@@ -9,12 +9,11 @@ import { SearchBar, PopularKeywords } from '@/features/search'
 import { CategoryFilter } from '@/features/category-filter'
 import { AdoptionCard, AdoptionCardHorizontal } from '@/entities/adoption'
 import { createMockListings } from '@/shared/mocks/adoption'
-import { CATEGORY_DESCRIPTION } from '@/shared/types'
+import { CATEGORY_DESCRIPTION, ANIMAL_CATEGORIES } from '@/shared/types'
 import type { AnimalCategory } from '@/shared/types'
 import { BreederExploreContent } from './BreederExploreContent'
-
-type ExploreType = 'adoption' | 'breeder'
-const VALID_CATEGORIES: AnimalCategory[] = ['all', 'dog', 'cat', 'lizard']
+import { EXPLORE_TABS, SEARCH_PLACEHOLDERS } from '../_lib/constants'
+import type { ExploreType } from '../_lib/constants'
 
 const mockListings = createMockListings()
 const popularListings = mockListings.filter((l) => l.isPopular)
@@ -30,7 +29,7 @@ const ExploreContent = () => {
 
   const categoryParam = searchParams.get('category')
   const selectedCategory: AnimalCategory =
-    categoryParam && VALID_CATEGORIES.includes(categoryParam as AnimalCategory)
+    categoryParam && ANIMAL_CATEGORIES.includes(categoryParam as AnimalCategory)
       ? (categoryParam as AnimalCategory)
       : 'all'
 
@@ -67,32 +66,22 @@ const ExploreContent = () => {
     <div className="mx-auto flex w-full max-w-[67.5rem] flex-col">
       {/* 모바일 탭 — 입양 탐색 / 브리더 탐색 */}
       <div className="flex items-center tab:hidden">
-        <button
-          type="button"
-          onClick={() => handleTypeChange('adoption')}
-          className={cn(
-            cafe24Proup.className,
-            'flex flex-1 items-center justify-center border-b-2 p-[0.625rem] font-cafe24 leading-[1.375rem]',
-            selectedType === 'adoption'
-              ? 'border-[#5d5d5d] text-[0.875rem] text-[#5d5d5d]'
-              : 'border-transparent text-[0.75rem] text-[#a7a7a7]',
-          )}
-        >
-          입양 탐색
-        </button>
-        <button
-          type="button"
-          onClick={() => handleTypeChange('breeder')}
-          className={cn(
-            cafe24Proup.className,
-            'flex flex-1 items-center justify-center border-b-2 p-[0.625rem] font-cafe24 leading-[1.375rem]',
-            selectedType === 'breeder'
-              ? 'border-[#5d5d5d] text-[0.875rem] text-[#5d5d5d]'
-              : 'border-transparent text-[0.75rem] text-[#a7a7a7]',
-          )}
-        >
-          브리더 탐색
-        </button>
+        {EXPLORE_TABS.map((tab) => (
+          <button
+            key={tab.type}
+            type="button"
+            onClick={() => handleTypeChange(tab.type)}
+            className={cn(
+              cafe24Proup.className,
+              'flex flex-1 items-center justify-center border-b-2 p-[0.625rem] font-cafe24 leading-[1.375rem]',
+              selectedType === tab.type
+                ? 'border-[#5d5d5d] text-[0.875rem] text-[#5d5d5d]'
+                : 'border-transparent text-[0.75rem] text-[#a7a7a7]',
+            )}
+          >
+            {tab.label}
+          </button>
+        ))}
       </div>
 
       {/* ══════ 모바일: 타이틀 + 카테고리 ══════ */}
@@ -131,7 +120,7 @@ const ExploreContent = () => {
 
           {/* 검색바 + 인기 검색어 */}
           <div className="w-full tab:mx-auto tab:mt-[1.25rem] tab:max-w-[42.5rem]">
-            <SearchBar />
+            <SearchBar placeholder={SEARCH_PLACEHOLDERS.adoption} />
             <PopularKeywords />
           </div>
 

--- a/src/app/(main)/explore/_ui/ExploreContent.tsx
+++ b/src/app/(main)/explore/_ui/ExploreContent.tsx
@@ -95,18 +95,18 @@ const ExploreContent = () => {
         </button>
       </div>
 
-      {/* ══════ 모바일: 카테고리 (브리더 탐색에서는 카테고리만, 입양 탐색에서는 타이틀 포함) ══════ */}
-      <div className="flex flex-col gap-[0.75rem] py-5 tab:hidden">
-        {selectedType === 'adoption' && (
-          <p
-            className={cn(
-              cafe24Proup.className,
-              'font-cafe24 text-center text-[0.875rem] leading-[1.5] text-[#5d5d5d]',
-            )}
-          >
-            {CATEGORY_DESCRIPTION[selectedCategory]}
-          </p>
-        )}
+      {/* ══════ 모바일: 타이틀 + 카테고리 ══════ */}
+      <div className="flex flex-col items-center gap-[0.75rem] p-5 tab:hidden">
+        <p
+          className={cn(
+            cafe24Proup.className,
+            'font-cafe24 text-center text-[0.875rem] leading-[1.5] text-[#5d5d5d]',
+          )}
+        >
+          {selectedType === 'breeder'
+            ? '신뢰있는 브리더들을 만나보세요'
+            : CATEGORY_DESCRIPTION[selectedCategory]}
+        </p>
         <CategoryFilter
           selected={selectedCategory}
           onChange={handleCategoryChange}

--- a/src/app/(main)/explore/_ui/ExploreContent.tsx
+++ b/src/app/(main)/explore/_ui/ExploreContent.tsx
@@ -95,33 +95,35 @@ const ExploreContent = () => {
         </button>
       </div>
 
+      {/* ══════ 모바일: 카테고리 (브리더 탐색에서는 카테고리만, 입양 탐색에서는 타이틀 포함) ══════ */}
+      <div className="flex flex-col gap-[0.75rem] py-5 tab:hidden">
+        {selectedType === 'adoption' && (
+          <p
+            className={cn(
+              cafe24Proup.className,
+              'font-cafe24 text-center text-[0.875rem] leading-[1.5] text-[#5d5d5d]',
+            )}
+          >
+            {CATEGORY_DESCRIPTION[selectedCategory]}
+          </p>
+        )}
+        <CategoryFilter
+          selected={selectedCategory}
+          onChange={handleCategoryChange}
+        />
+      </div>
+
+      {/* ══════ 데스크탑: 카테고리 ══════ */}
+      <CategoryFilter
+        selected={selectedCategory}
+        onChange={handleCategoryChange}
+        className="mt-[2.188rem] hidden tab:grid"
+      />
+
       {selectedType === 'breeder' ? (
         <BreederExploreContent />
       ) : (
         <>
-          {/* ══════ 모바일: 타이틀 + 카테고리 (gap12) ══════ */}
-          <div className="flex flex-col gap-[0.75rem] py-5 tab:hidden">
-            <p
-              className={cn(
-                cafe24Proup.className,
-                'font-cafe24 text-center text-[0.875rem] leading-[1.5] text-[#5d5d5d]',
-              )}
-            >
-              {CATEGORY_DESCRIPTION[selectedCategory]}
-            </p>
-            <CategoryFilter
-              selected={selectedCategory}
-              onChange={handleCategoryChange}
-            />
-          </div>
-
-          {/* ══════ 데스크탑: 카테고리 (top146 → mt ~98px from header) ══════ */}
-          <CategoryFilter
-            selected={selectedCategory}
-            onChange={handleCategoryChange}
-            className="mt-[2.188rem] hidden tab:grid"
-          />
-
           {/* 데스크탑 타이틀 — Pretendard Bold 20px, px100, h52, 중앙 정렬 (gap 35px from category) */}
           <p className="hidden px-[6.25rem] py-[0.625rem] text-center text-[1.25rem] font-bold leading-[1.375rem] text-[#5d5d5d] tab:mt-[2.188rem] tab:block">
             {CATEGORY_DESCRIPTION[selectedCategory]}

--- a/src/app/(main)/explore/_ui/ExploreContent.tsx
+++ b/src/app/(main)/explore/_ui/ExploreContent.tsx
@@ -11,7 +11,9 @@ import { AdoptionCard, AdoptionCardHorizontal } from '@/entities/adoption'
 import { createMockListings } from '@/shared/mocks/adoption'
 import { CATEGORY_DESCRIPTION } from '@/shared/types'
 import type { AnimalCategory } from '@/shared/types'
+import { BreederExploreContent } from './BreederExploreContent'
 
+type ExploreType = 'adoption' | 'breeder'
 const VALID_CATEGORIES: AnimalCategory[] = ['all', 'dog', 'cat', 'lizard']
 
 const mockListings = createMockListings()
@@ -22,11 +24,27 @@ const ExploreContent = () => {
   const router = useRouter()
   const pathname = usePathname()
 
+  const typeParam = searchParams.get('type')
+  const selectedType: ExploreType =
+    typeParam === 'breeder' ? 'breeder' : 'adoption'
+
   const categoryParam = searchParams.get('category')
   const selectedCategory: AnimalCategory =
     categoryParam && VALID_CATEGORIES.includes(categoryParam as AnimalCategory)
       ? (categoryParam as AnimalCategory)
       : 'all'
+
+  const handleTypeChange = useCallback(
+    (type: ExploreType) => {
+      const params = new URLSearchParams()
+      if (type === 'breeder') {
+        params.set('type', 'breeder')
+      }
+      const query = params.toString()
+      router.replace(`${pathname}${query ? `?${query}` : ''}`, { scroll: false })
+    },
+    [router, pathname],
+  )
 
   const handleCategoryChange = useCallback(
     (category: AnimalCategory) => {
@@ -51,110 +69,124 @@ const ExploreContent = () => {
       <div className="flex items-center tab:hidden">
         <button
           type="button"
+          onClick={() => handleTypeChange('adoption')}
           className={cn(
             cafe24Proup.className,
-            'flex flex-1 items-center justify-center border-b-2 border-[#5d5d5d] p-[0.625rem] font-cafe24 text-[0.875rem] leading-[1.375rem] text-[#5d5d5d]',
+            'flex flex-1 items-center justify-center border-b-2 p-[0.625rem] font-cafe24 leading-[1.375rem]',
+            selectedType === 'adoption'
+              ? 'border-[#5d5d5d] text-[0.875rem] text-[#5d5d5d]'
+              : 'border-transparent text-[0.75rem] text-[#a7a7a7]',
           )}
         >
           입양 탐색
         </button>
         <button
           type="button"
+          onClick={() => handleTypeChange('breeder')}
           className={cn(
             cafe24Proup.className,
-            'flex flex-1 items-center justify-center p-[0.625rem] font-cafe24 text-[0.75rem] leading-[1.375rem] text-[#a7a7a7]',
+            'flex flex-1 items-center justify-center border-b-2 p-[0.625rem] font-cafe24 leading-[1.375rem]',
+            selectedType === 'breeder'
+              ? 'border-[#5d5d5d] text-[0.875rem] text-[#5d5d5d]'
+              : 'border-transparent text-[0.75rem] text-[#a7a7a7]',
           )}
         >
           브리더 탐색
         </button>
       </div>
 
-      {/* ══════ 모바일: 타이틀 + 카테고리 (gap12) ══════ */}
-      <div className="flex flex-col gap-[0.75rem] py-5 tab:hidden">
-        <p
-          className={cn(
-            cafe24Proup.className,
-            'font-cafe24 text-center text-[0.875rem] leading-[1.5] text-[#5d5d5d]',
-          )}
-        >
-          {CATEGORY_DESCRIPTION[selectedCategory]}
-        </p>
-        <CategoryFilter
-          selected={selectedCategory}
-          onChange={handleCategoryChange}
-        />
-      </div>
-
-      {/* ══════ 데스크탑: 카테고리 (top146 → mt ~98px from header) ══════ */}
-      <CategoryFilter
-        selected={selectedCategory}
-        onChange={handleCategoryChange}
-        className="mt-[2.188rem] hidden tab:grid"
-      />
-
-      {/* 데스크탑 타이틀 — Pretendard Bold 20px, px100, h52, 중앙 정렬 (gap 35px from category) */}
-      <p className="hidden px-[6.25rem] py-[0.625rem] text-center text-[1.25rem] font-bold leading-[1.375rem] text-[#5d5d5d] tab:mt-[2.188rem] tab:block">
-        {CATEGORY_DESCRIPTION[selectedCategory]}
-      </p>
-
-      {/* 검색바 + 인기 검색어 */}
-      <div className=" w-full tab:mx-auto tab:mt-[1.25rem] tab:max-w-[42.5rem]">
-        <SearchBar />
-        <PopularKeywords />
-      </div>
-
-      {/* ─── 인기 있는 동물들 (mo: top475→검색바 후 ~gap33, pc: top584→gap ~64px) ─── */}
-      <section className="mt-[2.063rem] flex flex-col gap-[0.75rem] tab:mt-[4rem] tab:gap-[1.25rem]">
-        <SectionHeader
-          title={`인기있는 동물들 ${popularListings.length}`}
-          collapsible
-          collapsed={popularCollapsed}
-          onToggle={() => setPopularCollapsed((prev) => !prev)}
-        />
-        {/* 모바일: 가로형 카드 리스트 (gap 12px) */}
-        {!popularCollapsed && (
-          <div className="flex flex-col gap-[0.75rem] tab:hidden">
-            {popularListings.map((listing) => (
-              <AdoptionCardHorizontal
-                key={listing.listingId}
-                listing={listing}
-              />
-            ))}
+      {selectedType === 'breeder' ? (
+        <BreederExploreContent />
+      ) : (
+        <>
+          {/* ══════ 모바일: 타이틀 + 카테고리 (gap12) ══════ */}
+          <div className="flex flex-col gap-[0.75rem] py-5 tab:hidden">
+            <p
+              className={cn(
+                cafe24Proup.className,
+                'font-cafe24 text-center text-[0.875rem] leading-[1.5] text-[#5d5d5d]',
+              )}
+            >
+              {CATEGORY_DESCRIPTION[selectedCategory]}
+            </p>
+            <CategoryFilter
+              selected={selectedCategory}
+              onChange={handleCategoryChange}
+            />
           </div>
-        )}
-        {/* 데스크탑: 3열 세로형 카드 (gap 18.493px) */}
-        <div className="hidden tab:grid tab:grid-cols-3 tab:gap-[1.156rem]">
-          {popularListings.map((listing) => (
-            <AdoptionCard key={listing.listingId} listing={listing} />
-          ))}
-        </div>
-      </section>
 
-      {/* ─── 전체 입양 소식 (mo: gap20, pc: gap64→4rem) ─── */}
-      <section className="mt-[1.25rem] flex flex-col gap-[0.75rem] tab:mt-[4rem] tab:gap-[1.25rem]">
-        <SectionHeader
-          title={`전체 입양 소식 ${mockListings.length}`}
-          collapsible
-          collapsed={allCollapsed}
-          onToggle={() => setAllCollapsed((prev) => !prev)}
-        />
-        {/* 모바일 2열 / 데스크탑 3열, gap 피그마: mo 15.5px, pc 18.493px */}
-        {!allCollapsed && (
-          <div className="grid grid-cols-2 gap-[0.97rem] tab:hidden">
-            {mockListings.map((listing) => (
-              <AdoptionCard key={listing.listingId} listing={listing} />
-            ))}
+          {/* ══════ 데스크탑: 카테고리 (top146 → mt ~98px from header) ══════ */}
+          <CategoryFilter
+            selected={selectedCategory}
+            onChange={handleCategoryChange}
+            className="mt-[2.188rem] hidden tab:grid"
+          />
+
+          {/* 데스크탑 타이틀 — Pretendard Bold 20px, px100, h52, 중앙 정렬 (gap 35px from category) */}
+          <p className="hidden px-[6.25rem] py-[0.625rem] text-center text-[1.25rem] font-bold leading-[1.375rem] text-[#5d5d5d] tab:mt-[2.188rem] tab:block">
+            {CATEGORY_DESCRIPTION[selectedCategory]}
+          </p>
+
+          {/* 검색바 + 인기 검색어 */}
+          <div className="w-full tab:mx-auto tab:mt-[1.25rem] tab:max-w-[42.5rem]">
+            <SearchBar />
+            <PopularKeywords />
           </div>
-        )}
-        <div className="hidden tab:grid tab:grid-cols-3 tab:gap-[1.156rem]">
-          {mockListings.map((listing) => (
-            <AdoptionCard key={listing.listingId} listing={listing} />
-          ))}
-        </div>
-      </section>
 
-      {/* 하단 여백 */}
-      <div className="h-[4rem]" />
+          {/* ─── 인기 있는 동물들 (mo: top475→검색바 후 ~gap33, pc: top584→gap ~64px) ─── */}
+          <section className="mt-[2.063rem] flex flex-col gap-[0.75rem] tab:mt-[4rem] tab:gap-[1.25rem]">
+            <SectionHeader
+              title={`인기있는 동물들 ${popularListings.length}`}
+              collapsible
+              collapsed={popularCollapsed}
+              onToggle={() => setPopularCollapsed((prev) => !prev)}
+            />
+            {/* 모바일: 가로형 카드 리스트 (gap 12px) */}
+            {!popularCollapsed && (
+              <div className="flex flex-col gap-[0.75rem] tab:hidden">
+                {popularListings.map((listing) => (
+                  <AdoptionCardHorizontal
+                    key={listing.listingId}
+                    listing={listing}
+                  />
+                ))}
+              </div>
+            )}
+            {/* 데스크탑: 3열 세로형 카드 (gap 18.493px) */}
+            <div className="hidden tab:grid tab:grid-cols-3 tab:gap-[1.156rem]">
+              {popularListings.map((listing) => (
+                <AdoptionCard key={listing.listingId} listing={listing} />
+              ))}
+            </div>
+          </section>
+
+          {/* ─── 전체 입양 소식 (mo: gap20, pc: gap64→4rem) ─── */}
+          <section className="mt-[1.25rem] flex flex-col gap-[0.75rem] tab:mt-[4rem] tab:gap-[1.25rem]">
+            <SectionHeader
+              title={`전체 입양 소식 ${mockListings.length}`}
+              collapsible
+              collapsed={allCollapsed}
+              onToggle={() => setAllCollapsed((prev) => !prev)}
+            />
+            {/* 모바일 2열 / 데스크탑 3열, gap 피그마: mo 15.5px, pc 18.493px */}
+            {!allCollapsed && (
+              <div className="grid grid-cols-2 gap-[0.97rem] tab:hidden">
+                {mockListings.map((listing) => (
+                  <AdoptionCard key={listing.listingId} listing={listing} />
+                ))}
+              </div>
+            )}
+            <div className="hidden tab:grid tab:grid-cols-3 tab:gap-[1.156rem]">
+              {mockListings.map((listing) => (
+                <AdoptionCard key={listing.listingId} listing={listing} />
+              ))}
+            </div>
+          </section>
+
+          {/* 하단 여백 */}
+          <div className="h-[4rem]" />
+        </>
+      )}
     </div>
   )
 }

--- a/src/app/(main)/home/_ui/BreederCard.tsx
+++ b/src/app/(main)/home/_ui/BreederCard.tsx
@@ -13,28 +13,37 @@ const BreederCard = ({ breeder, showPopularBadge }: BreederCardProps) => {
   return (
     <div className="flex w-[10.25rem] shrink-0 flex-col gap-[0.438rem] tab:w-[21.75rem] tab:gap-0 tab:overflow-hidden tab:rounded-[0.935rem] tab:bg-[#e7e7e7]">
       {/* Image Area */}
-      <div className="relative h-[10.25rem] w-full overflow-hidden rounded-[0.375rem] bg-fill-placeholder tab:aspect-[348/290] tab:h-auto tab:rounded-none">
-        {/* 분양중 badge — overlay */}
-        {breeder.isBreeding && (
-          <Badge
-            variant="status"
-            className="absolute left-[0.625rem] top-[0.766rem] px-[0.625rem] py-[0.25rem] text-xs leading-[1.375rem]"
-          >
-            분양중
-          </Badge>
+      <div className="relative h-[10.25rem] w-full overflow-hidden rounded-[0.375rem] bg-fill-placeholder tab:aspect-[348/287] tab:h-auto tab:rounded-none">
+        {breeder.imageUrl && (
+          <Image
+            src={breeder.imageUrl}
+            alt={breeder.nickname}
+            fill
+            className="object-cover"
+          />
         )}
 
         {/* 인기 badge — overlay */}
         {showPopularBadge && (
           <Badge
             variant="outline"
-            className="absolute left-[1.211rem] top-[1.011rem] border-[#a8a8a8] bg-white px-[0.625rem] py-[0.25rem] text-sm font-semibold leading-[1.375rem] text-[#a8a8a8]"
+            className="absolute left-[1.228rem] top-[1.004rem] border-[#a8a8a8] bg-white px-[0.625rem] py-[0.25rem] text-sm font-semibold leading-[1.375rem] text-[#a8a8a8]"
           >
             인기🔥
           </Badge>
         )}
 
-        {/* Star icon — overlay */}
+        {/* 분양중 badge — mobile overlay */}
+        {breeder.isBreeding && (
+          <Badge
+            variant="status"
+            className="absolute left-[0.625rem] top-[0.766rem] px-[0.625rem] py-[0.25rem] text-xs leading-[1.375rem] tab:hidden"
+          >
+            분양중
+          </Badge>
+        )}
+
+        {/* Star icon — mobile overlay */}
         <button
           type="button"
           className="absolute right-[0.625rem] top-[0.766rem] tab:hidden"
@@ -45,7 +54,7 @@ const BreederCard = ({ breeder, showPopularBadge }: BreederCardProps) => {
       </div>
 
       {/* Info Area */}
-      <div className="flex flex-col tab:px-[1.228rem] tab:pb-[0.709rem]">
+      <div className="flex flex-col tab:px-[1.228rem] tab:pb-[0.68rem] tab:pt-[1.103rem]">
         {/* Name + Status Badge (desktop) */}
         <div className="flex items-center gap-1.5">
           <p className="text-sm font-semibold leading-[1.375rem] text-text-primary tab:text-[1.169rem] tab:leading-[1.286rem]">

--- a/src/app/(main)/home/_ui/BreederCard.tsx
+++ b/src/app/(main)/home/_ui/BreederCard.tsx
@@ -27,8 +27,8 @@ const BreederCard = ({ breeder, showPopularBadge }: BreederCardProps) => {
         {/* 인기 badge — overlay */}
         {showPopularBadge && (
           <Badge
-            variant="status"
-            className="absolute bottom-[0.625rem] right-[0.625rem] bg-[#ff6b00] px-[0.625rem] py-[0.25rem] text-xs leading-[1.375rem] text-white"
+            variant="outline"
+            className="absolute left-[1.211rem] top-[1.011rem] border-[#a8a8a8] bg-white px-[0.625rem] py-[0.25rem] text-sm font-semibold leading-[1.375rem] text-[#a8a8a8]"
           >
             인기🔥
           </Badge>

--- a/src/app/(main)/home/_ui/BreederCard.tsx
+++ b/src/app/(main)/home/_ui/BreederCard.tsx
@@ -6,9 +6,10 @@ import type { FavoriteBreeder } from '@/shared/mocks/myHome'
 
 interface BreederCardProps {
   breeder: FavoriteBreeder
+  showPopularBadge?: boolean
 }
 
-const BreederCard = ({ breeder }: BreederCardProps) => {
+const BreederCard = ({ breeder, showPopularBadge }: BreederCardProps) => {
   return (
     <div className="flex w-[10.25rem] shrink-0 flex-col gap-[0.438rem] tab:w-[21.75rem] tab:gap-0 tab:overflow-hidden tab:rounded-[0.935rem] tab:bg-[#e7e7e7]">
       {/* Image Area */}
@@ -20,6 +21,16 @@ const BreederCard = ({ breeder }: BreederCardProps) => {
             className="absolute left-[0.625rem] top-[0.766rem] px-[0.625rem] py-[0.25rem] text-xs leading-[1.375rem]"
           >
             분양중
+          </Badge>
+        )}
+
+        {/* 인기 badge — overlay */}
+        {showPopularBadge && (
+          <Badge
+            variant="status"
+            className="absolute bottom-[0.625rem] right-[0.625rem] bg-[#ff6b00] px-[0.625rem] py-[0.25rem] text-xs leading-[1.375rem] text-white"
+          >
+            인기🔥
           </Badge>
         )}
 

--- a/src/app/(main)/home/_ui/BreederCard.tsx
+++ b/src/app/(main)/home/_ui/BreederCard.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import Image from 'next/image'
+import Link from 'next/link'
 import { Badge } from '@/shared/ui'
 import type { FavoriteBreeder } from '@/shared/mocks/myHome'
 
@@ -10,8 +11,9 @@ interface BreederCardProps {
 }
 
 const BreederCard = ({ breeder, showPopularBadge }: BreederCardProps) => {
+  // TODO: API 연동 후 실제 브리더 홈 경로로 변경
   return (
-    <div className="flex w-[10.25rem] shrink-0 flex-col gap-[0.438rem] tab:w-[21.75rem] tab:gap-0 tab:overflow-hidden tab:rounded-[0.935rem] tab:bg-[#e7e7e7]">
+    <Link href={`/home/${breeder.id}`} className="flex w-[10.25rem] shrink-0 flex-col gap-[0.438rem] tab:w-[21.75rem] tab:gap-0 tab:overflow-hidden tab:rounded-[0.935rem] tab:bg-[#e7e7e7]">
       {/* Image Area */}
       <div className="relative h-[10.25rem] w-full overflow-hidden rounded-[0.375rem] bg-fill-placeholder tab:aspect-[348/287] tab:h-auto tab:rounded-none">
         {breeder.imageUrl && (
@@ -107,7 +109,7 @@ const BreederCard = ({ breeder, showPopularBadge }: BreederCardProps) => {
           </button>
         </div>
       </div>
-    </div>
+    </Link>
   )
 }
 

--- a/src/features/category-browse/ui/CategoryBrowse.tsx
+++ b/src/features/category-browse/ui/CategoryBrowse.tsx
@@ -2,10 +2,10 @@ import Link from 'next/link'
 import { SectionHeader } from '@/shared/ui'
 
 const CATEGORIES = [
-  { label: '강아지', href: '' },
-  { label: '고양이', href: '' },
-  { label: '도마뱀', href: '' },
-  { label: '브리더 탐색', href: '/explore' },
+  { label: '강아지', href: '/explore?category=dog' },
+  { label: '고양이', href: '/explore?category=cat' },
+  { label: '도마뱀', href: '/explore?category=lizard' },
+  { label: '브리더 탐색', href: '/explore?type=breeder' },
 ]
 
 const CategoryBrowse = () => {
@@ -13,26 +13,17 @@ const CategoryBrowse = () => {
     <div className="flex flex-col gap-[0.75rem]">
       <SectionHeader title="둘러보기" />
       <div className="grid grid-cols-2 gap-[0.625rem] tab:grid-cols-4 tab:gap-[1.25rem]">
-        {CATEGORIES.map((category) => {
-          const inner = (
+        {CATEGORIES.map((category) => (
+          <Link
+            key={category.label}
+            href={category.href}
+            className="flex h-[4.875rem] items-center justify-center rounded-[0.375rem] bg-[#c6c6c6] tab:rounded-[1.0625rem]"
+          >
             <span className="text-[0.875rem] font-semibold text-[#5d5d5d]">
               {category.label}
             </span>
-          )
-
-          const baseClass =
-            'flex h-[4.875rem] items-center justify-center rounded-[0.375rem] bg-[#c6c6c6] tab:rounded-[1.0625rem]'
-
-          return category.href ? (
-            <Link key={category.label} href={category.href} className={baseClass}>
-              {inner}
-            </Link>
-          ) : (
-            <div key={category.label} className={baseClass}>
-              {inner}
-            </div>
-          )
-        })}
+          </Link>
+        ))}
       </div>
     </div>
   )

--- a/src/features/category-filter/ui/CategoryFilter.tsx
+++ b/src/features/category-filter/ui/CategoryFilter.tsx
@@ -2,10 +2,8 @@
 
 import { tv } from 'tailwind-variants'
 import { cn } from '@/shared/lib/Cn'
-import { CATEGORY_LABEL } from '@/shared/types'
+import { CATEGORY_LABEL, ANIMAL_CATEGORIES } from '@/shared/types'
 import type { AnimalCategory } from '@/shared/types'
-
-const CATEGORIES: AnimalCategory[] = ['all', 'dog', 'cat', 'lizard']
 
 /* 모바일: h78 w158 rounded6 gap17(1.0625rem), 데스크탑: h124 flex-1 rounded16 gap12(0.75rem) */
 const tabVariants = tv({
@@ -33,7 +31,7 @@ const CategoryFilter = ({ selected, onChange, className }: CategoryFilterProps) 
         className,
       )}
     >
-      {CATEGORIES.map((category) => (
+      {ANIMAL_CATEGORIES.map((category) => (
         <button
           key={category}
           type="button"

--- a/src/features/search/ui/SearchBar.tsx
+++ b/src/features/search/ui/SearchBar.tsx
@@ -1,10 +1,22 @@
-const SearchBar = () => {
+interface SearchBarProps {
+  placeholder?: {
+    mobile: string
+    desktop: string
+  }
+}
+
+const DEFAULT_PLACEHOLDER = {
+  mobile: '검색해서 원하는 동물 찾기',
+  desktop: '검색해서 원하는 아이 찾기',
+}
+
+const SearchBar = ({ placeholder = DEFAULT_PLACEHOLDER }: SearchBarProps) => {
   return (
     <div className="flex items-center gap-[0.25rem]">
       <div className="flex flex-1 items-center gap-[0.5rem] rounded-[0.5rem] border border-[#e5e5e5] bg-white p-[0.75rem] tab:rounded-full tab:border-[#a8a8a8] tab:px-[1.75rem] tab:py-[0.75rem]">
         <span className="flex-1 text-[0.875rem] text-[#171717] tab:font-semibold tab:text-[#a8a8a8]">
-          <span className="tab:hidden">검색해서 원하는 동물 찾기</span>
-          <span className="hidden tab:inline">검색해서 원하는 아이 찾기</span>
+          <span className="tab:hidden">{placeholder.mobile}</span>
+          <span className="hidden tab:inline">{placeholder.desktop}</span>
         </span>
       </div>
       <div className="flex size-[3rem] shrink-0 items-center justify-center rounded-[0.5rem] bg-[#3b3b3b] p-[0.5rem] tab:hidden">

--- a/src/shared/mocks/breederExplore.ts
+++ b/src/shared/mocks/breederExplore.ts
@@ -1,0 +1,40 @@
+import type { FavoriteBreeder } from './myHome'
+
+export interface ExploreBreeder extends FavoriteBreeder {
+  isPopular: boolean
+}
+
+const BREEDER_BASE: Omit<ExploreBreeder, 'id'> = {
+  nickname: '도심속 도마뱀 사장님',
+  imageUrl: null,
+  badges: ['브리더 뱃지', '80 BPM', '주목할 브리더'],
+  isBreeding: true,
+  location: '마곡동',
+  date: '2026.4.30',
+  isPopular: false,
+}
+
+export const MOCK_FEATURED_BREEDERS: ExploreBreeder[] = Array.from(
+  { length: 3 },
+  (_, i) => ({
+    ...BREEDER_BASE,
+    id: `featured-${i + 1}`,
+    isPopular: true,
+  }),
+)
+
+export const MOCK_EXPLORE_BREEDERS: ExploreBreeder[] = Array.from(
+  { length: 9 },
+  (_, i) => ({
+    ...BREEDER_BASE,
+    id: `explore-${i + 1}`,
+  }),
+)
+
+export const POPULAR_KEYWORDS = [
+  '강아지 관리',
+  '고양이 관리',
+  '개코 도마뱀 관리',
+  '개코 도마뱀 관리',
+  '개코 도마뱀 관리',
+]

--- a/src/shared/mocks/breederExplore.ts
+++ b/src/shared/mocks/breederExplore.ts
@@ -2,16 +2,22 @@ import type { FavoriteBreeder } from './myHome'
 
 export interface ExploreBreeder extends FavoriteBreeder {
   isPopular: boolean
+  inquiryCount: number
+  favoriteCount: number
+  viewCount: number
 }
 
 const BREEDER_BASE: Omit<ExploreBreeder, 'id'> = {
   nickname: '도심속 도마뱀 사장님',
   imageUrl: null,
-  badges: ['브리더 뱃지', '80 BPM', '주목할 브리더'],
+  badges: ['초보집사', '50 BPM'],
   isBreeding: true,
   location: '마곡동',
   date: '2026.4.30',
   isPopular: false,
+  inquiryCount: 1,
+  favoriteCount: 10,
+  viewCount: 20,
 }
 
 export const MOCK_FEATURED_BREEDERS: ExploreBreeder[] = Array.from(

--- a/src/shared/types/AdoptionTypes.ts
+++ b/src/shared/types/AdoptionTypes.ts
@@ -5,6 +5,9 @@
 /** 동물 카테고리 필터 */
 export type AnimalCategory = 'all' | 'dog' | 'cat' | 'lizard'
 
+/** 유효한 카테고리 목록 */
+export const ANIMAL_CATEGORIES: AnimalCategory[] = ['all', 'dog', 'cat', 'lizard']
+
 /** 카테고리 한글 라벨 매핑 */
 export const CATEGORY_LABEL: Record<AnimalCategory, string> = {
   all: '전체',


### PR DESCRIPTION
## Summary
- 홈 둘러보기 카테고리(강아지/고양이/도마뱀) 클릭 시 `/explore?category=dog` 형태로 이동
- 브리더 탐색 클릭 시 `/explore?type=breeder`로 이동하여 브리더 전용 콘텐츠 렌더링
- 모바일: 탭 전환(입양/브리더), cafe24 타이틀, 가로형 브리더 카드, 2열 그리드
- 데스크탑: 카테고리 필터, 주목할 브리더(인기🔥 배지), 3열 브리더 카드 그리드
- 리팩토링: 탭 map 처리, ANIMAL_CATEGORIES 공유, SEARCH_PLACEHOLDERS 상수화, FavoriteButton 재사용

## Test plan
- [ ] 홈에서 강아지/고양이/도마뱀 카테고리 클릭 시 `/explore?category=*`로 이동 확인
- [ ] 홈에서 브리더 탐색 클릭 시 `/explore?type=breeder`로 이동 확인
- [ ] 모바일 탭 전환(입양 탐색 ↔ 브리더 탐색) 동작 확인
- [ ] 브리더 카드 클릭 시 `/home/{id}`로 이동 확인
- [ ] 데스크탑/모바일 반응형 레이아웃 확인

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)