### PR TITLE
feat(adoption): 입양 신청서 제출 v2 API 연결

### DIFF
--- a/src/entities/adoption/Api.ts
+++ b/src/entities/adoption/Api.ts
@@ -6,6 +6,10 @@ import type {
   AdoptionPetDetail,
   AdoptionListParams,
   AdoptionPopularParams,
+  AdoptionFavoriteResponse,
+  AdoptionFavoritesParams,
+  AdoptionAdoptedParams,
+  AdoptedPetCard,
 } from '@/shared/types'
 
 /** 입양 동물 목록 조회 */
@@ -48,4 +52,49 @@ export const getAdoptionDetail = async (petId: string): Promise<AdoptionPetDetai
     `${API_VERSION}/adoption/${petId}`,
   )
   return unwrap(response, '입양 동물 상세 조회에 실패했습니다.')
+}
+
+/** 동물 관심 등록 */
+export const addAdoptionFavorite = async (petId: string): Promise<AdoptionFavoriteResponse> => {
+  const response = await apiClient.post<ApiResponseFull<AdoptionFavoriteResponse>>(
+    `${API_VERSION}/adoption/${petId}/favorite`,
+  )
+  return unwrap(response, '관심 동물 등록에 실패했습니다.')
+}
+
+/** 동물 관심 해제 */
+export const removeAdoptionFavorite = async (petId: string): Promise<AdoptionFavoriteResponse> => {
+  const response = await apiClient.delete<ApiResponseFull<AdoptionFavoriteResponse>>(
+    `${API_VERSION}/adoption/${petId}/favorite`,
+  )
+  return unwrap(response, '관심 동물 해제에 실패했습니다.')
+}
+
+/** 입양 관심 목록 조회 */
+export const getMyFavoriteAdoptions = async (
+  params: AdoptionFavoritesParams = {},
+): Promise<PaginationResponse<AdoptionPetCard>> => {
+  const query = new URLSearchParams()
+  if (params.status) query.set('status', params.status)
+  if (params.page) query.set('page', String(params.page))
+  if (params.pageSize) query.set('pageSize', String(params.pageSize))
+
+  const response = await apiClient.get<ApiResponseFull<PaginationResponse<AdoptionPetCard>>>(
+    `${API_VERSION}/adoption/me/favorites?${query.toString()}`,
+  )
+  return unwrap(response, '관심 목록 조회에 실패했습니다.')
+}
+
+/** 내가 입양한 목록 조회 */
+export const getMyAdoptedPets = async (
+  params: AdoptionAdoptedParams = {},
+): Promise<PaginationResponse<AdoptedPetCard>> => {
+  const query = new URLSearchParams()
+  if (params.page) query.set('page', String(params.page))
+  if (params.pageSize) query.set('pageSize', String(params.pageSize))
+
+  const response = await apiClient.get<ApiResponseFull<PaginationResponse<AdoptedPetCard>>>(
+    `${API_VERSION}/adoption/me/adopted?${query.toString()}`,
+  )
+  return unwrap(response, '입양 완료 목록 조회에 실패했습니다.')
 }

--- a/src/entities/adoption/Hooks.ts
+++ b/src/entities/adoption/Hooks.ts
@@ -23,3 +23,9 @@ export const usePopularAdoptions = (petType?: CommunityPetType, limit?: number) 
 
 export const useAdoptionDetail = (petId: string) =>
   useQuery(adoptionQueries.detail(petId))
+
+export const useMyFavoriteAdoptions = (status?: PetStatus, pageSize?: number) =>
+  useInfiniteQuery(adoptionQueries.myFavorites(status, pageSize))
+
+export const useMyAdoptedPets = (pageSize?: number) =>
+  useInfiniteQuery(adoptionQueries.myAdopted(pageSize))

--- a/src/entities/adoption/Queries.ts
+++ b/src/entities/adoption/Queries.ts
@@ -1,6 +1,12 @@
 import { createQuery, createInfiniteQuery, STALE_TIME } from '@/shared/api'
 import type { CommunityPetType, PetStatus, AdoptionSortType } from '@/shared/types'
-import { getAdoptionList, getPopularAdoptions, getAdoptionDetail } from './Api'
+import {
+  getAdoptionList,
+  getPopularAdoptions,
+  getAdoptionDetail,
+  getMyFavoriteAdoptions,
+  getMyAdoptedPets,
+} from './Api'
 
 export const adoptionQueries = {
   all: () => ['adoption'] as const,
@@ -39,6 +45,20 @@ export const adoptionQueries = {
       queryKey: [...adoptionQueries.all(), 'detail', petId],
       queryFn: () => getAdoptionDetail(petId),
       enabled: !!petId,
+      staleTime: STALE_TIME.DEFAULT,
+    }),
+
+  myFavorites: (status?: PetStatus, pageSize = 15) =>
+    createInfiniteQuery({
+      queryKey: [...adoptionQueries.all(), 'myFavorites', status, pageSize],
+      queryFn: (page) => getMyFavoriteAdoptions({ status, page, pageSize }),
+      staleTime: STALE_TIME.DEFAULT,
+    }),
+
+  myAdopted: (pageSize = 15) =>
+    createInfiniteQuery({
+      queryKey: [...adoptionQueries.all(), 'myAdopted', pageSize],
+      queryFn: (page) => getMyAdoptedPets({ page, pageSize }),
       staleTime: STALE_TIME.DEFAULT,
     }),
 }

--- a/src/features/adoption/api.ts
+++ b/src/features/adoption/api.ts
@@ -1,0 +1,17 @@
+import { apiClient, API_VERSION, unwrap } from '@/shared/api'
+import type {
+  ApiResponseFull,
+  CreateAdoptionApplicationRequest,
+  CreateAdoptionApplicationResponse,
+} from '@/shared/types'
+
+/** 입양 신청서 제출 */
+export const createAdoptionApplication = async (
+  data: CreateAdoptionApplicationRequest,
+): Promise<CreateAdoptionApplicationResponse> => {
+  const response = await apiClient.post<ApiResponseFull<CreateAdoptionApplicationResponse>>(
+    `${API_VERSION}/adoption-application`,
+    data,
+  )
+  return unwrap(response, '입양 신청에 실패했습니다.')
+}

--- a/src/features/adoption/index.ts
+++ b/src/features/adoption/index.ts
@@ -1,0 +1,1 @@
+export * from './model/hooks'

--- a/src/features/adoption/model/hooks.ts
+++ b/src/features/adoption/model/hooks.ts
@@ -3,6 +3,8 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { adoptionQueries } from '@/entities/adoption/Queries'
 import { addAdoptionFavorite, removeAdoptionFavorite } from '@/entities/adoption/Api'
+import { createAdoptionApplication } from '../api'
+import type { CreateAdoptionApplicationRequest } from '@/shared/types'
 
 export const useAddAdoptionFavorite = () => {
   const qc = useQueryClient()
@@ -18,6 +20,16 @@ export const useRemoveAdoptionFavorite = () => {
   const qc = useQueryClient()
   return useMutation({
     mutationFn: (petId: string) => removeAdoptionFavorite(petId),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: adoptionQueries.all() })
+    },
+  })
+}
+
+export const useCreateAdoptionApplication = () => {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (data: CreateAdoptionApplicationRequest) => createAdoptionApplication(data),
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: adoptionQueries.all() })
     },

--- a/src/features/adoption/model/hooks.ts
+++ b/src/features/adoption/model/hooks.ts
@@ -1,0 +1,25 @@
+'use client'
+
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { adoptionQueries } from '@/entities/adoption/Queries'
+import { addAdoptionFavorite, removeAdoptionFavorite } from '@/entities/adoption/Api'
+
+export const useAddAdoptionFavorite = () => {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (petId: string) => addAdoptionFavorite(petId),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: adoptionQueries.all() })
+    },
+  })
+}
+
+export const useRemoveAdoptionFavorite = () => {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (petId: string) => removeAdoptionFavorite(petId),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: adoptionQueries.all() })
+    },
+  })
+}

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -1,4 +1,5 @@
 export * from './adopter'
+export * from './adoption'
 export * from './application'
 export * from './auth'
 export * from './breeder'

--- a/src/shared/types/AdoptionTypes.ts
+++ b/src/shared/types/AdoptionTypes.ts
@@ -177,6 +177,25 @@ export interface AdoptionAdoptedParams {
   pageSize?: number
 }
 
+// ==================== v2 입양 신청 ====================
+
+/** v2 입양 신청서 제출 요청 */
+export interface CreateAdoptionApplicationRequest {
+  petId: string
+  adoptionPlan: string
+  familyMembers: string
+  privacyConsent: boolean
+  basicCareConsent: boolean
+  emergencyCareConsent: boolean
+  allFamilyConsent: boolean
+}
+
+/** v2 입양 신청서 제출 응답 */
+export interface CreateAdoptionApplicationResponse {
+  applicationId: string
+  status: string
+}
+
 // ==================== v2 입양 API 타입 ====================
 
 /** v2 정렬 기준 */

--- a/src/shared/types/AdoptionTypes.ts
+++ b/src/shared/types/AdoptionTypes.ts
@@ -150,6 +150,33 @@ export interface AdoptionDetailDto {
   otherListings: AdoptionListingCard[]
 }
 
+// ==================== v2 입양 API 타입 (인증) ====================
+
+/** v2 관심 등록/해제 응답 */
+export interface AdoptionFavoriteResponse {
+  petId: string
+  favoriteCount: number
+  success: boolean
+}
+
+/** v2 내가 입양한 동물 카드 (adoptedAt 추가) */
+export interface AdoptedPetCard extends AdoptionPetCard {
+  adoptedAt: string
+}
+
+/** v2 관심 목록 파라미터 */
+export interface AdoptionFavoritesParams {
+  status?: PetStatus
+  page?: number
+  pageSize?: number
+}
+
+/** v2 입양 완료 목록 파라미터 */
+export interface AdoptionAdoptedParams {
+  page?: number
+  pageSize?: number
+}
+
 // ==================== v2 입양 API 타입 ====================
 
 /** v2 정렬 기준 */


### PR DESCRIPTION
## Summary
- 입양 신청서 제출 API 연결 (POST /api/v2/adoption-application)
- CreateAdoptionApplicationRequest, CreateAdoptionApplicationResponse 타입 추가
- useCreateAdoptionApplication mutation 훅 추가

Closes #59

## Test plan
- [ ] 필수 필드 7개 모두 포함하여 신청 성공 확인
- [ ] 중복 신청 시 409 에러 처리 확인
- [ ] 비활성/입양완료 펫에 신청 시 400 에러 처리 확인
- [ ] 신청 성공 후 adoption 쿼리 invalidation 동작 확인