### PR TITLE
feat(home): FAQ 섹션 API 연결

### DIFF
--- a/src/shared/types/HomeTypes.ts
+++ b/src/shared/types/HomeTypes.ts
@@ -23,13 +23,19 @@ export interface BannerDto {
   targetAudience?: ('guest' | 'adopter' | 'breeder')[]
 }
 
+/** FAQ 카테고리 */
+export type FaqCategory = 'service' | 'adoption' | 'breeder' | 'payment' | 'etc'
+
+/** FAQ 사용자 타입 */
+export type FaqUserType = 'adopter' | 'breeder' | 'both'
+
 /** FAQ DTO */
 export interface FaqDto {
   faqId: string
   question: string
   answer: string
-  category: string
-  userType: HomeUserType
+  category: FaqCategory
+  userType: FaqUserType
   order: number
 }
 

--- a/src/widgets/faq/ui/FaqSection.tsx
+++ b/src/widgets/faq/ui/FaqSection.tsx
@@ -1,31 +1,17 @@
+'use client'
+
 import { cn } from '@/shared/lib/Cn'
 import { cafe24Proup } from '@/shared/lib/fonts'
 import { Container, SectionHeader } from '@/shared/ui'
+import { useAdopterFaqs, useBreederFaqs } from '@/entities/home'
 import type { HomeUserType } from '@/shared/types'
 
 interface FaqSectionProps {
   userType?: HomeUserType
 }
 
-const FAQ_ITEMS: Record<HomeUserType, string[]> = {
-  adopter: [
-    '혹시 사기나 허위 브리더가 있을까 걱정돼요',
-    '혹시 사기나 허위 브리더가 있을까 걱정돼요',
-    '혹시 사기나 허위 브리더가 있을까 걱정돼요',
-    '혹시 사기나 허위 브리더가 있을까 걱정돼요',
-    '혹시 사기나 허위 브리더가 있을까 걱정돼요',
-  ],
-  breeder: [
-    '혹시 사기나 허위 브리더가 있을까 걱정돼요',
-    '혹시 사기나 허위 브리더가 있을까 걱정돼요',
-    '혹시 사기나 허위 브리더가 있을까 걱정돼요',
-    '혹시 사기나 허위 브리더가 있을까 걱정돼요',
-    '혹시 사기나 허위 브리더가 있을까 걱정돼요',
-  ],
-}
-
 const FaqSection = ({ userType = 'adopter' }: FaqSectionProps) => {
-  const faqItems = FAQ_ITEMS[userType]
+  const { data: faqs } = userType === 'adopter' ? useAdopterFaqs() : useBreederFaqs()
 
   return (
     <Container className="mt-[3rem] pb-[3rem]">
@@ -52,10 +38,10 @@ const FaqSection = ({ userType = 'adopter' }: FaqSectionProps) => {
         <div className="flex-1">
           <SectionHeader title="자주 묻는 질문" linkText="자세히 보기" linkHref="/faq" />
           <div className="mt-[0.721rem] grid grid-cols-1 tab:mt-[1.6525rem] tab:grid-cols-2 tab:gap-x-[2.5rem]">
-            {faqItems.map((item, i) => (
-              <div key={i} className="border-t border-[#a8a8a8] py-[0.625rem] tab:py-[1.44rem]">
+            {faqs?.map((faq) => (
+              <div key={faq.faqId} className="border-b border-[#a8a8a8] py-[0.625rem] first:border-t tab:py-[1.44rem]">
                 <p className="text-[0.875rem] font-semibold text-[#818181] tab:text-[1rem]">
-                  {item}
+                  {faq.question}
                 </p>
               </div>
             ))}

--- a/src/widgets/faq/ui/FaqSection.tsx
+++ b/src/widgets/faq/ui/FaqSection.tsx
@@ -39,7 +39,7 @@ const FaqSection = ({ userType = 'adopter' }: FaqSectionProps) => {
           <SectionHeader title="자주 묻는 질문" linkText="자세히 보기" linkHref="/faq" />
           <div className="mt-[0.721rem] grid grid-cols-1 tab:mt-[1.6525rem] tab:grid-cols-2 tab:gap-x-[2.5rem]">
             {faqs?.map((faq) => (
-              <div key={faq.faqId} className="border-b border-[#a8a8a8] py-[0.625rem] first:border-t tab:py-[1.44rem]">
+              <div key={faq.faqId} className="border-b border-[#a8a8a8] py-[0.625rem] first:border-t tab:py-[1.44rem] tab:[&:nth-child(2)]:border-t">
                 <p className="text-[0.875rem] font-semibold text-[#818181] tab:text-[1rem]">
                   {faq.question}
                 </p>


### PR DESCRIPTION
## Summary
- FaqSection을 하드코딩된 FAQ_ITEMS에서 `useAdopterFaqs`/`useBreederFaqs` 훅으로 전환
- `FaqDto` 타입 Swagger 스펙 반영 (`category` enum, `userType`에 `both` 추가)
- FAQ 항목 마지막 하단 border 추가

## Test plan
- [ ] 홈 화면 FAQ 섹션 데이터 정상 렌더링 확인
- [ ] adopter/breeder 타입별 FAQ 분기 확인
- [ ] FAQ 항목 상/하단 border 정상 표시 확인

Closes #43