### PR TITLE
style(onboarding): 회원유형 선택 페이지 피그마 디자인 적용

### DIFF
--- a/public/images/onboarding/btn-pixel-breeder.svg
+++ b/public/images/onboarding/btn-pixel-breeder.svg
@@ -1,0 +1,6 @@
+<svg preserveAspectRatio="none" width="100%" height="100%" overflow="visible" style="display: block;" viewBox="0 0 250.503 213.59" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="Group 75">
+<path id="Union" d="M240.482 20.04H250.503V213.59H20.04V201.938H10.0205V189.539H0V20.04H10.0205V10.0205H240.482V20.04ZM220.442 10.0195H30.0605V0H220.442V10.0195Z" fill="var(--fill-0, #6B6B6B)" style="fill:#6B6B6B;fill:color(display-p3 0.4196 0.4196 0.4196);fill-opacity:1;"/>
+<path id="Union_2" d="M220.442 20.04H240.482V189.539H220.442V201.938H30.0605V189.539H10.0205V20.04H30.0605V10.0205H220.442V20.04Z" fill="var(--fill-0, white)" style="fill:white;fill-opacity:1;"/>
+</g>
+</svg>

--- a/public/images/onboarding/btn-pixel-general.svg
+++ b/public/images/onboarding/btn-pixel-general.svg
@@ -1,0 +1,6 @@
+<svg preserveAspectRatio="none" width="100%" height="100%" overflow="visible" style="display: block;" viewBox="0 0 250.503 213.59" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="Group 75">
+<path id="Union" d="M240.482 20.04H250.503V213.59H20.04V201.938H10.0205V189.539H0V20.04H10.0205V10.0205H240.482V20.04ZM220.442 10.0195H30.0605V0H220.442V10.0195Z" fill="var(--fill-0, #A9835A)" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<path id="Union_2" d="M220.442 20.04H240.482V189.539H220.442V201.938H30.0605V189.539H10.0205V20.04H30.0605V10.0205H220.442V20.04Z" fill="var(--fill-0, #FFFA94)" style="fill:#FFFA94;fill:color(display-p3 1.0000 0.9800 0.5793);fill-opacity:1;"/>
+</g>
+</svg>

--- a/src/app/signup/layout.tsx
+++ b/src/app/signup/layout.tsx
@@ -1,12 +1,24 @@
-import { LogoButton } from '@/widgets/gnb'
+import Image from 'next/image'
+import Link from 'next/link'
 
 const SignupLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <div className="flex min-h-screen flex-col">
-      <header className="flex w-full items-center bg-white px-[1.25rem] py-[0.5rem] tab:px-[6.25rem]">
-        <LogoButton />
+      <header className="flex w-full items-center justify-center bg-white px-5 py-2 tab:px-20">
+        <div className="flex w-full max-w-[80rem] items-center justify-between">
+          <Link href="/" aria-label="홈으로 이동">
+            <Image
+              src="/1440/logo.svg"
+              alt="Pawpong"
+              width={96}
+              height={32}
+              priority
+            />
+          </Link>
+          <div className="hidden h-12 w-[22.375rem] tab:flex" />
+        </div>
       </header>
-      <main className="flex-1">{children}</main>
+      <main className="flex flex-1 flex-col">{children}</main>
     </div>
   )
 }

--- a/src/widgets/signup-type-select/ui/SignupTypeSelect.tsx
+++ b/src/widgets/signup-type-select/ui/SignupTypeSelect.tsx
@@ -1,36 +1,80 @@
 'use client'
 
+import { useState } from 'react'
 import { useRouter } from 'next/navigation'
+import { cafe24Proup } from '@/shared/lib/fonts'
+import { cn } from '@/shared/lib/Cn'
 import { UserTypeCard } from './UserTypeCard'
 
 const USER_TYPE_OPTIONS = [
-  { value: 'general' as const, label: '일반' },
-  { value: 'breeder' as const, label: '브리더' },
+  {
+    value: 'general' as const,
+    label: '일반',
+    imageSrc: '/images/onboarding/btn-pixel-general.svg',
+    textColor: 'text-[#a9835a]',
+  },
+  {
+    value: 'breeder' as const,
+    label: '브리더',
+    imageSrc: '/images/onboarding/btn-pixel-breeder.svg',
+    textColor: 'text-[#6b6b6b]',
+  },
 ]
+
+type UserType = 'general' | 'breeder'
 
 const SignupTypeSelect = () => {
   const router = useRouter()
+  const [selected, setSelected] = useState<UserType | null>(null)
 
-  const handleSelect = (type: 'general' | 'breeder') => {
-    router.push(`/signup/${type}`)
+  const handleNext = () => {
+    if (selected) {
+      router.push(`/signup/${selected}`)
+    }
   }
 
   return (
-    <div className="flex flex-col items-center">
-      <div className="flex h-[5rem] w-full items-center justify-center py-[0.625rem] tab:h-[7.8125rem]">
-        <h1 className="text-center text-[1.25rem] leading-snug font-bold text-[#5d5d5d] tab:text-[2rem]">
-          회원 유형을 선택해 주세요
+    <div className="flex flex-1 flex-col items-center">
+      <div className="flex w-full items-center justify-center py-12">
+        <h1
+          className={cn(
+            cafe24Proup.className,
+            'text-center font-cafe24 text-[1.25rem] font-bold leading-[1.5] text-[#3e3e3e] tab:text-[1.5rem]',
+          )}
+        >
+          회원유형을 선택해 주세요
         </h1>
       </div>
 
-      <div className="mt-[2rem] flex flex-col items-center gap-[1.3125rem] tab:mt-[13.9375rem] tab:flex-row tab:gap-[5.585rem]">
+      <div className="flex flex-1 flex-col items-center justify-center gap-5 tab:flex-row tab:gap-12">
         {USER_TYPE_OPTIONS.map((option) => (
           <UserTypeCard
             key={option.value}
             label={option.label}
-            onClick={() => handleSelect(option.value)}
+            imageSrc={option.imageSrc}
+            textColor={option.textColor}
+            selected={selected === option.value}
+            onClick={() => setSelected(option.value)}
           />
         ))}
+      </div>
+
+      <div className="flex w-full flex-col items-center gap-5 py-8">
+        <button
+          type="button"
+          onClick={handleNext}
+          disabled={!selected}
+          className="h-12 w-[16.125rem] rounded-full bg-[#fffa94] text-base font-semibold text-[#3e3e3e] transition-colors disabled:opacity-40"
+        >
+          다음
+        </button>
+        <button
+          type="button"
+          onClick={() => router.back()}
+          className="text-base font-medium text-[#3e3e3e]"
+        >
+          뒤로
+        </button>
       </div>
     </div>
   )

--- a/src/widgets/signup-type-select/ui/UserTypeCard.tsx
+++ b/src/widgets/signup-type-select/ui/UserTypeCard.tsx
@@ -1,18 +1,34 @@
 'use client'
 
+import Image from 'next/image'
+import { cafe24Proup } from '@/shared/lib/fonts'
+import { cn } from '@/shared/lib/Cn'
+
 interface UserTypeCardProps {
   label: string
+  imageSrc: string
+  textColor: string
+  selected?: boolean
   onClick: () => void
 }
 
-const UserTypeCard = ({ label, onClick }: UserTypeCardProps) => {
+const UserTypeCard = ({ label, imageSrc, textColor, selected, onClick }: UserTypeCardProps) => {
   return (
     <button
       type="button"
       onClick={onClick}
-      className="flex h-[13.8125rem] w-[14.9375rem] items-center justify-center rounded-[0.5625rem] bg-[#d9d9d9] transition-colors hover:bg-[#cecece] tab:h-[17.38rem] tab:w-[18.765rem] tab:rounded-[0.715rem]"
+      className={`relative flex h-[10rem] w-[12rem] items-center justify-center transition-transform hover:scale-105 tab:h-[13.375rem] tab:w-[15.656rem] ${selected ? 'scale-105' : ''}`}
     >
-      <span className="text-[1.4375rem] font-bold text-black tab:text-[1.787rem]">{label}</span>
+      <Image src={imageSrc} alt="" fill className="object-contain" priority />
+      <span
+        className={cn(
+          cafe24Proup.className,
+          `relative z-10 font-cafe24 text-[1.5rem] font-bold leading-[1.5] tab:text-[2.5rem]`,
+          textColor,
+        )}
+      >
+        {label}
+      </span>
     </button>
   )
 }


### PR DESCRIPTION
## Summary
- 온보딩 회원유형 선택 페이지를 피그마 디자인에 맞춰 UI 업데이트
- 픽셀아트 카드 SVG 에셋 추가 (일반/브리더)
- 헤더에 로고 이미지 적용 및 레이아웃 정렬 (max-w-[80rem], justify-between)
- 카페24 프로업 폰트 적용 (타이틀, 카드 텍스트)
- 다음/뒤로 버튼 피그마 스펙 반영 (#fffa94, pill shape)
- 카드 선택 후 다음 버튼으로 이동하는 2-step UX 적용

Closes #63

## Test plan
- [ ] /signup 페이지 접속 시 피그마 디자인과 일치하는지 확인
- [ ] 카페24 프로업 폰트가 타이틀, 카드 텍스트에 적용되는지 확인
- [ ] 일반/브리더 카드 선택 후 다음 버튼 클릭 시 정상 이동 확인
- [ ] 미선택 시 다음 버튼 비활성화 확인
- [ ] 모바일/태블릿 반응형 확인