### PR TITLE
feat(home): 공개 프로필 API 연결 (유저홈, 브리더홈)

### DIFF
--- a/src/app/(main)/home/[userId]/_ui/BreederHomeContent.tsx
+++ b/src/app/(main)/home/[userId]/_ui/BreederHomeContent.tsx
@@ -3,8 +3,9 @@
 import { useState } from 'react'
 import Image from 'next/image'
 import { Container } from '@/shared/ui'
-import { MOCK_BREEDER_PROFILE, MOCK_MY_HOME_POSTS } from '@/shared/mocks/myHome'
+import { MOCK_MY_HOME_POSTS } from '@/shared/mocks/myHome'
 import { createMockListings } from '@/shared/mocks/adoption'
+import { useBreederPublicProfile } from '@/entities/breeder'
 import { ProfileCard } from '../../_ui/ProfileCard'
 import { BreederListingCard } from '../../_ui/BreederListingCard'
 import { AdoptionCard } from '@/entities/adoption'
@@ -18,11 +19,14 @@ interface BreederHomeContentProps {
   userId: string
 }
 
-const BreederHomeContent = ({ userId: _userId }: BreederHomeContentProps) => {
+const BreederHomeContent = ({ userId }: BreederHomeContentProps) => {
   const [activeTab, setActiveTab] = useState('listings')
-  const profile = MOCK_BREEDER_PROFILE
+  const { data: profile } = useBreederPublicProfile(userId)
+  // TODO: 분양 개체 / 게시글 API 연결
   const listings = createMockListings()
   const posts = MOCK_MY_HOME_POSTS
+
+  if (!profile) return null
 
   return (
     <div className="flex w-full flex-col">

--- a/src/app/(main)/home/[userId]/_ui/UserHomeContent.tsx
+++ b/src/app/(main)/home/[userId]/_ui/UserHomeContent.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { Container, Separator } from '@/shared/ui'
-import { MOCK_MY_HOME_PROFILE, MOCK_MY_HOME_POSTS } from '@/shared/mocks/myHome'
+import { useAdopterPublicProfile } from '@/entities/adopter'
+import { MOCK_MY_HOME_POSTS } from '@/shared/mocks/myHome'
 import { ProfileCard } from '../../_ui/ProfileCard'
 import { HomeTitle } from '../../_ui/HomeTitle'
 import { PostList } from '../../_ui/PostList'
@@ -11,10 +12,12 @@ interface UserHomeContentProps {
   userId: string
 }
 
-const UserHomeContent = ({ userId: _userId }: UserHomeContentProps) => {
-  // TODO: API 연동 후 userId로 데이터 fetch
-  const profile = MOCK_MY_HOME_PROFILE
+const UserHomeContent = ({ userId }: UserHomeContentProps) => {
+  const { data: profile } = useAdopterPublicProfile(userId)
+  // TODO: 게시글 API 연결
   const posts = MOCK_MY_HOME_POSTS
+
+  if (!profile) return null
 
   return (
     <div className="flex w-full flex-col">

--- a/src/app/(main)/home/[userId]/_ui/UserHomeRouter.tsx
+++ b/src/app/(main)/home/[userId]/_ui/UserHomeRouter.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import { useAdopterPublicProfile } from '@/entities/adopter'
+import { UserHomeContent } from './UserHomeContent'
+import { BreederHomeContent } from './BreederHomeContent'
+
+interface UserHomeRouterProps {
+  userId: string
+}
+
+const UserHomeRouter = ({ userId }: UserHomeRouterProps) => {
+  const { data: adopterProfile, isError: isAdopterError } = useAdopterPublicProfile(userId)
+
+  if (isAdopterError) {
+    return <BreederHomeContent userId={userId} />
+  }
+
+  if (adopterProfile) {
+    return <UserHomeContent userId={userId} />
+  }
+
+  return null
+}
+
+export { UserHomeRouter }

--- a/src/app/(main)/home/[userId]/page.tsx
+++ b/src/app/(main)/home/[userId]/page.tsx
@@ -1,22 +1,12 @@
-import { UserHomeContent } from './_ui/UserHomeContent'
-import { BreederHomeContent } from './_ui/BreederHomeContent'
+import { UserHomeRouter } from './_ui/UserHomeRouter'
 
 interface UserHomePageProps {
   params: Promise<{ userId: string }>
 }
 
-// TODO: API 연동 후 userId로 사용자 타입 판별
-const MOCK_BREEDER_IDS = ['breeder-1']
-
 const UserHomePage = async ({ params }: UserHomePageProps) => {
   const { userId } = await params
-  const isBreeder = MOCK_BREEDER_IDS.includes(userId)
-
-  if (isBreeder) {
-    return <BreederHomeContent userId={userId} />
-  }
-
-  return <UserHomeContent userId={userId} />
+  return <UserHomeRouter userId={userId} />
 }
 
 export default UserHomePage

--- a/src/app/(main)/home/_ui/MyHomeContent.tsx
+++ b/src/app/(main)/home/_ui/MyHomeContent.tsx
@@ -3,12 +3,11 @@
 import { useState } from 'react'
 import { BookmarkIcon } from '@/shared/assets/icons'
 import { Container, Separator, SectionHeader } from '@/shared/ui'
-import {
-  MOCK_MY_HOME_PROFILE,
-  MOCK_BREEDER_PROFILE,
-  MOCK_MY_HOME_POSTS,
-} from '@/shared/mocks/myHome'
+import { MOCK_MY_HOME_POSTS } from '@/shared/mocks/myHome'
 import { createMockListings } from '@/shared/mocks/adoption'
+import { useAdopterProfile } from '@/entities/adopter'
+import { useMyBreederProfile } from '@/entities/breeder'
+import type { AdopterPublicProfile, BreederPublicProfile } from '@/shared/types'
 import { AdoptionCard } from '@/entities/adoption'
 import { ProfileCard } from './ProfileCard'
 import { HomeTabs, TabsContent } from './HomeTabs'
@@ -20,17 +19,49 @@ import { FavoriteBreedersContent } from './FavoriteBreedersContent'
 import { BreederListingCard } from './BreederListingCard'
 import { MY_HOME_TABS, BREEDER_MY_HOME_TABS } from './constants'
 
-// TODO: 실제 유저 정보에서 브리더 여부 판단
-const IS_BREEDER = true
-
 const MyHomeContent = () => {
-  const isBreeder = IS_BREEDER
+  const { data: adopterProfile } = useAdopterProfile()
+  const { data: breederProfile } = useMyBreederProfile()
+
+  const isBreeder = !!breederProfile
   const tabs = isBreeder ? BREEDER_MY_HOME_TABS : MY_HOME_TABS
   const defaultTab = isBreeder ? 'listings' : 'posts'
 
   const [activeTab, setActiveTab] = useState(defaultTab)
   const posts = MOCK_MY_HOME_POSTS
   const listings = isBreeder ? createMockListings() : []
+
+  const adopterPublicProfile: AdopterPublicProfile | null = adopterProfile
+    ? {
+        userId: adopterProfile.adopterId,
+        nickname: adopterProfile.nickname,
+        profileImageUrl: adopterProfile.profileImageFileName,
+        bio: '',
+        bpm: 0,
+        followerCount: 0,
+        isFollowing: false,
+      }
+    : null
+
+  const breederPublicProfile: BreederPublicProfile | null = breederProfile
+    ? {
+        breederId: breederProfile.breederId,
+        nickname: breederProfile.breederName,
+        profileImageUrl: breederProfile.profileImageFileName,
+        bio: breederProfile.profileInfo.profileDescription,
+        bpm: 0,
+        followerCount: 0,
+        level: breederProfile.verificationInfo.level ?? 'new',
+        plan: 'basic',
+        businessLocation: {
+          city: breederProfile.profileInfo.locationInfo.cityName,
+          district: breederProfile.profileInfo.locationInfo.districtName,
+        },
+        isFavorited: false,
+      }
+    : null
+
+  if (!adopterPublicProfile && !breederPublicProfile) return null
 
   return (
     <div className="flex w-full flex-col">
@@ -44,11 +75,11 @@ const MyHomeContent = () => {
       />
 
       <Container className="pc:px-[10rem]">
-        {isBreeder ? (
-          <ProfileCard profile={MOCK_BREEDER_PROFILE} mode="mine-breeder" />
-        ) : (
-          <ProfileCard profile={MOCK_MY_HOME_PROFILE} />
-        )}
+        {isBreeder && breederPublicProfile ? (
+          <ProfileCard profile={breederPublicProfile} mode="mine-breeder" />
+        ) : adopterPublicProfile ? (
+          <ProfileCard profile={adopterPublicProfile} />
+        ) : null}
       </Container>
 
       <HomeTabs tabs={tabs} activeTab={activeTab} onTabChange={setActiveTab}>

--- a/src/app/(main)/home/_ui/ProfileCard.tsx
+++ b/src/app/(main)/home/_ui/ProfileCard.tsx
@@ -6,17 +6,17 @@ import type { AvatarItem } from '@/shared/ui'
 import Image from 'next/image'
 import { cn } from '@/shared/lib/Cn'
 import { LocationIcon } from '@/shared/assets/icons'
-import type { MyHomeProfile, BreederProfile } from '@/shared/mocks/myHome'
+import type { AdopterPublicProfile, BreederPublicProfile } from '@/shared/types'
 
 type ProfileMode = 'mine' | 'mine-breeder' | 'other' | 'breeder'
 
 interface ProfileCardBaseProps {
-  profile: MyHomeProfile
+  profile: AdopterPublicProfile
   mode?: 'mine' | 'other'
 }
 
 interface ProfileCardBreederProps {
-  profile: BreederProfile
+  profile: BreederPublicProfile
   mode: 'breeder' | 'mine-breeder'
 }
 
@@ -149,7 +149,10 @@ const ACTION_MAP = {
 const ProfileCard = ({ profile, mode = 'mine' }: ProfileCardProps) => {
   const Actions = ACTION_MAP[mode]
   const isBreederProfile = mode === 'breeder' || mode === 'mine-breeder'
-  const breederLocation = isBreederProfile ? (profile as BreederProfile).location : null
+  const breederProfile = isBreederProfile ? (profile as BreederPublicProfile) : null
+  const locationText = breederProfile
+    ? `${breederProfile.businessLocation.city} ${breederProfile.businessLocation.district}`
+    : null
 
   return (
     <div className="tab:overflow-hidden tab:rounded-2xl tab:bg-surface-primary">
@@ -163,22 +166,16 @@ const ProfileCard = ({ profile, mode = 'mine' }: ProfileCardProps) => {
                 브리더
               </Badge>
             )}
-            {profile.badges.map((badge) => (
-              <Badge
-                key={badge}
-                variant="outline"
-                className="h-6 text-xs leading-[1.375rem] tab:text-sm"
-              >
-                {badge}
-              </Badge>
-            ))}
+            <Badge variant="outline" className="h-6 text-xs leading-[1.375rem] tab:text-sm">
+              {profile.bpm} BPM
+            </Badge>
           </div>
           <p className="text-base font-bold text-text-primary tab:mt-[0.804rem] tab:text-2xl tab:leading-[1.375rem] tab:font-semibold">
             {profile.nickname}
           </p>
           {/* Location — breeder, mobile only */}
-          {isBreederProfile && (
-            <LocationInfo location={breederLocation!} className="mt-1 tab:hidden" />
+          {locationText && (
+            <LocationInfo location={locationText} className="mt-1 tab:hidden" />
           )}
           <Bio text={profile.bio} className="mt-3 hidden max-w-[26.1rem] tab:block" />
         </div>
@@ -191,8 +188,8 @@ const ProfileCard = ({ profile, mode = 'mine' }: ProfileCardProps) => {
         {/* Section 3: Avatar */}
         <div className="shrink-0">
           <Avatar size="lg" className="size-[4.0625rem] tab:h-[7.3125rem] tab:w-[7.4375rem]">
-            {profile.avatarUrl ? (
-              <AvatarImage src={profile.avatarUrl} alt={profile.nickname} />
+            {profile.profileImageUrl ? (
+              <AvatarImage src={profile.profileImageUrl} alt={profile.nickname} />
             ) : (
               <AvatarFallback className="bg-fill-muted" />
             )}
@@ -211,8 +208,8 @@ const ProfileCard = ({ profile, mode = 'mine' }: ProfileCardProps) => {
       />
 
       {/* Location — breeder, desktop only */}
-      {isBreederProfile && (
-        <LocationInfo location={breederLocation!} className="hidden py-2 tab:flex tab:px-10" />
+      {locationText && (
+        <LocationInfo location={locationText} className="hidden py-2 tab:flex tab:px-10" />
       )}
 
       {/* Separator — desktop only */}

--- a/src/entities/adopter/Api.ts
+++ b/src/entities/adopter/Api.ts
@@ -1,6 +1,8 @@
 import { apiClient, API_VERSION, unwrap } from '@/shared/api'
+import type { ApiRequestConfig } from '@/shared/api'
 import type {
   AdopterProfileDto,
+  AdopterPublicProfile,
   FavoriteItemDto,
   FavoriteAddResponseDto,
   FavoriteRemoveResponseDto,
@@ -8,7 +10,17 @@ import type {
   ReviewCreateRequest,
   WithdrawReason,
   PaginationResponse,
+  ApiResponseFull,
 } from '@/shared/types'
+
+/** 입양자 공개 프로필 조회 (유저홈) */
+export const getAdopterPublicProfile = (userId: string) =>
+  apiClient
+    .get<ApiResponseFull<AdopterPublicProfile>>(
+      `${API_VERSION}/profile/users/${userId}`,
+      { skipAuth: true } as ApiRequestConfig,
+    )
+    .then((res) => unwrap(res, '입양자 프로필 조회에 실패했습니다.'))
 
 /** 내 프로필 조회 */
 export const getAdopterProfile = () =>

--- a/src/entities/adopter/Hooks.ts
+++ b/src/entities/adopter/Hooks.ts
@@ -5,6 +5,9 @@ import { adopterQueries } from './Queries'
 
 export const useAdopterProfile = () => useQuery(adopterQueries.profile())
 
+export const useAdopterPublicProfile = (userId: string) =>
+  useQuery(adopterQueries.publicProfile(userId))
+
 export const useFavorites = (limit?: number) => useInfiniteQuery(adopterQueries.favorites(limit))
 
 export const useMyReviews = (limit?: number) => useInfiniteQuery(adopterQueries.reviews(limit))

--- a/src/entities/adopter/Queries.ts
+++ b/src/entities/adopter/Queries.ts
@@ -1,6 +1,6 @@
-import { createQuery, createInfiniteQuery } from '@/shared/api'
+import { createQuery, createInfiniteQuery, STALE_TIME } from '@/shared/api'
 import type { FavoriteItemDto, MyReviewItemDto } from '@/shared/types'
-import { getAdopterProfile, getFavorites, getMyReviews } from './Api'
+import { getAdopterProfile, getAdopterPublicProfile, getFavorites, getMyReviews } from './Api'
 
 export const adopterQueries = {
   all: () => ['adopter'] as const,
@@ -9,6 +9,14 @@ export const adopterQueries = {
     createQuery({
       queryKey: [...adopterQueries.all(), 'profile'],
       queryFn: getAdopterProfile,
+    }),
+
+  publicProfile: (userId: string) =>
+    createQuery({
+      queryKey: [...adopterQueries.all(), 'public-profile', userId],
+      queryFn: () => getAdopterPublicProfile(userId),
+      enabled: !!userId,
+      staleTime: STALE_TIME.VERY_LONG,
     }),
 
   favorites: (limit = 20) =>

--- a/src/entities/breeder/Api.ts
+++ b/src/entities/breeder/Api.ts
@@ -1,7 +1,9 @@
 import { apiClient, API_VERSION, unwrap, unwrapNullable } from '@/shared/api'
 import type { ApiRequestConfig } from '@/shared/api'
 import type {
+  ApiResponseFull,
   BreederProfileResponseDto,
+  BreederPublicProfile,
   ProfileUpdateRequestDto,
   BreederProfileUpdateResponseDto,
   DashboardResponseDto,
@@ -20,7 +22,16 @@ import type {
   SendChatMessageRequest,
 } from '@/shared/types'
 
-/** 브리더 공개 프로필 조회 */
+/** 브리더 공개 프로필 조회 (브리더홈) */
+export const getBreederPublicProfile = (breederId: string) =>
+  apiClient
+    .get<ApiResponseFull<BreederPublicProfile>>(
+      `${API_VERSION}/profile/breeders/${breederId}`,
+      { skipAuth: true } as ApiRequestConfig,
+    )
+    .then((res) => unwrap(res, '브리더 프로필 조회에 실패했습니다.'))
+
+/** 브리더 상세 프로필 조회 (기존) */
 export const getBreederProfile = (breederId: string) =>
   apiClient
     .get<{

--- a/src/entities/breeder/Hooks.ts
+++ b/src/entities/breeder/Hooks.ts
@@ -4,6 +4,9 @@ import { useQuery, useInfiniteQuery } from '@tanstack/react-query'
 import { breederQueries } from './Queries'
 import type { SearchBreederParams } from '@/shared/types'
 
+export const useBreederPublicProfile = (breederId: string) =>
+  useQuery(breederQueries.publicProfile(breederId))
+
 export const useBreederProfile = (breederId: string) => useQuery(breederQueries.profile(breederId))
 
 export const useMyBreederProfile = () => useQuery(breederQueries.myProfile())

--- a/src/entities/breeder/Queries.ts
+++ b/src/entities/breeder/Queries.ts
@@ -8,6 +8,7 @@ import type {
   ReceivedApplicationItemDto,
 } from '@/shared/types'
 import {
+  getBreederPublicProfile,
   getBreederProfile,
   getMyBreederProfile,
   getBreederDashboard,
@@ -24,6 +25,14 @@ import {
 
 export const breederQueries = {
   all: () => ['breeder'] as const,
+
+  publicProfile: (breederId: string) =>
+    createQuery({
+      queryKey: [...breederQueries.all(), 'public-profile', breederId],
+      queryFn: () => getBreederPublicProfile(breederId),
+      enabled: !!breederId,
+      staleTime: STALE_TIME.VERY_LONG,
+    }),
 
   profile: (breederId: string) =>
     createQuery({

--- a/src/shared/types/AdopterTypes.ts
+++ b/src/shared/types/AdopterTypes.ts
@@ -21,6 +21,17 @@ export interface AdopterProfileDto {
   updatedAt: string
 }
 
+/** 입양자 공개 프로필 (유저홈) */
+export interface AdopterPublicProfile {
+  userId: string
+  nickname: string
+  profileImageUrl?: string
+  bio: string
+  bpm: number
+  followerCount: number
+  isFollowing: boolean
+}
+
 export interface AdopterProfileUpdateRequest {
   name?: string
   phone?: string

--- a/src/shared/types/BreederTypes.ts
+++ b/src/shared/types/BreederTypes.ts
@@ -151,6 +151,25 @@ export interface BreederProfileResponseDto {
   verificationInfo: BreederVerificationDto
 }
 
+/** 브리더 공개 프로필 (브리더홈) */
+export interface BreederPublicProfile {
+  breederId: string
+  nickname: string
+  profileImageUrl?: string
+  bio: string
+  longDescription?: string
+  bpm: number
+  followerCount: number
+  level: BreederLevel
+  plan: 'basic' | 'pro'
+  businessLocation: {
+    city: string
+    district: string
+    address?: string
+  }
+  isFavorited: boolean
+}
+
 /** 브리더 프로필 수정 요청 — Partial<BreederProfileInfoDto> 기반 */
 export type ProfileUpdateRequestDto = Partial<
   Omit<BreederProfileInfoDto, 'specializationAreas'> & {


### PR DESCRIPTION
## Summary
- 입양자 공개 프로필 API 연결 (GET /api/v2/profile/users/{userId})
- 브리더 공개 프로필 API 연결 (GET /api/v2/profile/breeders/{breederId})
- ProfileCard를 API 응답 타입(AdopterPublicProfile, BreederPublicProfile)으로 전환
- 유저홈 진입 시 사용자 타입 자동 판별 (adopter 우선, 실패 시 breeder fallback)
- MyHomeContent 마이홈도 실제 프로필 API로 전환

## Changes
- `shared/types/AdopterTypes.ts` - AdopterPublicProfile 타입 추가
- `shared/types/BreederTypes.ts` - BreederPublicProfile 타입 추가
- `entities/adopter/` - getAdopterPublicProfile API, 쿼리, 훅 추가
- `entities/breeder/` - getBreederPublicProfile API, 쿼리, 훅 추가
- `home/_ui/ProfileCard.tsx` - mock 타입 제거, API 타입으로 전환
- `home/[userId]/` - UserHomeRouter로 사용자 타입 자동 판별
- `home/_ui/MyHomeContent.tsx` - 실제 프로필 API로 전환

## Test plan
- [ ] /home/{adopterId} 접속 시 입양자 프로필 정상 표시
- [ ] /home/{breederId} 접속 시 브리더 프로필 정상 표시
- [ ] /home (마이홈) 접속 시 내 프로필 정상 표시
- [ ] 존재하지 않는 ID 접속 시 빈 화면 (에러 없음)

Closes #47