### PR TITLE
feat(adoption): 입양 v2 API 연결 (목록, 인기, 상세)

### DIFF
--- a/src/entities/adoption/Api.ts
+++ b/src/entities/adoption/Api.ts
@@ -1,0 +1,51 @@
+import { apiClient, API_VERSION, unwrap } from '@/shared/api'
+import type {
+  ApiResponseFull,
+  PaginationResponse,
+  AdoptionPetCard,
+  AdoptionPetDetail,
+  AdoptionListParams,
+  AdoptionPopularParams,
+} from '@/shared/types'
+
+/** 입양 동물 목록 조회 */
+export const getAdoptionList = async (
+  params: AdoptionListParams = {},
+): Promise<PaginationResponse<AdoptionPetCard>> => {
+  const query = new URLSearchParams()
+  if (params.petType) query.set('petType', params.petType)
+  if (params.breederId) query.set('breederId', params.breederId)
+  if (params.excludePetId) query.set('excludePetId', params.excludePetId)
+  if (params.status) query.set('status', params.status)
+  if (params.keyword) query.set('keyword', params.keyword)
+  if (params.sort) query.set('sort', params.sort)
+  if (params.page) query.set('page', String(params.page))
+  if (params.pageSize) query.set('pageSize', String(params.pageSize))
+
+  const response = await apiClient.get<ApiResponseFull<PaginationResponse<AdoptionPetCard>>>(
+    `${API_VERSION}/adoption?${query.toString()}`,
+  )
+  return unwrap(response, '입양 동물 목록 조회에 실패했습니다.')
+}
+
+/** 인기 입양 동물 조회 */
+export const getPopularAdoptions = async (
+  params: AdoptionPopularParams = {},
+): Promise<AdoptionPetCard[]> => {
+  const query = new URLSearchParams()
+  if (params.petType) query.set('petType', params.petType)
+  if (params.limit) query.set('limit', String(params.limit))
+
+  const response = await apiClient.get<ApiResponseFull<AdoptionPetCard[]>>(
+    `${API_VERSION}/adoption/popular?${query.toString()}`,
+  )
+  return unwrap(response, '인기 입양 동물 조회에 실패했습니다.')
+}
+
+/** 입양 동물 상세 조회 */
+export const getAdoptionDetail = async (petId: string): Promise<AdoptionPetDetail> => {
+  const response = await apiClient.get<ApiResponseFull<AdoptionPetDetail>>(
+    `${API_VERSION}/adoption/${petId}`,
+  )
+  return unwrap(response, '입양 동물 상세 조회에 실패했습니다.')
+}

--- a/src/entities/adoption/Hooks.ts
+++ b/src/entities/adoption/Hooks.ts
@@ -1,0 +1,25 @@
+'use client'
+
+import { useQuery, useInfiniteQuery } from '@tanstack/react-query'
+import type { CommunityPetType, PetStatus, AdoptionSortType } from '@/shared/types'
+import { adoptionQueries } from './Queries'
+
+export const useAdoptionList = (
+  sort?: AdoptionSortType,
+  petType?: CommunityPetType,
+  status?: PetStatus,
+  keyword?: string,
+  pageSize?: number,
+) => useInfiniteQuery(adoptionQueries.list(sort, petType, status, keyword, pageSize))
+
+export const useBreederAdoptionPets = (
+  breederId: string,
+  excludePetId?: string,
+  pageSize?: number,
+) => useInfiniteQuery(adoptionQueries.breederPets(breederId, excludePetId, pageSize))
+
+export const usePopularAdoptions = (petType?: CommunityPetType, limit?: number) =>
+  useQuery(adoptionQueries.popular(petType, limit))
+
+export const useAdoptionDetail = (petId: string) =>
+  useQuery(adoptionQueries.detail(petId))

--- a/src/entities/adoption/Queries.ts
+++ b/src/entities/adoption/Queries.ts
@@ -1,0 +1,44 @@
+import { createQuery, createInfiniteQuery, STALE_TIME } from '@/shared/api'
+import type { CommunityPetType, PetStatus, AdoptionSortType } from '@/shared/types'
+import { getAdoptionList, getPopularAdoptions, getAdoptionDetail } from './Api'
+
+export const adoptionQueries = {
+  all: () => ['adoption'] as const,
+
+  list: (
+    sort: AdoptionSortType = 'latest',
+    petType?: CommunityPetType,
+    status?: PetStatus,
+    keyword?: string,
+    pageSize = 15,
+  ) =>
+    createInfiniteQuery({
+      queryKey: [...adoptionQueries.all(), 'list', sort, petType, status, keyword, pageSize],
+      queryFn: (page) => getAdoptionList({ sort, petType, status, keyword, page, pageSize }),
+      staleTime: STALE_TIME.DEFAULT,
+    }),
+
+  breederPets: (breederId: string, excludePetId?: string, pageSize = 15) =>
+    createInfiniteQuery({
+      queryKey: [...adoptionQueries.all(), 'breederPets', breederId, excludePetId, pageSize],
+      queryFn: (page) =>
+        getAdoptionList({ breederId, excludePetId, page, pageSize }),
+      enabled: !!breederId,
+      staleTime: STALE_TIME.DEFAULT,
+    }),
+
+  popular: (petType?: CommunityPetType, limit = 3) =>
+    createQuery({
+      queryKey: [...adoptionQueries.all(), 'popular', petType, limit],
+      queryFn: () => getPopularAdoptions({ petType, limit }),
+      staleTime: STALE_TIME.DEFAULT,
+    }),
+
+  detail: (petId: string) =>
+    createQuery({
+      queryKey: [...adoptionQueries.all(), 'detail', petId],
+      queryFn: () => getAdoptionDetail(petId),
+      enabled: !!petId,
+      staleTime: STALE_TIME.DEFAULT,
+    }),
+}

--- a/src/entities/adoption/index.ts
+++ b/src/entities/adoption/index.ts
@@ -1,1 +1,3 @@
 export { AdoptionCard, AdoptionCardHorizontal } from './ui/AdoptionCard'
+export * from './Queries'
+export * from './Hooks'

--- a/src/shared/types/AdoptionTypes.ts
+++ b/src/shared/types/AdoptionTypes.ts
@@ -2,6 +2,16 @@
  * 입양 탐색 페이지 관련 타입 정의
  */
 
+import type { PetGender, PetStatus } from './BreederTypes'
+import type { CommunityPetType } from './CommunityTypes'
+import type {
+  VaccinationStatusType,
+  GeneticTestStatusType,
+  PetVaccinationRecord,
+  PetGeneticTestRecord,
+  ParentRelation,
+} from './PetPostingTypes'
+
 /** 동물 카테고리 필터 */
 export type AnimalCategory = 'all' | 'dog' | 'cat' | 'lizard'
 
@@ -138,4 +148,89 @@ export interface AdoptionDetailDto {
   parents: ParentInfo[]
   breedingEnvironment: BreedingEnvironment
   otherListings: AdoptionListingCard[]
+}
+
+// ==================== v2 입양 API 타입 ====================
+
+/** v2 정렬 기준 */
+export type AdoptionSortType = 'latest' | 'popular'
+
+/** v2 입양 동물 카드 */
+export interface AdoptionPetCard {
+  petId: string
+  breederId: string
+  breederName: string
+  name: string
+  breed: string
+  petType: CommunityPetType
+  gender: PetGender
+  ageDescription: string
+  price: number
+  status: PetStatus
+  primaryPhotoUrl: string
+  photoUrls: string[]
+  inquiryCount: number
+  favoriteCount: number
+  viewCount: number
+  isFavorited: boolean
+  isPopular: boolean
+  createdAt: string
+}
+
+/** v2 입양 동물 목록 파라미터 */
+export interface AdoptionListParams {
+  petType?: CommunityPetType
+  breederId?: string
+  excludePetId?: string
+  status?: PetStatus
+  keyword?: string
+  sort?: AdoptionSortType
+  page?: number
+  pageSize?: number
+}
+
+/** v2 인기 입양 동물 파라미터 */
+export interface AdoptionPopularParams {
+  petType?: CommunityPetType
+  limit?: number
+}
+
+/** v2 입양 상세 - 부모 정보 */
+export interface AdoptionParent {
+  relation: ParentRelation
+  breed: string
+  name: string
+  birthDate: string
+  photoUrl: string
+}
+
+/** v2 입양 상세 - 사육 환경 */
+export interface AdoptionBreedingEnv {
+  description: string
+  photoUrl: string
+}
+
+/** v2 입양 상세 - 브리더 요약 */
+export interface AdoptionBreederSummary {
+  breederId: string
+  displayName: string
+  profileImageUrl: string
+  locationText: string
+  bpm: number
+}
+
+/** v2 입양 동물 상세 */
+export interface AdoptionPetDetail extends AdoptionPetCard {
+  description: string
+  tags: string[]
+  birthDate: string
+  vaccinationStatus: VaccinationStatusType
+  vaccinationRecords: PetVaccinationRecord[]
+  vaccinationIncompleteReason?: string
+  geneticTestStatus: GeneticTestStatusType
+  geneticTestRecords: PetGeneticTestRecord[]
+  geneticTestIncompleteReason?: string
+  parents: AdoptionParent[]
+  breedingEnvironment?: AdoptionBreedingEnv
+  breeder: AdoptionBreederSummary
 }


### PR DESCRIPTION
## Summary
- 입양 v2 API 레이어 구축 (entities/adoption/ Api.ts, Queries.ts, Hooks.ts)
- v2 전용 타입 추가 (AdoptionPetCard, AdoptionPetDetail, AdoptionListParams 등)
- 기존 v1 타입 유지하면서 v2 타입 병행 (점진적 마이그레이션)
- PetPostingTypes의 건강정보 타입 재사용

Closes #55

## 변경 파일
- `shared/types/AdoptionTypes.ts` - v2 타입 10개 추가 (AdoptionPetCard, AdoptionPetDetail, AdoptionListParams 등)
- `entities/adoption/Api.ts` - API 함수 3개 (getAdoptionList, getPopularAdoptions, getAdoptionDetail)
- `entities/adoption/Queries.ts` - adoptionQueries (list, breederPets, popular, detail)
- `entities/adoption/Hooks.ts` - 훅 4개 (useAdoptionList, useBreederAdoptionPets, usePopularAdoptions, useAdoptionDetail)
- `entities/adoption/index.ts` - Queries, Hooks export 추가

## Test plan
- [ ] pnpm type-check 통과 확인
- [ ] 입양 목록 petType/status/keyword 필터 동작 확인
- [ ] 브리더 다른 분양 동물 (breederId + excludePetId) 조회 확인
- [ ] 상세 조회 시 건강정보/부모/사육환경 데이터 정상 반환 확인