### PR TITLE
refactor(api): API v2 마이그레이션 및 배너 API 연결

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,16 @@
 import type { NextConfig } from 'next'
 import { withSentryConfig } from '@sentry/nextjs'
 
-const nextConfig: NextConfig = {}
+const nextConfig: NextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'kr.object.iwinv.kr',
+      },
+    ],
+  },
+}
 
 export default withSentryConfig(nextConfig, {
   org: 'colding',

--- a/src/entities/adopter/Api.ts
+++ b/src/entities/adopter/Api.ts
@@ -1,4 +1,4 @@
-import { apiClient, unwrap } from '@/shared/api'
+import { apiClient, API_VERSION, unwrap } from '@/shared/api'
 import type {
   AdopterProfileDto,
   FavoriteItemDto,
@@ -13,7 +13,9 @@ import type {
 /** 내 프로필 조회 */
 export const getAdopterProfile = () =>
   apiClient
-    .get<{ success: boolean; data: AdopterProfileDto; message?: string }>('/api/adopter/profile')
+    .get<{ success: boolean; data: AdopterProfileDto; message?: string }>(
+      `${API_VERSION}/adopter/profile`,
+    )
     .then(unwrap)
 
 /** 프로필 수정 */
@@ -23,7 +25,7 @@ export const updateAdopterProfile = (data: Partial<AdopterProfileDto>) =>
       success: boolean
       data: { adopterId: string; updatedFields: string[]; message: string }
       message?: string
-    }>('/api/adopter/profile', data)
+    }>(`${API_VERSION}/adopter/profile`, data)
     .then(unwrap)
 
 /** 회원 탈퇴 */
@@ -33,7 +35,7 @@ export const deleteAdopterAccount = (data: { reason: WithdrawReason; otherReason
       success: boolean
       data: { adopterId: string; deletedAt: string; message: string }
       message?: string
-    }>('/api/adopter/account', { data })
+    }>(`${API_VERSION}/adopter/account`, { data })
     .then(unwrap)
 
 /** 즐겨찾기 목록 */
@@ -43,17 +45,15 @@ export const getFavorites = (page = 1, limit = 20) =>
       success: boolean
       data: PaginationResponse<FavoriteItemDto>
       message?: string
-    }>('/api/adopter/favorites', { params: { page, limit } })
+    }>(`${API_VERSION}/adopter/favorites`, { params: { page, limit } })
     .then(unwrap)
 
 /** 즐겨찾기 추가 */
 export const addFavorite = (breederId: string) =>
   apiClient
     .post<{ success: boolean; data: FavoriteAddResponseDto; message?: string }>(
-      '/api/adopter/favorite',
-      {
-        breederId,
-      },
+      `${API_VERSION}/adopter/favorite`,
+      { breederId },
     )
     .then(unwrap)
 
@@ -64,7 +64,7 @@ export const removeFavorite = (breederId: string) =>
       success: boolean
       data: FavoriteRemoveResponseDto
       message?: string
-    }>(`/api/adopter/favorite/${breederId}`)
+    }>(`${API_VERSION}/adopter/favorite/${breederId}`)
     .then(unwrap)
 
 /** 내 후기 목록 */
@@ -74,7 +74,7 @@ export const getMyReviews = (page = 1, limit = 10) =>
       success: boolean
       data: PaginationResponse<MyReviewItemDto>
       message?: string
-    }>('/api/adopter/reviews', { params: { page, limit } })
+    }>(`${API_VERSION}/adopter/reviews`, { params: { page, limit } })
     .then(unwrap)
 
 /** 후기 작성 */
@@ -84,5 +84,5 @@ export const createReview = (data: ReviewCreateRequest) =>
       success: boolean
       data: { reviewId: string; message: string }
       message?: string
-    }>('/api/adopter/review', data)
+    }>(`${API_VERSION}/adopter/review`, data)
     .then(unwrap)

--- a/src/entities/application/Api.ts
+++ b/src/entities/application/Api.ts
@@ -1,4 +1,4 @@
-import { apiClient, unwrap } from '@/shared/api'
+import { apiClient, API_VERSION, unwrap } from '@/shared/api'
 import type {
   ApplicationCreateRequest,
   ApplicationListItemDto,
@@ -18,7 +18,7 @@ export const createApplication = (data: ApplicationCreateRequest) =>
       success: boolean
       data: { applicationId: string; message: string }
       message?: string
-    }>('/api/adopter/application', data)
+    }>(`${API_VERSION}/adopter/application`, data)
     .then(unwrap)
 
 /** 내 신청 목록 (입양자용) */
@@ -28,7 +28,7 @@ export const getMyApplications = (page = 1, limit = 10, animalType?: 'cat' | 'do
       success: boolean
       data: PaginationResponse<ApplicationListItemDto>
       message?: string
-    }>('/api/adopter/applications', { params: { page, limit, animalType } })
+    }>(`${API_VERSION}/adopter/applications`, { params: { page, limit, animalType } })
     .then(unwrap)
 
 /** 신청 상세 (입양자용) */
@@ -38,7 +38,7 @@ export const getApplicationDetail = (applicationId: string) =>
       success: boolean
       data: ApplicationDetailDto
       message?: string
-    }>(`/api/adopter/applications/${applicationId}`)
+    }>(`${API_VERSION}/adopter/applications/${applicationId}`)
     .then(unwrap)
 
 /** 신청 상태 변경 (브리더용) */
@@ -51,7 +51,7 @@ export const updateApplicationStatus = (
       success: boolean
       data: ApplicationStatusUpdateResponseDto
       message?: string
-    }>(`/api/breeder-management/applications/${applicationId}`, data)
+    }>(`${API_VERSION}/breeder-management/applications/${applicationId}`, data)
     .then(unwrap)
 
 /** 브리더 신청 폼 조회 (브리더 관리용) */
@@ -61,7 +61,7 @@ export const getApplicationForm = () =>
       success: boolean
       data: ApplicationFormDto
       message?: string
-    }>('/api/breeder-management/application-form')
+    }>(`${API_VERSION}/breeder-management/application-form`)
     .then(unwrap)
 
 /** 브리더 신청 폼 업데이트 */
@@ -71,5 +71,5 @@ export const updateApplicationForm = (data: ApplicationFormSimpleUpdateRequest) 
       success: boolean
       data: ApplicationFormSimpleUpdateResponse
       message?: string
-    }>('/api/breeder-management/application-form', data)
+    }>(`${API_VERSION}/breeder-management/application-form`, data)
     .then(unwrap)

--- a/src/entities/breeder/Api.ts
+++ b/src/entities/breeder/Api.ts
@@ -1,4 +1,4 @@
-import { apiClient, unwrap, unwrapNullable } from '@/shared/api'
+import { apiClient, API_VERSION, unwrap, unwrapNullable } from '@/shared/api'
 import type { ApiRequestConfig } from '@/shared/api'
 import type {
   BreederProfileResponseDto,
@@ -27,7 +27,7 @@ export const getBreederProfile = (breederId: string) =>
       success: boolean
       data: BreederProfileResponseDto
       message?: string
-    }>(`/api/breeder/${breederId}`, { skipAuth: true } as ApiRequestConfig)
+    }>(`${API_VERSION}/breeder/${breederId}`, { skipAuth: true } as ApiRequestConfig)
     .then(unwrap)
 
 /** 내 브리더 프로필 조회 */
@@ -37,7 +37,7 @@ export const getMyBreederProfile = () =>
       success: boolean
       data: BreederProfileResponseDto
       message?: string
-    }>('/api/breeder-management/profile')
+    }>(`${API_VERSION}/breeder-management/profile`)
     .then(unwrap)
 
 /** 브리더 프로필 수정 */
@@ -47,7 +47,7 @@ export const updateBreederProfile = (data: ProfileUpdateRequestDto) =>
       success: boolean
       data: BreederProfileUpdateResponseDto
       message?: string
-    }>('/api/breeder-management/profile', data)
+    }>(`${API_VERSION}/breeder-management/profile`, data)
     .then(unwrap)
 
 /** 브리더 대시보드 조회 */
@@ -57,7 +57,7 @@ export const getBreederDashboard = () =>
       success: boolean
       data: DashboardResponseDto
       message?: string
-    }>('/api/breeder-management/dashboard')
+    }>(`${API_VERSION}/breeder-management/dashboard`)
     .then(unwrap)
 
 /** 브리더 탐색/검색 */
@@ -67,15 +67,16 @@ export const exploreBreeders = (params: SearchBreederParams = {}) =>
       success: boolean
       data: PaginationResponse<Breeder>
       message?: string
-    }>('/api/breeder/explore', params)
+    }>(`${API_VERSION}/breeder/explore`, params)
     .then(unwrap)
 
 /** 인기 브리더 목록 */
 export const getPopularBreeders = () =>
   apiClient
-    .get<{ success: boolean; data: Breeder[]; message?: string }>('/api/breeder/popular', {
-      skipAuth: true,
-    } as ApiRequestConfig)
+    .get<{ success: boolean; data: Breeder[]; message?: string }>(
+      `${API_VERSION}/breeder/popular`,
+      { skipAuth: true } as ApiRequestConfig,
+    )
     .then(unwrap)
 
 /** 분양 개체 목록 */
@@ -85,7 +86,7 @@ export const getBreederPets = (breederId: string, page = 1, limit = 20) =>
       success: boolean
       data: PaginationResponse<AvailablePetSummaryDto>
       message?: string
-    }>(`/api/breeder/${breederId}/pets`, {
+    }>(`${API_VERSION}/breeder/${breederId}/pets`, {
       params: { page, limit },
       skipAuth: true,
     } as ApiRequestConfig)
@@ -98,7 +99,7 @@ export const getParentPets = (breederId: string, page = 1, limit = 4) =>
       success: boolean
       data: PaginationResponse<ParentPetSummaryDto>
       message?: string
-    }>(`/api/breeder/${breederId}/parent-pets`, {
+    }>(`${API_VERSION}/breeder/${breederId}/parent-pets`, {
       params: { page, limit },
       skipAuth: true,
     } as ApiRequestConfig)
@@ -111,7 +112,7 @@ export const getBreederReviews = (breederId: string, page = 1, limit = 10) =>
       success: boolean
       data: PaginationResponse<PublicReviewDto>
       message?: string
-    }>(`/api/breeder/${breederId}/reviews`, {
+    }>(`${API_VERSION}/breeder/${breederId}/reviews`, {
       params: { page, limit },
       skipAuth: true,
     } as ApiRequestConfig)
@@ -124,7 +125,9 @@ export const getBreederApplicationForm = (breederId: string) =>
       success: boolean
       data: BreederApplicationFormDto
       message?: string
-    }>(`/api/breeder/${breederId}/application-form`, { skipAuth: true } as ApiRequestConfig)
+    }>(`${API_VERSION}/breeder/${breederId}/application-form`, {
+      skipAuth: true,
+    } as ApiRequestConfig)
     .then(unwrap)
 
 /** 받은 신청 목록 (브리더용) */
@@ -134,7 +137,7 @@ export const getReceivedApplications = (page = 1, limit = 10) =>
       success: boolean
       data: PaginationResponse<ReceivedApplicationItemDto>
       message?: string
-    }>('/api/breeder-management/applications', { params: { page, limit } })
+    }>(`${API_VERSION}/breeder-management/applications`, { params: { page, limit } })
     .then(unwrap)
 
 /** 받은 신청 상세 (브리더용) */
@@ -144,7 +147,7 @@ export const getReceivedApplicationDetail = (applicationId: string) =>
       success: boolean
       data: ReceivedApplicationDetailDto
       message?: string
-    }>(`/api/breeder-management/applications/${applicationId}`)
+    }>(`${API_VERSION}/breeder-management/applications/${applicationId}`)
     .then(unwrap)
 
 /** 신청 상태 변경 (브리더용) */
@@ -157,7 +160,7 @@ export const updateBreederApplicationStatus = (
       success: boolean
       data: ApplicationStatusUpdateResponseDto
       message?: string
-    }>(`/api/breeder-management/applications/${applicationId}`, data)
+    }>(`${API_VERSION}/breeder-management/applications/${applicationId}`, data)
     .then(unwrap)
 
 /** 채팅 메시지 조회 */
@@ -168,7 +171,7 @@ export const getApplicationChatMessages = async (
     success: boolean
     data: ChatMessageDto[] | { messages?: ChatMessageDto[]; items?: ChatMessageDto[] }
     message?: string
-  }>(`/api/breeder-management/applications/${applicationId}/chat/messages`)
+  }>(`${API_VERSION}/breeder-management/applications/${applicationId}/chat/messages`)
 
   const data = unwrap(res)
   if (Array.isArray(data)) return data
@@ -184,5 +187,5 @@ export const sendApplicationChatMessage = (applicationId: string, data: SendChat
       success: boolean
       data: ChatMessageDto | null
       message?: string
-    }>(`/api/breeder-management/applications/${applicationId}/chat/messages`, data)
+    }>(`${API_VERSION}/breeder-management/applications/${applicationId}/chat/messages`, data)
     .then((res) => unwrapNullable(res, '채팅 메시지 전송에 실패했습니다.'))

--- a/src/entities/chat/Api.ts
+++ b/src/entities/chat/Api.ts
@@ -1,4 +1,4 @@
-import { apiClient, unwrap, unwrapVoid } from '@/shared/api'
+import { apiClient, API_VERSION, unwrap, unwrapVoid } from '@/shared/api'
 import type {
   ChatRoomResponseDto,
   ChatMessageResponseDto,
@@ -9,7 +9,9 @@ import type {
 /** 내 채팅방 목록 조회 */
 export const getChatRooms = () =>
   apiClient
-    .get<{ success: boolean; data: ChatRoomResponseDto[]; message?: string }>('/api/chat/rooms')
+    .get<{ success: boolean; data: ChatRoomResponseDto[]; message?: string }>(
+      `${API_VERSION}/chat/rooms`,
+    )
     .then(unwrap)
 
 /** 채팅방 생성 또는 기존 방 조회 */
@@ -19,13 +21,15 @@ export const createOrGetChatRoom = (data: CreateRoomRequestDto) =>
       success: boolean
       data: ChatRoomResponseDto
       message?: string
-    }>('/api/chat/rooms', data)
+    }>(`${API_VERSION}/chat/rooms`, data)
     .then(unwrap)
 
 /** 채팅방 종료 */
 export const closeChatRoom = (roomId: string) =>
   apiClient
-    .delete<{ success: boolean; data: object; message?: string }>(`/api/chat/rooms/${roomId}`)
+    .delete<{ success: boolean; data: object; message?: string }>(
+      `${API_VERSION}/chat/rooms/${roomId}`,
+    )
     .then(unwrapVoid)
 
 /** 채팅 메시지 내역 조회 (커서 기반 페이지네이션) */
@@ -35,7 +39,7 @@ export const getChatMessages = (roomId: string, limit?: number, before?: string)
       success: boolean
       data: ChatMessageResponseDto[]
       message?: string
-    }>(`/api/chat/rooms/${roomId}/messages`, { params: { limit, before } })
+    }>(`${API_VERSION}/chat/rooms/${roomId}/messages`, { params: { limit, before } })
     .then(unwrap)
 
 /** 채팅 메시지 전송 */
@@ -45,5 +49,5 @@ export const sendChatMessage = (roomId: string, data: SendChatMessageRequest) =>
       success: boolean
       data: ChatMessageResponseDto
       message?: string
-    }>(`/api/chat/rooms/${roomId}/messages`, data)
+    }>(`${API_VERSION}/chat/rooms/${roomId}/messages`, data)
     .then(unwrap)

--- a/src/entities/community/Api.ts
+++ b/src/entities/community/Api.ts
@@ -1,4 +1,4 @@
-import { apiClient, unwrap, unwrapVoid } from '@/shared/api'
+import { apiClient, API_VERSION, unwrap, unwrapVoid } from '@/shared/api'
 import type {
   ApiResponseFull,
   PaginationResponse,
@@ -20,7 +20,7 @@ export const getCommunityPosts = async (
   if (params.pageSize) query.set('pageSize', String(params.pageSize))
 
   const response = await apiClient.get<ApiResponseFull<PaginationResponse<CommunityPostCard>>>(
-    `/api/v2/community/posts?${query.toString()}`,
+    `${API_VERSION}/community/posts?${query.toString()}`,
   )
 
   return unwrap(response, '커뮤니티 게시글 목록 조회에 실패했습니다.')
@@ -29,31 +29,31 @@ export const getCommunityPosts = async (
 /** 커뮤니티 게시글 상세 조회 */
 export const getCommunityPostDetail = async (postId: string): Promise<CommunityPostDetail> => {
   const response = await apiClient.get<ApiResponseFull<CommunityPostDetail>>(
-    `/api/v2/community/posts/${postId}`,
+    `${API_VERSION}/community/posts/${postId}`,
   )
   return unwrap(response, '커뮤니티 게시글 조회에 실패했습니다.')
 }
 
 /** 게시글 좋아요 */
 export const likeCommunityPost = async (postId: string): Promise<void> => {
-  const response = await apiClient.post(`/api/v2/community/posts/${postId}/like`)
+  const response = await apiClient.post(`${API_VERSION}/community/posts/${postId}/like`)
   unwrapVoid(response, '좋아요 처리에 실패했습니다.')
 }
 
 /** 게시글 좋아요 취소 */
 export const unlikeCommunityPost = async (postId: string): Promise<void> => {
-  const response = await apiClient.delete(`/api/v2/community/posts/${postId}/like`)
+  const response = await apiClient.delete(`${API_VERSION}/community/posts/${postId}/like`)
   unwrapVoid(response, '좋아요 취소에 실패했습니다.')
 }
 
 /** 게시글 북마크 */
 export const bookmarkCommunityPost = async (postId: string): Promise<void> => {
-  const response = await apiClient.post(`/api/v2/community/posts/${postId}/bookmark`)
+  const response = await apiClient.post(`${API_VERSION}/community/posts/${postId}/bookmark`)
   unwrapVoid(response, '북마크 처리에 실패했습니다.')
 }
 
 /** 게시글 북마크 취소 */
 export const unbookmarkCommunityPost = async (postId: string): Promise<void> => {
-  const response = await apiClient.delete(`/api/v2/community/posts/${postId}/bookmark`)
+  const response = await apiClient.delete(`${API_VERSION}/community/posts/${postId}/bookmark`)
   unwrapVoid(response, '북마크 취소에 실패했습니다.')
 }

--- a/src/entities/feed/Api.ts
+++ b/src/entities/feed/Api.ts
@@ -1,4 +1,4 @@
-import { apiClient, unwrap } from '@/shared/api'
+import { apiClient, API_VERSION, unwrap } from '@/shared/api'
 import type { FeedVideo, FeedComment, PaginationResponse } from '@/shared/types'
 
 /** 백엔드 원본 비디오 타입 */
@@ -35,9 +35,9 @@ interface BackendComment {
   isOwner: boolean
 }
 
-function transformVideo(v: BackendFeedVideo): FeedVideo {
+const transformVideo = (v: BackendFeedVideo): FeedVideo => {
   const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://localhost:8080'
-  const hlsUrl = `${baseUrl}/api/feed/videos/stream/${v.videoId}/master.m3u8`
+  const hlsUrl = `${baseUrl}${API_VERSION}/feed/videos/stream/${v.videoId}/master.m3u8`
   return {
     _id: v.videoId,
     uploaderId: v.uploadedBy._id,
@@ -59,21 +59,19 @@ function transformVideo(v: BackendFeedVideo): FeedVideo {
   }
 }
 
-function transformComment(c: BackendComment, videoId: string): FeedComment {
-  return {
-    _id: c.commentId,
-    commentId: c.commentId,
-    videoId,
-    userId: c.author._id,
-    userName: c.author.name || c.author.businessName || 'Unknown',
-    userProfileImage: c.author.profileImageFileName,
-    content: c.content,
-    likeCount: c.likeCount,
-    replyCount: c.replyCount,
-    isOwner: c.isOwner,
-    createdAt: c.createdAt,
-  }
-}
+const transformComment = (c: BackendComment, videoId: string): FeedComment => ({
+  _id: c.commentId,
+  commentId: c.commentId,
+  videoId,
+  userId: c.author._id,
+  userName: c.author.name || c.author.businessName || 'Unknown',
+  userProfileImage: c.author.profileImageFileName,
+  content: c.content,
+  likeCount: c.likeCount,
+  replyCount: c.replyCount,
+  isOwner: c.isOwner,
+  createdAt: c.createdAt,
+})
 
 /** 피드 비디오 목록 조회 */
 export const getFeedVideos = async (
@@ -88,7 +86,7 @@ export const getFeedVideos = async (
   const response = await apiClient.get<{
     items: BackendFeedVideo[]
     pagination: PaginationResponse<FeedVideo>['pagination']
-  }>(`/api/feed/videos?${params.toString()}`)
+  }>(`${API_VERSION}/feed/videos?${params.toString()}`)
 
   return {
     items: response.data.items.map(transformVideo),
@@ -102,7 +100,7 @@ export const toggleVideoLike = (videoId: string) =>
     .post<{
       success: boolean
       data: { videoId: string; isLiked: boolean; likeCount: number }
-    }>(`/api/feed/like/${videoId}`)
+    }>(`${API_VERSION}/feed/like/${videoId}`)
     .then((res) => unwrap(res, '좋아요 처리에 실패했습니다.'))
 
 /** 비디오 댓글 목록 조회 */
@@ -114,7 +112,7 @@ export const getVideoComments = async (
   const response = await apiClient.get<{
     success: boolean
     data: { comments: BackendComment[]; totalCount: number; hasNextPage: boolean }
-  }>(`/api/feed/comment/${videoId}?page=${page}&limit=${limit}`)
+  }>(`${API_VERSION}/feed/comment/${videoId}?page=${page}&limit=${limit}`)
 
   const data = unwrap(response, '댓글 목록 조회에 실패했습니다.')
   return {
@@ -126,7 +124,7 @@ export const getVideoComments = async (
 
 /** 댓글 작성 */
 export const createVideoComment = (videoId: string, content: string) =>
-  apiClient.post(`/api/feed/comment/${videoId}`, { content }).then((res) => res.data)
+  apiClient.post(`${API_VERSION}/feed/comment/${videoId}`, { content }).then((res) => res.data)
 
 /** 태그 검색 */
 export const searchTags = (query: string) =>
@@ -134,11 +132,11 @@ export const searchTags = (query: string) =>
     .get<{
       success: boolean
       data: { tags: string[] }
-    }>(`/api/feed/tag/search?q=${encodeURIComponent(query)}`)
+    }>(`${API_VERSION}/feed/tag/search?q=${encodeURIComponent(query)}`)
     .then((res) => unwrap(res, '태그 검색에 실패했습니다.').tags)
 
 /** HLS 스트리밍 URL 생성 */
 export const getHlsStreamUrl = (videoId: string, filename: string): string => {
   const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://localhost:8080'
-  return `${baseUrl}/api/feed/videos/stream/${videoId}/${filename}`
+  return `${baseUrl}${API_VERSION}/feed/videos/stream/${videoId}/${filename}`
 }

--- a/src/entities/filter/Api.ts
+++ b/src/entities/filter/Api.ts
@@ -1,8 +1,10 @@
-import { apiClient, unwrap } from '@/shared/api'
+import { apiClient, API_VERSION, unwrap } from '@/shared/api'
 import type { AllFilterOptions } from '@/shared/types'
 
 /** 전체 필터 옵션 조회 */
 export const getAllFilterOptions = () =>
   apiClient
-    .get<{ success: boolean; data: AllFilterOptions; message?: string }>('/api/filter-options')
+    .get<{ success: boolean; data: AllFilterOptions; message?: string }>(
+      `${API_VERSION}/filter-options`,
+    )
     .then(unwrap)

--- a/src/entities/home/Api.ts
+++ b/src/entities/home/Api.ts
@@ -1,26 +1,32 @@
-import { apiClient, unwrap } from '@/shared/api'
+import { apiClient, API_VERSION, unwrap } from '@/shared/api'
 import type { ApiResponseFull, BannerDto, FaqDto, AvailablePetDto } from '@/shared/types'
 
 /** 활성 배너 목록 */
 export const getBanners = () =>
   apiClient
-    .get<ApiResponseFull<BannerDto[]>>('/api/home/banners')
+    .get<ApiResponseFull<BannerDto[]>>(`${API_VERSION}/home/banners`)
     .then((res) => unwrap(res, '배너 목록 조회에 실패했습니다.'))
 
 /** 입양자용 FAQ */
 export const getAdopterFaqs = () =>
   apiClient
-    .get<ApiResponseFull<FaqDto[]>>('/api/home/faqs', { params: { userType: 'adopter' } })
+    .get<ApiResponseFull<FaqDto[]>>(`${API_VERSION}/home/faqs`, {
+      params: { userType: 'adopter' },
+    })
     .then((res) => unwrap(res, '입양자 FAQ 조회에 실패했습니다.'))
 
 /** 브리더용 FAQ */
 export const getBreederFaqs = () =>
   apiClient
-    .get<ApiResponseFull<FaqDto[]>>('/api/home/faqs', { params: { userType: 'breeder' } })
+    .get<ApiResponseFull<FaqDto[]>>(`${API_VERSION}/home/faqs`, {
+      params: { userType: 'breeder' },
+    })
     .then((res) => unwrap(res, '브리더 FAQ 조회에 실패했습니다.'))
 
 /** 분양중인 아이들 */
 export const getAvailablePets = (limit = 10) =>
   apiClient
-    .get<ApiResponseFull<AvailablePetDto[]>>('/api/home/available-pets', { params: { limit } })
+    .get<ApiResponseFull<AvailablePetDto[]>>(`${API_VERSION}/home/available-pets`, {
+      params: { limit },
+    })
     .then((res) => unwrap(res, '분양중인 아이들 조회에 실패했습니다.'))

--- a/src/entities/inquiry/Api.ts
+++ b/src/entities/inquiry/Api.ts
@@ -1,4 +1,4 @@
-import { ApiError, apiClient, unwrap, unwrapVoid } from '@/shared/api'
+import { ApiError, apiClient, API_VERSION, unwrap, unwrapVoid } from '@/shared/api'
 import type {
   ApiResponse,
   Inquiry,
@@ -15,7 +15,7 @@ export const getInquiries = async (
   sort: InquirySortType,
 ): Promise<InquiryListResponse> => {
   return apiClient
-    .get<ApiResponse<InquiryListResponse>>('/api/inquiry', {
+    .get<ApiResponse<InquiryListResponse>>(`${API_VERSION}/inquiry`, {
       params: { page, limit: 15, animalType, sort },
     })
     .then((res) => unwrap(res, '문의 목록 조회에 실패했습니다.'))
@@ -24,7 +24,9 @@ export const getInquiries = async (
 /** 문의 상세 조회 */
 export const getInquiryDetail = async (inquiryId: string): Promise<Inquiry | null> => {
   try {
-    const response = await apiClient.get<ApiResponse<Inquiry>>(`/api/inquiry/${inquiryId}`)
+    const response = await apiClient.get<ApiResponse<Inquiry>>(
+      `${API_VERSION}/inquiry/${inquiryId}`,
+    )
     return unwrap(response, '문의 상세 조회에 실패했습니다.')
   } catch (error) {
     if (error instanceof ApiError && error.status === 404) {
@@ -37,7 +39,7 @@ export const getInquiryDetail = async (inquiryId: string): Promise<Inquiry | nul
 /** 문의 작성 */
 export const createInquiry = async (data: CreateInquiryRequest): Promise<{ inquiryId: string }> => {
   return apiClient
-    .post<ApiResponse<{ inquiryId: string }>>('/api/inquiry', data)
+    .post<ApiResponse<{ inquiryId: string }>>(`${API_VERSION}/inquiry`, data)
     .then((res) => unwrap(res, '문의 작성에 실패했습니다.'))
 }
 
@@ -47,7 +49,7 @@ export const getBreederInquiries = async (
   page: number,
 ): Promise<InquiryListResponse> => {
   return apiClient
-    .get<ApiResponse<InquiryListResponse>>('/api/inquiry/breeder', {
+    .get<ApiResponse<InquiryListResponse>>(`${API_VERSION}/inquiry/breeder`, {
       params: { answered, page, limit: 15 },
     })
     .then((res) => unwrap(res, '문의 답변 목록 조회에 실패했습니다.'))
@@ -55,8 +57,9 @@ export const getBreederInquiries = async (
 
 /** 답변 작성 */
 export const createInquiryAnswer = async (inquiryId: string, content: string): Promise<void> => {
-  const response = await apiClient.post<ApiResponse<null>>(`/api/inquiry/${inquiryId}/answer`, {
-    content,
-  })
+  const response = await apiClient.post<ApiResponse<null>>(
+    `${API_VERSION}/inquiry/${inquiryId}/answer`,
+    { content },
+  )
   unwrapVoid(response, '답변 작성에 실패했습니다.')
 }

--- a/src/entities/notice/Api.ts
+++ b/src/entities/notice/Api.ts
@@ -1,10 +1,10 @@
-import { apiClient, unwrap } from '@/shared/api'
+import { apiClient, API_VERSION, unwrap } from '@/shared/api'
 import type { ApiResponseFull, PaginationResponse, Notice } from '@/shared/types'
 
 /** 공지사항 목록 조회 */
 export const getNoticeList = async (page = 1, limit = 10): Promise<PaginationResponse<Notice>> =>
   apiClient
-    .get<ApiResponseFull<PaginationResponse<Notice>>>('/api/notice', {
+    .get<ApiResponseFull<PaginationResponse<Notice>>>(`${API_VERSION}/notice`, {
       params: { page, limit },
     })
     .then((res) => unwrap(res, '공지사항 목록 조회에 실패했습니다.'))
@@ -12,5 +12,5 @@ export const getNoticeList = async (page = 1, limit = 10): Promise<PaginationRes
 /** 공지사항 상세 조회 */
 export const getNoticeDetail = async (noticeId: string): Promise<Notice> =>
   apiClient
-    .get<ApiResponseFull<Notice>>(`/api/notice/${noticeId}`)
+    .get<ApiResponseFull<Notice>>(`${API_VERSION}/notice/${noticeId}`)
     .then((res) => unwrap(res, '공지사항 상세 조회에 실패했습니다.'))

--- a/src/entities/notification/Api.ts
+++ b/src/entities/notification/Api.ts
@@ -1,4 +1,4 @@
-import { apiClient, unwrap, unwrapVoid } from '@/shared/api'
+import { apiClient, API_VERSION, unwrap, unwrapVoid } from '@/shared/api'
 import type { ApiResponseFull, NotificationResponseDto, PaginationResponse } from '@/shared/types'
 
 /** 알림 목록 조회 */
@@ -10,16 +10,17 @@ export const getNotifications = async (
   const params: Record<string, unknown> = { page, limit }
   if (isRead !== undefined) params.isRead = isRead
   return apiClient
-    .get<ApiResponseFull<PaginationResponse<NotificationResponseDto>>>('/api/notification', {
-      params,
-    })
+    .get<ApiResponseFull<PaginationResponse<NotificationResponseDto>>>(
+      `${API_VERSION}/notification`,
+      { params },
+    )
     .then((res) => unwrap(res, '알림 목록 조회에 실패했습니다.'))
 }
 
 /** 읽지 않은 알림 수 조회 */
 export const getUnreadCount = async (): Promise<number> => {
   return apiClient
-    .get<ApiResponseFull<{ unreadCount: number }>>('/api/notification/unread-count')
+    .get<ApiResponseFull<{ unreadCount: number }>>(`${API_VERSION}/notification/unread-count`)
     .then((res) => unwrap(res, '읽지 않은 알림 수를 불러오는데 실패했습니다.').unreadCount)
 }
 
@@ -28,21 +29,21 @@ export const markAsRead = async (notificationId: string) => {
   return apiClient
     .patch<
       ApiResponseFull<{ notificationId: string; isRead: boolean; readAt: string }>
-    >(`/api/notification/${notificationId}/read`)
+    >(`${API_VERSION}/notification/${notificationId}/read`)
     .then((res) => unwrap(res, '알림 읽음 처리에 실패했습니다.'))
 }
 
 /** 전체 알림 읽음 처리 */
 export const markAllAsRead = async () => {
   return apiClient
-    .patch<ApiResponseFull<{ updatedCount: number }>>('/api/notification/read-all')
+    .patch<ApiResponseFull<{ updatedCount: number }>>(`${API_VERSION}/notification/read-all`)
     .then((res) => unwrap(res, '모든 알림 읽음 처리에 실패했습니다.'))
 }
 
 /** 알림 삭제 */
 export const deleteNotification = async (notificationId: string): Promise<void> => {
   const response = await apiClient.delete<ApiResponseFull<null>>(
-    `/api/notification/${notificationId}`,
+    `${API_VERSION}/notification/${notificationId}`,
   )
   unwrapVoid(response, '알림 삭제에 실패했습니다.')
 }

--- a/src/features/auth/api.ts
+++ b/src/features/auth/api.ts
@@ -1,4 +1,4 @@
-import { apiClient, unwrap, unwrapVoid } from '@/shared/api'
+import { apiClient, API_VERSION, unwrap, unwrapVoid } from '@/shared/api'
 import type {
   ApiResponse,
   AuthResponseDto,
@@ -8,33 +8,36 @@ import type {
 
 export const checkEmailDuplicate = (email: string) =>
   apiClient
-    .post<ApiResponse<{ isDuplicate: boolean }>>('/api/auth/check-email', { email })
+    .post<ApiResponse<{ isDuplicate: boolean }>>(`${API_VERSION}/auth/check-email`, { email })
     .then((res) => unwrap(res, '이메일 중복 확인에 실패했습니다.').isDuplicate)
 
 export const checkNicknameDuplicate = (nickname: string) =>
   apiClient
-    .post<ApiResponse<{ isDuplicate: boolean }>>('/api/auth/check-nickname', { nickname })
+    .post<ApiResponse<{ isDuplicate: boolean }>>(`${API_VERSION}/auth/check-nickname`, { nickname })
     .then((res) => unwrap(res, '닉네임 중복 확인에 실패했습니다.').isDuplicate)
 
 export const checkBreederNameDuplicate = (breederName: string) =>
   apiClient
-    .post<ApiResponse<{ isDuplicate: boolean }>>('/api/auth/check-breeder-name', { breederName })
+    .post<ApiResponse<{ isDuplicate: boolean }>>(`${API_VERSION}/auth/check-breeder-name`, {
+      breederName,
+    })
     .then((res) => unwrap(res, '브리더 상호명 중복 확인에 실패했습니다.').isDuplicate)
 
 export const sendVerificationCode = async (phone: string): Promise<void> => {
   const cleanPhone = phone.replace(/-/g, '')
-  const response = await apiClient.post<ApiResponse<null>>('/api/auth/phone/send-code', {
-    phone: cleanPhone,
-  })
+  const response = await apiClient.post<ApiResponse<null>>(
+    `${API_VERSION}/auth/phone/send-code`,
+    { phone: cleanPhone },
+  )
   unwrapVoid(response, '인증 코드 발송에 실패했습니다.')
 }
 
 export const verifyCode = async (phone: string, code: string): Promise<void> => {
   const cleanPhone = phone.replace(/-/g, '')
-  const response = await apiClient.post<ApiResponse<null>>('/api/auth/phone/verify-code', {
-    phone: cleanPhone,
-    code,
-  })
+  const response = await apiClient.post<ApiResponse<null>>(
+    `${API_VERSION}/auth/phone/verify-code`,
+    { phone: cleanPhone, code },
+  )
   unwrapVoid(response, '인증 코드 확인에 실패했습니다.')
 }
 
@@ -42,7 +45,7 @@ export const completeAdopterRegistration = async (
   data: AdopterRegistrationDto,
 ): Promise<AuthResponseDto> =>
   apiClient
-    .post<ApiResponse<AuthResponseDto>>('/api/auth/social/complete', {
+    .post<ApiResponse<AuthResponseDto>>(`${API_VERSION}/auth/social/complete`, {
       tempId: data.tempId,
       email: data.email,
       name: data.name,
@@ -57,7 +60,7 @@ export const completeBreederRegistration = async (
   data: BreederRegistrationDto,
 ): Promise<AuthResponseDto> =>
   apiClient
-    .post<ApiResponse<AuthResponseDto>>('/api/auth/social/complete', {
+    .post<ApiResponse<AuthResponseDto>>(`${API_VERSION}/auth/social/complete`, {
       ...data,
       role: 'breeder',
     })
@@ -74,10 +77,11 @@ export const uploadBreederDocuments = async (
   formData.append('level', level)
 
   return apiClient
-    .post<ApiResponse<{ documentUrls: string[] }>>('/api/auth/upload-breeder-documents', formData, {
-      headers: { 'Content-Type': 'multipart/form-data' },
-      params: { tempId },
-    })
+    .post<ApiResponse<{ documentUrls: string[] }>>(
+      `${API_VERSION}/auth/upload-breeder-documents`,
+      formData,
+      { params: { tempId } },
+    )
     .then((res) => unwrap(res, '서류 업로드에 실패했습니다.'))
 }
 
@@ -88,13 +92,11 @@ export const uploadProfileImage = async (
   const formData = new FormData()
   formData.append('file', file)
   const url = tempId
-    ? `/api/auth/upload-breeder-profile?tempId=${encodeURIComponent(tempId)}`
-    : '/api/auth/upload-breeder-profile'
+    ? `${API_VERSION}/auth/upload-breeder-profile?tempId=${encodeURIComponent(tempId)}`
+    : `${API_VERSION}/auth/upload-breeder-profile`
 
   return apiClient
-    .post<ApiResponse<{ url: string; filename: string; size: number }>>(url, formData, {
-      headers: { 'Content-Type': 'multipart/form-data' },
-    })
+    .post<ApiResponse<{ url: string; filename: string; size: number }>>(url, formData)
     .then((res) => unwrap(res, '프로필 이미지 업로드에 실패했습니다.'))
 }
 
@@ -102,7 +104,7 @@ export const logout = async (): Promise<{ message: string; loggedOutAt: string }
   try {
     const response =
       await apiClient.post<ApiResponse<{ message: string; loggedOutAt: string }>>(
-        '/api/auth/logout',
+        `${API_VERSION}/auth/logout`,
       )
     await fetch('/api/auth/clear-cookie', { method: 'POST' })
     return unwrap(response, '로그아웃에 실패했습니다.')

--- a/src/features/report/api.ts
+++ b/src/features/report/api.ts
@@ -1,4 +1,4 @@
-import { apiClient, unwrap } from '@/shared/api'
+import { apiClient, API_VERSION, unwrap } from '@/shared/api'
 import type { ReportReviewPayload, ReportBreederPayload } from '@/shared/types'
 
 export const reportReview = (payload: ReportReviewPayload) =>
@@ -7,7 +7,7 @@ export const reportReview = (payload: ReportReviewPayload) =>
       success: boolean
       data: { reportId: string; message: string }
       message?: string
-    }>('/api/adopter/report/review', payload)
+    }>(`${API_VERSION}/adopter/report/review`, payload)
     .then(unwrap)
 
 export const reportBreeder = (payload: ReportBreederPayload) =>
@@ -16,5 +16,5 @@ export const reportBreeder = (payload: ReportBreederPayload) =>
       success: boolean
       data: { reportId: string; message: string }
       message?: string
-    }>('/api/adopter/report', { type: 'breeder', ...payload })
+    }>(`${API_VERSION}/adopter/report`, { type: 'breeder', ...payload })
     .then(unwrap)

--- a/src/features/upload/api.ts
+++ b/src/features/upload/api.ts
@@ -1,4 +1,4 @@
-import { apiClient, unwrap, unwrapVoid } from '@/shared/api'
+import { apiClient, API_VERSION, unwrap, unwrapVoid } from '@/shared/api'
 import type { UploadResponse } from '@/shared/types'
 
 const UPLOAD_TIMEOUT = 60000
@@ -11,8 +11,7 @@ export const uploadRepresentativePhotos = (files: File[]) => {
       success: boolean
       data: UploadResponse[]
       message?: string
-    }>('/api/upload/representative-photos', formData, {
-      headers: { 'Content-Type': 'multipart/form-data' },
+    }>(`${API_VERSION}/upload/representative-photos`, formData, {
       timeout: UPLOAD_TIMEOUT,
     })
     .then(unwrap)
@@ -32,8 +31,7 @@ export const uploadParentPetPhoto = async (
       success: boolean
       data: UploadResponse | UploadResponse[]
       message?: string
-    }>(`/api/upload/parent-pet-photos/${petId}`, formData, {
-      headers: { 'Content-Type': 'multipart/form-data' },
+    }>(`${API_VERSION}/upload/parent-pet-photos/${petId}`, formData, {
       timeout: UPLOAD_TIMEOUT,
     })
     .then(unwrap)
@@ -55,8 +53,7 @@ export const uploadAvailablePetPhoto = async (
       success: boolean
       data: UploadResponse | UploadResponse[]
       message?: string
-    }>(`/api/upload/available-pet-photos/${petId}`, formData, {
-      headers: { 'Content-Type': 'multipart/form-data' },
+    }>(`${API_VERSION}/upload/available-pet-photos/${petId}`, formData, {
       timeout: UPLOAD_TIMEOUT,
     })
     .then(unwrap)
@@ -70,12 +67,9 @@ export const uploadSingleFile = (file: File, folder?: string) => {
   if (folder) formData.append('folder', folder)
   return apiClient
     .post<{ success: boolean; data: UploadResponse; message?: string }>(
-      '/api/upload/single',
+      `${API_VERSION}/upload/single`,
       formData,
-      {
-        headers: { 'Content-Type': 'multipart/form-data' },
-        timeout: UPLOAD_TIMEOUT,
-      },
+      { timeout: UPLOAD_TIMEOUT },
     )
     .then(unwrap)
 }
@@ -86,19 +80,17 @@ export const uploadMultipleFiles = (files: File[], folder?: string) => {
   if (folder) formData.append('folder', folder)
   return apiClient
     .post<{ success: boolean; data: UploadResponse[]; message?: string }>(
-      '/api/upload/multiple',
+      `${API_VERSION}/upload/multiple`,
       formData,
-      {
-        headers: { 'Content-Type': 'multipart/form-data' },
-        timeout: UPLOAD_TIMEOUT,
-      },
+      { timeout: UPLOAD_TIMEOUT },
     )
     .then(unwrap)
 }
 
 export const deleteFile = async (fileName: string): Promise<void> => {
-  const response = await apiClient.delete<{ success: boolean; message?: string }>('/api/upload', {
-    data: { fileName },
-  })
+  const response = await apiClient.delete<{ success: boolean; message?: string }>(
+    `${API_VERSION}/upload`,
+    { data: { fileName } },
+  )
   unwrapVoid(response, '파일 삭제에 실패했습니다.')
 }

--- a/src/shared/api/Client.ts
+++ b/src/shared/api/Client.ts
@@ -158,3 +158,6 @@ function createApiClient(): AxiosInstance {
 }
 
 export const apiClient = createApiClient()
+
+/** 외부 API 버전 prefix */
+export const API_VERSION = '/api/v2' as const

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -1,4 +1,4 @@
-export { apiClient } from './Client'
+export { apiClient, API_VERSION } from './Client'
 export type { ApiRequestConfig } from './Client'
 export {
   ApiError,

--- a/src/shared/types/HomeTypes.ts
+++ b/src/shared/types/HomeTypes.ts
@@ -19,6 +19,7 @@ export interface BannerDto {
   title?: string
   description?: string
   order: number
+  isActive: boolean
   targetAudience?: ('guest' | 'adopter' | 'breeder')[]
 }
 

--- a/src/widgets/banner/ui/Banner.tsx
+++ b/src/widgets/banner/ui/Banner.tsx
@@ -1,71 +1,70 @@
 'use client'
 
+import Image from 'next/image'
+import Link from 'next/link'
 import { Swiper, SwiperSlide } from 'swiper/react'
 import { Autoplay, Pagination } from 'swiper/modules'
-import { cn } from '@/shared/lib/Cn'
-import { cafe24Proup } from '@/shared/lib/fonts'
+import { useBanners } from '@/entities/home'
+import type { BannerDto } from '@/shared/types'
 import 'swiper/css'
 import 'swiper/css/pagination'
 
-const BANNER_SLIDES = [
-  {
-    title: ['건강하고 사랑스러운', '내 취향의 동물들을 찾고 계신가요?'],
-    titleMobile: ['건강하고 사랑스러운', '내 취향의 동물들을', '찾고 계신가요?'],
-    subtitle: '평생을 함께할 반려동물 포퐁에서 찾으세요!',
-    subtitleMobile: ['평생을 함께할 반려동물', '포퐁에서 찾으세요!'],
-  },
-  {
-    title: ['검증된 브리더만', '포퐁에서 만나보세요'],
-    titleMobile: ['검증된 브리더만', '포퐁에서', '만나보세요'],
-    subtitle: '브리더 인증 시스템으로 안심하고 분양받으세요',
-    subtitleMobile: ['브리더 인증 시스템으로', '안심하고 분양받으세요'],
-  },
-  {
-    title: ['반려동물과 함께하는', '행복한 일상을 시작하세요'],
-    titleMobile: ['반려동물과 함께하는', '행복한 일상을', '시작하세요'],
-    subtitle: '포퐁이 좋은 만남을 도와드릴게요',
-    subtitleMobile: ['포퐁이 좋은 만남을', '도와드릴게요'],
-  },
-]
+const BannerSlide = ({ banner }: { banner: BannerDto }) => {
+  const content = (
+    <section className="relative w-full overflow-hidden bg-[#d9d9d9]">
+      {/* Desktop */}
+      <div className="hidden aspect-[16/5] tab:block">
+        <Image
+          src={banner.desktopImageUrl}
+          alt={banner.title ?? ''}
+          fill
+          className="object-cover"
+          priority
+        />
+      </div>
+      {/* Mobile */}
+      <div className="block aspect-[16/9] tab:hidden">
+        <Image
+          src={banner.mobileImageUrl}
+          alt={banner.title ?? ''}
+          fill
+          className="object-cover"
+          priority
+        />
+      </div>
+    </section>
+  )
+
+  if (banner.linkUrl) {
+    if (banner.linkType === 'external') {
+      return (
+        <a href={banner.linkUrl} target="_blank" rel="noopener noreferrer">
+          {content}
+        </a>
+      )
+    }
+    return <Link href={banner.linkUrl}>{content}</Link>
+  }
+
+  return content
+}
 
 const Banner = () => {
+  const { data: banners } = useBanners()
+
+  if (!banners || banners.length === 0) return null
+
   return (
     <Swiper
       modules={[Autoplay, Pagination]}
       autoplay={{ delay: 4000, disableOnInteraction: false }}
       pagination={{ clickable: true }}
-      loop
+      loop={banners.length > 1}
       className="w-full"
     >
-      {BANNER_SLIDES.map((slide, i) => (
-        <SwiperSlide key={i}>
-          <section className="flex w-full flex-col items-center gap-[1.25rem] bg-[#d9d9d9] px-[1.25rem] py-[2.5rem] text-center text-black tab:px-[3rem] tab:py-[6.25rem] pc:px-[6.25rem]">
-            <h2
-              className={cn(
-                cafe24Proup.className,
-                'font-cafe24 text-[1.5rem] leading-[1.5] tab:text-[2.5rem]',
-              )}
-            >
-              {slide.title.map((line, j) => (
-                <span key={j} className="hidden tab:block">
-                  {line}
-                </span>
-              ))}
-              {slide.titleMobile.map((line, j) => (
-                <span key={j} className="block tab:hidden">
-                  {line}
-                </span>
-              ))}
-            </h2>
-            <p className="text-[1.25rem] leading-[1.5] font-bold tab:text-[1.5rem]">
-              <span className="hidden tab:inline">{slide.subtitle}</span>
-              {slide.subtitleMobile.map((line, j) => (
-                <span key={j} className="block tab:hidden">
-                  {line}
-                </span>
-              ))}
-            </p>
-          </section>
+      {banners.map((banner) => (
+        <SwiperSlide key={banner.bannerId}>
+          <BannerSlide banner={banner} />
         </SwiperSlide>
       ))}
     </Swiper>


### PR DESCRIPTION
## Summary
- `API_VERSION` 상수를 `shared/api`에 도입하여 전체 외부 API URL을 `/api/v2` 기반으로 통일
- 홈 배너를 하드코딩에서 `/api/v2/home/banners` API 연결로 전환, `next/image` 이미지 기반 렌더링
- `multipart/form-data` 불필요 헤더 제거 (axios 자동 감지)

## Test plan
- [ ] 홈 화면 배너 정상 렌더링 확인 (데스크톱/모바일 이미지 분기)
- [ ] 배너 링크 클릭 시 internal/external 이동 확인
- [ ] 각 도메인 API 호출 정상 동작 확인 (브리더, 입양자, 알림, 커뮤니티 등)
- [ ] 파일 업로드 정상 동작 확인 (FormData 헤더 제거 후)
- [ ] 인증 관련 API 정상 동작 확인

Closes #41