### PR TITLE
style(onboarding): 온보딩 피그마 디자인 적용 및 리팩토링 (#67)

### DIFF
--- a/public/images/onboarding/onboarding-banner-small.svg
+++ b/public/images/onboarding/onboarding-banner-small.svg
@@ -1,0 +1,600 @@
+<svg width="238" height="277" viewBox="0 0 238 277" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_1241_32632)">
+<path d="M0 16C0 7.16344 7.16344 0 16 0H222C230.837 0 238 7.16344 238 16V261C238 269.837 230.837 277 222 277H16C7.16344 277 0 269.837 0 261V16Z" fill="#8ED4FF" style="fill:#8ED4FF;fill:color(display-p3 0.5571 0.8302 1.0000);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 101.663 123.565)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="47.7745" height="4.50905" transform="matrix(-1 0 0 1 96.8862 123.565)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="47.7745" height="4.50905" transform="matrix(-1 0 0 1 49.1104 123.565)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="71.6619" height="4.50905" transform="matrix(-1 0 0 1 87.3311 110.037)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 101.663 119.056)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="47.7745" height="4.50905" transform="matrix(-1 0 0 1 96.8862 119.056)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="35.7971" height="4.50905" transform="matrix(-1 0 0 1 49.1104 119.056)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="69.2396" height="4.50905" transform="matrix(-1 0 0 1 87.3311 105.528)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 101.663 114.547)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="47.7745" height="4.50905" transform="matrix(-1 0 0 1 96.8862 114.547)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="38.1856" height="4.50905" transform="matrix(-1 0 0 1 49.1104 114.547)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 96.8862 110.037)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 87.3311 101.019)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 44.333 101.019)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 77.7769 101.019)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 34.7778 101.019)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 77.7769 96.5093)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 34.7778 96.5093)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 30.001 96.5093)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 77.7769 92)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 68.2217 96.5093)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 68.2217 101.019)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 68.2217 92)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 58.6665 101.019)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 58.6665 96.5093)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 92.1079 110.037)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 82.5537 101.019)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 39.5562 101.019)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 72.9985 96.5093)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 82.5537 96.5093)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 39.5562 96.5093)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 63.4443 96.5093)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 72.9985 101.019)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 30.001 101.019)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 25.2236 101.019)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 25.2236 96.5093)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 20.4468 101.019)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 20.4468 105.528)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 15.7026 110.037)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 10.9248 114.547)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="7.16585" height="4.50905" transform="matrix(-1 0 0 1 13.314 119.056)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 6.14795 119.056)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 72.9985 92)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 63.4443 101.019)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 63.4443 92)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 53.8896 101.019)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="-601" y="128" width="1440" height="149" fill="#CDA67B" style="fill:#CDA67B;fill:color(display-p3 0.8047 0.6502 0.4809);fill-opacity:1;"/>
+<rect x="77.7432" y="96.5093" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="49.0801" y="96.5093" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="72.9663" y="96.5093" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="44.3027" y="96.5093" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="68.189" y="96.5093" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="29.9707" y="164.149" width="38.2187" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="39.5249" y="96.5093" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="63.4121" y="101.019" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="34.748" y="101.019" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="53.8569" y="101.019" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="29.9707" y="105.528" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="82.5215" y="105.528" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="82.5215" y="101.019" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="68.189" y="101.019" width="14.332" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="63.4121" y="105.528" width="19.1093" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="34.748" y="110.037" width="47.7734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="34.748" y="114.547" width="47.7734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="34.748" y="119.056" width="47.7734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="34.748" y="105.528" width="19.1093" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="39.5249" y="101.019" width="14.332" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="29.9707" y="114.547" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="82.5215" y="114.547" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="29.9707" y="123.565" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="34.748" y="132.584" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="82.5215" y="123.565" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="58.6343" y="105.528" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="53.8569" y="105.528" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="29.9707" y="110.037" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="82.5215" y="110.037" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="29.9707" y="119.056" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="82.5215" y="119.056" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="29.9707" y="128.075" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="34.748" y="137.093" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="39.5249" y="137.093" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="29.9707" y="137.093" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="25.1938" y="141.603" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="6.0835" y="159.641" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="10.8613" y="150.621" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="6.0835" y="150.621" width="4.77734" height="9.01867" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="10.8613" y="155.132" width="4.77734" height="9.01867" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="15.6387" y="155.13" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="15.6387" y="150.622" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="15.6387" y="159.642" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="6.0835" y="146.112" width="9.55437" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="82.5215" y="128.075" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="72.9663" y="105.528" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="44.3027" y="105.528" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="68.189" y="114.547" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="68.189" y="119.056" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="77.7432" y="132.584" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="68.189" y="123.565" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="44.3027" y="123.565" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="72.9663" y="123.565" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="49.0801" y="123.565" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="63.4121" y="123.565" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="72.9663" y="137.093" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="68.189" y="141.603" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="68.189" y="146.112" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="68.189" y="150.622" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="68.189" y="155.131" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="68.189" y="159.64" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="68.189" y="164.149" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="53.8569" y="164.149" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="68.189" y="168.659" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="53.8569" y="168.659" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="39.5249" y="168.659" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="25.1938" y="168.659" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="72.9663" y="168.658" width="4.50905" height="4.77734" transform="rotate(-90 72.9663 168.658)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="63.4121" y="164.149" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="49.0801" y="164.149" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="34.748" y="164.149" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="63.4121" y="168.659" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="49.0801" y="168.659" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="34.748" y="168.659" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="20.4155" y="168.659" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="72.9663" y="173.167" width="4.50905" height="4.77734" transform="rotate(-90 72.9663 173.167)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="58.6343" y="173.167" width="4.50905" height="4.77734" transform="rotate(-90 58.6343 173.167)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="44.3027" y="173.167" width="4.50905" height="4.77734" transform="rotate(-90 44.3027 173.167)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="29.9707" y="173.167" width="4.50905" height="4.77734" transform="rotate(-90 29.9707 173.167)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="58.6343" y="123.565" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="53.8569" y="123.565" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="77.7432" y="123.565" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="39.5249" y="123.565" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="39.5249" y="128.075" width="42.996" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="29.9707" y="141.603" width="38.2187" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="29.9707" y="146.112" width="38.2187" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="25.1938" y="146.112" width="4.77734" height="22.5467" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="20.4155" y="146.112" width="4.77734" height="22.5467" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="9.01831" transform="matrix(1 0 0 -1 15.6387 150.621)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="13.5276" transform="matrix(1 0 0 -1 1.30664 159.64)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.50905" height="9.55489" transform="matrix(-1.26344e-08 -1 -1 1.12552e-08 15.6387 146.111)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.50905" height="9.55489" transform="matrix(-1.26344e-08 -1 -1 1.12552e-08 20.4155 168.659)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="39.5249" y="132.584" width="38.2187" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="49.0801" y="137.093" width="23.8867" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="29.9707" y="150.622" width="38.2187" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="29.9707" y="155.131" width="38.2187" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="29.9707" y="159.64" width="38.2187" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="34.748" y="123.565" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="34.748" y="128.075" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="49.0801" y="114.547" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="49.0801" y="119.056" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="58.6343" y="132.584" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="58.6343" y="141.603" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="58.6343" y="146.112" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="58.6343" y="150.621" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="44.3027" y="137.093" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 104.886 170.913)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 104.886 175.422)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 119.218 175.422)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 104.886 179.932)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 119.218 179.932)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 109.664 170.913)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 109.664 184.441)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 128.773 179.932)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 123.995 179.932)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 114.441 170.913)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 114.441 184.441)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 133.55 179.932)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="9.55467" height="9.01867" transform="matrix(-1 0 0 1 114.441 175.422)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="147.882" y="175.422" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="133.55" y="175.422" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="147.882" y="179.932" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="133.55" y="179.932" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="128.773" y="184.441" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="128.773" y="188.95" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="128.773" y="193.46" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="138.327" y="188.95" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="138.327" y="197.969" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="138.327" y="202.479" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="138.327" y="206.988" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="138.327" y="193.46" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="133.55" y="184.441" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="133.55" y="188.95" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="133.55" y="197.969" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="133.55" y="202.479" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="133.55" y="206.988" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="133.55" y="211.497" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="138.327" y="211.497" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="133.55" y="193.46" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="123.995" y="197.969" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="123.995" y="202.479" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="123.995" y="206.988" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="123.995" y="211.497" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="119.218" y="197.969" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="119.218" y="202.479" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="119.218" y="206.988" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="119.218" y="211.497" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="123.995" y="206.988" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="143.105" y="188.95" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="143.105" y="197.969" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="143.105" y="202.479" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="143.105" y="206.988" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="143.105" y="193.46" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 123.995 184.441)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 128.773 184.441)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 123.995 188.95)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 128.773 188.95)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 123.995 193.46)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 128.773 193.46)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 114.441 188.95)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 114.441 197.969)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 114.441 202.479)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 114.441 206.988)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 114.441 193.46)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 119.218 184.441)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 119.218 188.95)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 119.218 197.969)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 119.218 202.479)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 119.218 206.988)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 119.218 211.497)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 133.55 197.969)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 133.55 202.479)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 133.55 206.988)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 133.55 211.497)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="23.8864" height="4.50905" transform="matrix(-1 0 0 1 143.104 225.025)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="23.8864" height="4.50905" transform="matrix(-1 0 0 1 143.104 220.516)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="23.8864" height="4.50905" transform="matrix(-1 0 0 1 143.104 216.006)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 123.995 229.534)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 128.773 229.534)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="14.3317" height="4.50905" transform="matrix(-1 0 0 1 143.104 229.535)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 152.66 229.535)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 152.66 225.025)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 152.66 220.516)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 152.66 216.006)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 157.437 229.534)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 157.437 225.025)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 157.437 220.516)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 157.437 216.006)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 162.214 229.534)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 162.214 225.025)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 162.214 220.516)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 123.995 234.044)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 128.773 234.044)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="19.1093" height="4.50905" transform="matrix(-1 0 0 1 147.881 234.044)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="19.1093" height="4.50905" transform="matrix(-1 0 0 1 147.881 238.553)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 152.66 234.044)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 157.437 234.044)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 162.214 234.044)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 123.995 238.553)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 128.773 238.553)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 119.218 193.46)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 109.664 188.95)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 109.664 197.969)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 109.664 193.46)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="143.105" y="170.913" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="143.105" y="184.441" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="147.882" y="184.441" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="147.882" y="193.46" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="104.886" y="193.46" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="114.441" y="216.006" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="143.105" y="211.497" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="147.882" y="202.479" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="104.886" y="202.479" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="114.441" y="225.025" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="143.105" y="220.516" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="162.214" y="220.516" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="171.769" y="220.516" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="181.324" y="220.516" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="157.437" y="216.006" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="171.769" y="216.006" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="176.546" y="216.006" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="147.882" y="188.95" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="104.886" y="188.95" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="147.882" y="197.969" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="104.886" y="197.969" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="114.441" y="220.516" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="143.105" y="216.006" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="147.882" y="206.988" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="104.886" y="206.988" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="114.441" y="229.535" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="143.105" y="225.025" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="162.214" y="225.025" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="171.769" y="225.025" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="181.324" y="225.025" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="181.324" y="229.534" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="171.769" y="238.553" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="176.546" y="234.044" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="114.441" y="234.044" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="109.664" y="238.553" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="109.664" y="243.062" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="114.441" y="243.062" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="119.218" y="243.062" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="123.995" y="243.062" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="128.773" y="243.062" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="133.55" y="243.062" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="138.327" y="243.062" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="143.105" y="243.062" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="147.882" y="243.062" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="152.66" y="243.062" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="157.437" y="243.062" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="162.214" y="243.062" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="143.105" y="229.534" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="162.214" y="229.534" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="166.992" y="229.535" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="166.992" y="238.553" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="109.664" y="211.497" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="147.882" y="211.497" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="152.66" y="211.497" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="138.327" y="170.913" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="133.55" y="170.913" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="138.327" y="184.441" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="133.55" y="184.441" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="176.546" y="220.516" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="176.546" y="225.025" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="176.546" y="229.535" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="171.769" y="229.535" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="171.769" y="234.044" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="166.992" y="234.044" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="162.214" y="234.044" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="162.214" y="238.553" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="157.437" y="238.553" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="152.658" y="238.553" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="147.881" y="238.553" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="128.773" y="238.553" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="114.441" y="238.553" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="133.55" y="238.553" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="114.441" y="184.441" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="138.327" y="175.422" width="9.55467" height="9.01867" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="135.954" y="123.565" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="140.731" y="123.565" width="47.7745" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="188.506" y="123.565" width="47.7745" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="150.286" y="110.037" width="71.6619" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="135.954" y="119.056" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="140.731" y="119.056" width="47.7745" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="188.506" y="119.056" width="35.7971" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="150.286" y="105.528" width="69.2396" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="135.954" y="114.547" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="140.731" y="114.547" width="47.7745" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="188.506" y="114.547" width="38.1856" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="140.731" y="110.037" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="150.286" y="101.019" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="193.284" y="101.019" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="159.84" y="101.019" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="202.838" y="101.019" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="159.84" y="96.5093" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="202.838" y="96.5093" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="207.616" y="96.5093" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="159.84" y="92" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="169.396" y="96.5093" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="169.396" y="101.019" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="169.396" y="92" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="178.95" y="101.019" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="178.95" y="96.5093" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="145.508" y="110.037" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="155.063" y="101.019" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="198.061" y="101.019" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="164.619" y="96.5093" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="155.063" y="96.5093" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="198.061" y="96.5093" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="174.173" y="96.5093" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="164.619" y="101.019" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="207.616" y="101.019" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="212.393" y="101.019" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="212.393" y="96.5093" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="217.17" y="101.019" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="217.17" y="105.528" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="221.914" y="110.037" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="226.692" y="114.547" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="224.303" y="119.056" width="7.16585" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="231.469" y="119.056" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="164.619" y="92" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="174.173" y="101.019" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="174.173" y="92" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="183.728" y="101.019" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="47.7745" height="4.50905" transform="matrix(-1 0 0 1 274.466 123.565)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="47.7745" height="4.50905" transform="matrix(-1 0 0 1 226.691 123.565)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="71.6619" height="4.50905" transform="matrix(-1 0 0 1 264.911 110.037)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="47.7745" height="4.50905" transform="matrix(-1 0 0 1 274.466 119.056)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="35.7971" height="4.50905" transform="matrix(-1 0 0 1 226.691 119.056)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="69.2396" height="4.50905" transform="matrix(-1 0 0 1 264.911 105.528)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="47.7745" height="4.50905" transform="matrix(-1 0 0 1 274.466 114.547)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="38.1856" height="4.50905" transform="matrix(-1 0 0 1 226.691 114.547)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 221.913 101.019)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 212.358 101.019)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 212.358 96.5093)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 207.582 96.5093)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 236.248 101.019)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 236.248 96.5093)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 217.136 101.019)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 217.136 96.5093)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 241.024 96.5093)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 207.581 101.019)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 202.804 101.019)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 202.804 96.5093)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 198.027 101.019)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 198.027 105.528)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 193.283 110.037)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 188.505 114.547)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="7.16585" height="4.50905" transform="matrix(-1 0 0 1 190.894 119.056)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 183.728 119.056)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 241.024 101.019)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 241.024 92)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 231.47 101.019)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 144.301 110.037)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 144.301 114.546)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 163.409 114.546)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 144.301 119.056)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 163.409 119.056)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 153.855 110.037)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 153.855 123.565)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 172.963 114.546)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 149.077 110.037)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 149.077 123.565)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 168.187 114.546)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 158.633 110.037)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 158.633 123.565)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 177.741 114.546)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="14.332" height="4.50905" transform="matrix(-1 0 0 1 158.633 114.546)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="14.332" height="9.01867" transform="matrix(-1 0 0 1 158.633 114.546)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="196.852" y="110.037" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="196.852" y="114.546" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="177.741" y="114.546" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="196.852" y="119.056" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="177.741" y="119.056" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="172.963" y="119.056" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="168.186" y="119.056" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="172.963" y="123.565" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="168.186" y="123.565" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="172.963" y="128.075" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="168.186" y="128.075" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="172.963" y="132.584" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="172.963" y="137.093" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="172.963" y="141.603" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="172.963" y="146.112" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="172.963" y="150.621" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="172.963" y="155.13" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="172.963" y="159.64" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="172.963" y="164.149" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="168.186" y="132.584" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="182.518" y="128.075" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="182.518" y="137.093" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="182.518" y="141.603" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="182.518" y="146.112" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="182.518" y="150.621" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="182.518" y="155.13" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="182.518" y="159.64" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="182.518" y="164.149" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="182.518" y="168.659" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="182.518" y="173.168" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="182.518" y="177.677" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="187.295" y="173.168" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="192.073" y="155.13" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="196.85" y="155.13" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="187.295" y="177.677" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="182.518" y="132.584" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="177.741" y="123.565" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="177.741" y="128.075" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="177.741" y="137.093" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="177.741" y="141.603" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="177.741" y="146.112" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="177.741" y="150.621" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="177.741" y="155.13" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="177.741" y="159.64" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="177.741" y="164.149" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="177.741" y="168.659" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="177.741" y="173.168" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="177.741" y="177.677" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="177.741" y="132.584" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="168.187" y="137.093" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="168.187" y="141.603" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="168.187" y="146.112" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="168.187" y="146.112" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="168.187" y="150.621" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="168.187" y="155.13" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="168.187" y="159.64" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="168.187" y="164.149" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="187.296" y="128.075" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="187.296" y="137.093" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="187.296" y="141.603" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="187.296" y="146.112" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="187.296" y="132.584" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 168.187 119.056)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 168.187 123.565)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 168.187 128.075)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 168.187 132.584)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 168.187 137.093)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 168.187 141.603)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 168.187 146.112)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 168.187 150.621)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 168.187 155.13)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 168.187 159.64)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 158.633 128.075)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 158.633 137.093)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 158.633 141.603)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 158.633 146.112)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 158.633 132.584)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 163.409 123.565)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 163.409 128.075)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 163.409 137.093)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 163.409 141.603)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 163.409 146.112)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 163.409 150.621)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 168.187 164.149)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 168.187 168.659)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 172.963 168.659)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 177.741 168.659)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 196.852 168.659)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 196.852 164.149)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 196.852 159.64)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 201.627 168.659)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 201.627 164.149)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 201.627 159.64)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 206.406 168.659)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 206.406 164.149)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 206.406 159.64)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 168.187 173.168)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 172.963 173.168)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 177.741 173.168)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 177.741 177.677)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 196.852 173.168)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 196.852 177.677)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 201.627 173.168)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 201.627 177.677)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 206.406 173.168)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="9.55467" height="4.50905" transform="matrix(-1 0 0 1 211.182 177.677)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="9.55467" height="4.50905" transform="matrix(-1 0 0 1 215.96 173.168)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="9.0181" height="4.77734" transform="matrix(1.26344e-08 -1 -1 -1.12552e-08 220.738 177.677)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="13.5274" height="4.77734" transform="matrix(1.26344e-08 -1 -1 -1.12552e-08 225.514 173.167)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 168.187 177.677)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 163.409 177.677)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 172.963 177.677)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 163.409 132.584)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 153.855 128.075)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 153.855 137.093)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 153.855 132.584)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="187.296" y="110.037" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="187.296" y="123.565" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="192.073" y="110.037" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="192.073" y="123.565" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="192.073" y="132.584" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="149.077" y="132.584" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="158.633" y="155.13" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="187.296" y="150.621" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="192.073" y="141.603" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="149.077" y="141.603" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="158.633" y="164.149" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="187.296" y="159.64" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="206.406" y="159.64" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="215.96" y="159.64" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="225.514" y="159.64" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="201.627" y="155.13" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="215.96" y="155.13" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="220.738" y="155.13" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="192.073" y="128.075" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="149.077" y="128.075" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="192.073" y="137.093" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="149.077" y="137.093" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="158.633" y="159.64" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="187.296" y="155.13" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="192.073" y="146.112" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="149.077" y="146.112" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="158.633" y="168.659" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="187.296" y="164.149" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="206.406" y="164.149" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="215.96" y="164.149" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="215.96" y="177.677" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="225.514" y="164.149" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="225.514" y="168.659" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="220.738" y="173.168" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="158.633" y="173.168" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="153.855" y="177.677" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="153.855" y="182.187" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="158.633" y="182.187" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="163.409" y="182.187" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="168.187" y="182.187" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="172.963" y="182.187" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="177.741" y="182.187" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="182.518" y="182.187" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="187.296" y="182.187" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="192.073" y="182.187" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="196.852" y="182.187" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="201.627" y="182.187" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="206.406" y="182.187" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="187.296" y="168.659" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="206.406" y="168.659" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="211.182" y="168.659" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="211.182" y="177.677" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="153.855" y="150.621" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="192.073" y="150.621" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="196.852" y="150.621" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="182.518" y="110.037" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="182.518" y="123.565" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="182.518" y="114.546" width="14.332" height="9.01867" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+</g>
+<defs>
+<clipPath id="clip0_1241_32632">
+<path d="M0 16C0 7.16344 7.16344 0 16 0H222C230.837 0 238 7.16344 238 16V261C238 269.837 230.837 277 222 277H16C7.16344 277 0 269.837 0 261V16Z" fill="white" style="fill:white;fill-opacity:1;"/>
+</clipPath>
+</defs>
+</svg>

--- a/public/images/onboarding/onboarding-banner.svg
+++ b/public/images/onboarding/onboarding-banner.svg
@@ -1,0 +1,617 @@
+<svg width="621" height="277" viewBox="0 0 621 277" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_1241_25266)">
+<path d="M0 16C0 7.16344 7.16344 0 16 0H605C613.837 0 621 7.16344 621 16V261C621 269.837 613.837 277 605 277H16C7.16344 277 0 269.837 0 261V16Z" fill="#8ED4FF" style="fill:#8ED4FF;fill:color(display-p3 0.5571 0.8302 1.0000);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 293.663 123.565)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="47.7745" height="4.50905" transform="matrix(-1 0 0 1 288.886 123.565)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="47.7745" height="4.50905" transform="matrix(-1 0 0 1 241.11 123.565)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="71.6619" height="4.50905" transform="matrix(-1 0 0 1 279.331 110.037)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 293.663 119.056)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="47.7745" height="4.50905" transform="matrix(-1 0 0 1 288.886 119.056)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="35.7971" height="4.50905" transform="matrix(-1 0 0 1 241.11 119.056)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="69.2396" height="4.50905" transform="matrix(-1 0 0 1 279.331 105.528)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 293.663 114.547)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="47.7745" height="4.50905" transform="matrix(-1 0 0 1 288.886 114.547)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="38.1856" height="4.50905" transform="matrix(-1 0 0 1 241.11 114.547)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 288.886 110.037)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 279.331 101.019)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 236.333 101.019)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 269.777 101.019)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 226.778 101.019)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 269.777 96.5093)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 226.778 96.5093)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 222.001 96.5093)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 269.777 92)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 260.222 96.5093)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 260.222 101.019)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 260.222 92)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 250.667 101.019)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 250.667 96.5093)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 284.108 110.037)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 274.554 101.019)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 231.556 101.019)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 264.999 96.5093)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 274.554 96.5093)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 231.556 96.5093)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 255.445 96.5093)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 264.999 101.019)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 222.001 101.019)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 217.224 101.019)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 217.224 96.5093)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 212.447 101.019)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 212.447 105.528)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 207.703 110.037)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 202.925 114.547)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="7.16585" height="4.50905" transform="matrix(-1 0 0 1 205.314 119.056)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 198.148 119.056)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 264.999 92)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 255.445 101.019)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 255.445 92)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 245.89 101.019)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="-409" y="128" width="1440" height="149" fill="#CDA67B" style="fill:#CDA67B;fill:color(display-p3 0.8047 0.6502 0.4809);fill-opacity:1;"/>
+<rect x="269.744" y="96.5093" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="241.08" y="96.5093" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="264.967" y="96.5093" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="236.303" y="96.5093" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="260.189" y="96.5093" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="221.971" y="164.149" width="38.2187" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="231.525" y="96.5093" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="255.412" y="101.019" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="226.748" y="101.019" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="245.857" y="101.019" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="221.971" y="105.528" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="274.522" y="105.528" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="274.522" y="101.019" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="260.189" y="101.019" width="14.332" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="255.412" y="105.528" width="19.1093" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="226.748" y="110.037" width="47.7734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="226.748" y="114.547" width="47.7734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="226.748" y="119.056" width="47.7734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="226.748" y="105.528" width="19.1093" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="231.525" y="101.019" width="14.332" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="221.971" y="114.547" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="274.522" y="114.547" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="221.971" y="123.565" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="226.748" y="132.584" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="274.522" y="123.565" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="250.634" y="105.528" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="245.857" y="105.528" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="221.971" y="110.037" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="274.522" y="110.037" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="221.971" y="119.056" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="274.522" y="119.056" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="221.971" y="128.075" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="226.748" y="137.093" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="231.525" y="137.093" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="221.971" y="137.093" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="217.194" y="141.603" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="198.084" y="159.641" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="202.862" y="150.621" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="198.084" y="150.621" width="4.77734" height="9.01867" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="202.862" y="155.132" width="4.77734" height="9.01867" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="207.639" y="155.13" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="207.639" y="150.622" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="207.639" y="159.642" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="198.084" y="146.112" width="9.55437" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="274.522" y="128.075" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="264.967" y="105.528" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="236.303" y="105.528" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="260.189" y="114.547" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="260.189" y="119.056" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="269.744" y="132.584" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="260.189" y="123.565" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="236.303" y="123.565" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="264.967" y="123.565" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="241.08" y="123.565" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="255.412" y="123.565" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="264.967" y="137.093" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="260.189" y="141.603" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="260.189" y="146.112" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="260.189" y="150.622" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="260.189" y="155.131" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="260.189" y="159.64" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="260.189" y="164.149" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="245.857" y="164.149" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="260.189" y="168.659" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="245.857" y="168.659" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="231.525" y="168.659" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="217.194" y="168.659" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="264.967" y="168.658" width="4.50905" height="4.77734" transform="rotate(-90 264.967 168.658)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="255.412" y="164.149" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="241.08" y="164.149" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="226.748" y="164.149" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="255.412" y="168.659" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="241.08" y="168.659" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="226.748" y="168.659" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="212.416" y="168.659" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="264.967" y="173.167" width="4.50905" height="4.77734" transform="rotate(-90 264.967 173.167)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="250.634" y="173.167" width="4.50905" height="4.77734" transform="rotate(-90 250.634 173.167)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="236.303" y="173.167" width="4.50905" height="4.77734" transform="rotate(-90 236.303 173.167)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="221.971" y="173.167" width="4.50905" height="4.77734" transform="rotate(-90 221.971 173.167)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="250.634" y="123.565" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="245.857" y="123.565" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="269.744" y="123.565" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="231.525" y="123.565" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="231.525" y="128.075" width="42.996" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="221.971" y="141.603" width="38.2187" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="221.971" y="146.112" width="38.2187" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="217.194" y="146.112" width="4.77734" height="22.5467" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="212.416" y="146.112" width="4.77734" height="22.5467" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="9.01831" transform="matrix(1 0 0 -1 207.639 150.621)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="13.5276" transform="matrix(1 0 0 -1 193.307 159.64)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.50905" height="9.55489" transform="matrix(-1.26344e-08 -1 -1 1.12552e-08 207.639 146.111)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.50905" height="9.55489" transform="matrix(-1.26344e-08 -1 -1 1.12552e-08 212.416 168.659)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="231.525" y="132.584" width="38.2187" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="241.08" y="137.093" width="23.8867" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="221.971" y="150.622" width="38.2187" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="221.971" y="155.131" width="38.2187" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="221.971" y="159.64" width="38.2187" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="226.748" y="123.565" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="226.748" y="128.075" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="241.08" y="114.547" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="241.08" y="119.056" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="250.634" y="132.584" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="250.634" y="141.603" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="250.634" y="146.112" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="250.634" y="150.621" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="236.303" y="137.093" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 296.886 170.913)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 296.886 175.422)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 311.218 175.422)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 296.886 179.932)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 311.218 179.932)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 301.664 170.913)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 301.664 184.441)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 320.773 179.932)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 315.995 179.932)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 306.441 170.913)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 306.441 184.441)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 325.55 179.932)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="9.55467" height="9.01867" transform="matrix(-1 0 0 1 306.441 175.422)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="339.882" y="175.422" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="325.55" y="175.422" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="339.882" y="179.932" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="325.55" y="179.932" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="320.773" y="184.441" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="320.773" y="188.95" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="320.773" y="193.46" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="330.327" y="188.95" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="330.327" y="197.969" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="330.327" y="202.479" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="330.327" y="206.988" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="330.327" y="193.46" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="325.55" y="184.441" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="325.55" y="188.95" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="325.55" y="197.969" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="325.55" y="202.479" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="325.55" y="206.988" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="325.55" y="211.497" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="330.327" y="211.497" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="325.55" y="193.46" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="315.995" y="197.969" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="315.995" y="202.479" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="315.995" y="206.988" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="315.995" y="211.497" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="311.218" y="197.969" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="311.218" y="202.479" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="311.218" y="206.988" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="311.218" y="211.497" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="315.995" y="206.988" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="335.105" y="188.95" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="335.105" y="197.969" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="335.105" y="202.479" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="335.105" y="206.988" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="335.105" y="193.46" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 315.995 184.441)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 320.773 184.441)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 315.995 188.95)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 320.773 188.95)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 315.995 193.46)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 320.773 193.46)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 306.441 188.95)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 306.441 197.969)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 306.441 202.479)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 306.441 206.988)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 306.441 193.46)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 311.218 184.441)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 311.218 188.95)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 311.218 197.969)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 311.218 202.479)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 311.218 206.988)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 311.218 211.497)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 325.55 197.969)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 325.55 202.479)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 325.55 206.988)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 325.55 211.497)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="23.8864" height="4.50905" transform="matrix(-1 0 0 1 335.104 225.025)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="23.8864" height="4.50905" transform="matrix(-1 0 0 1 335.104 220.516)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="23.8864" height="4.50905" transform="matrix(-1 0 0 1 335.104 216.006)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 315.995 229.534)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 320.773 229.534)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="14.3317" height="4.50905" transform="matrix(-1 0 0 1 335.104 229.535)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 344.659 229.535)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 344.659 225.025)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 344.659 220.516)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 344.659 216.006)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 349.436 229.534)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 349.436 225.025)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 349.436 220.516)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 349.436 216.006)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 354.214 229.534)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 354.214 225.025)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 354.214 220.516)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 315.995 234.044)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 320.773 234.044)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="19.1093" height="4.50905" transform="matrix(-1 0 0 1 339.881 234.044)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="19.1093" height="4.50905" transform="matrix(-1 0 0 1 339.881 238.553)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 344.659 234.044)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 349.436 234.044)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 354.214 234.044)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 315.995 238.553)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 320.773 238.553)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 311.218 193.46)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 301.664 188.95)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 301.664 197.969)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 301.664 193.46)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="335.105" y="170.913" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="335.105" y="184.441" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="339.882" y="184.441" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="339.882" y="193.46" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="296.886" y="193.46" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="306.441" y="216.006" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="335.105" y="211.497" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="339.882" y="202.479" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="296.886" y="202.479" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="306.441" y="225.025" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="335.105" y="220.516" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="354.214" y="220.516" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="363.769" y="220.516" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="373.324" y="220.516" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="349.436" y="216.006" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="363.769" y="216.006" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="368.546" y="216.006" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="339.882" y="188.95" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="296.886" y="188.95" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="339.882" y="197.969" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="296.886" y="197.969" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="306.441" y="220.516" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="335.105" y="216.006" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="339.882" y="206.988" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="296.886" y="206.988" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="306.441" y="229.535" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="335.105" y="225.025" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="354.214" y="225.025" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="363.769" y="225.025" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="373.324" y="225.025" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="373.324" y="229.534" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="363.769" y="238.553" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="368.546" y="234.044" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="306.441" y="234.044" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="301.664" y="238.553" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="301.664" y="243.062" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="306.441" y="243.062" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="311.218" y="243.062" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="315.995" y="243.062" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="320.773" y="243.062" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="325.55" y="243.062" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="330.327" y="243.062" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="335.105" y="243.062" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="339.882" y="243.062" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="344.659" y="243.062" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="349.436" y="243.062" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="354.214" y="243.062" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="335.105" y="229.534" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="354.214" y="229.534" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="358.991" y="229.535" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="358.991" y="238.553" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="301.664" y="211.497" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="339.882" y="211.497" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="344.659" y="211.497" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="330.327" y="170.913" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="325.55" y="170.913" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="330.327" y="184.441" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="325.55" y="184.441" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="368.546" y="220.516" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="368.546" y="225.025" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="368.546" y="229.535" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="363.769" y="229.535" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="363.769" y="234.044" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="358.991" y="234.044" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="354.214" y="234.044" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="354.214" y="238.553" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="349.436" y="238.553" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="344.658" y="238.553" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="339.881" y="238.553" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="320.773" y="238.553" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="306.441" y="238.553" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="325.55" y="238.553" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="306.441" y="184.441" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="330.327" y="175.422" width="9.55467" height="9.01867" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 375.713 134.837)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 375.713 139.347)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 394.821 139.347)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 375.713 143.856)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 394.821 143.856)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 385.267 134.837)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 385.267 148.365)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 404.375 139.347)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 380.489 134.837)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 380.489 148.365)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 399.599 139.347)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 390.045 134.837)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 390.045 148.365)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 409.153 139.347)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="14.332" height="4.50905" transform="matrix(-1 0 0 1 390.045 139.347)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="14.332" height="9.01867" transform="matrix(-1 0 0 1 390.045 139.347)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="428.263" y="134.837" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="428.263" y="139.347" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="409.153" y="139.347" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="428.263" y="143.856" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="409.153" y="143.856" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="404.375" y="143.856" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="399.598" y="143.856" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="404.375" y="148.365" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="399.598" y="148.365" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="404.375" y="152.875" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="399.598" y="152.875" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="404.375" y="157.384" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="404.375" y="161.894" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="404.375" y="166.403" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="404.375" y="170.912" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="404.375" y="175.421" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="404.375" y="179.931" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="404.375" y="184.44" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="404.375" y="188.949" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="399.598" y="157.384" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="413.93" y="152.875" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="413.93" y="161.894" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="413.93" y="166.403" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="413.93" y="170.912" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="413.93" y="175.421" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="413.93" y="179.931" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="413.93" y="184.44" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="413.93" y="188.949" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="413.93" y="193.459" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="413.93" y="197.968" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="413.93" y="202.478" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="418.707" y="197.968" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="423.485" y="179.931" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="428.261" y="179.931" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="418.707" y="202.478" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="413.93" y="157.384" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="409.153" y="148.365" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="409.153" y="152.875" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="409.153" y="161.894" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="409.153" y="166.403" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="409.153" y="170.912" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="409.153" y="175.421" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="409.153" y="179.931" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="409.153" y="184.44" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="409.153" y="188.949" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="409.153" y="193.459" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="409.153" y="197.968" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="409.153" y="202.478" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="409.153" y="157.384" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="399.599" y="161.894" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="399.599" y="166.403" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="399.599" y="170.912" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="399.599" y="170.912" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="399.599" y="175.421" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="399.599" y="179.931" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="399.599" y="184.44" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="399.599" y="188.949" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="418.708" y="152.875" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="418.708" y="161.894" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="418.708" y="166.403" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="418.708" y="170.912" width="4.77734" height="4.50905" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect x="418.708" y="157.384" width="4.77734" height="4.50905" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 399.599 143.856)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 399.599 148.365)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 399.599 152.875)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 399.599 157.384)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 399.599 161.894)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 399.599 166.403)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 399.599 170.912)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 399.599 175.421)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 399.599 179.931)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 399.599 184.44)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 390.045 152.875)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 390.045 161.894)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 390.045 166.403)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 390.045 170.912)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 390.045 157.384)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 394.821 148.365)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 394.821 152.875)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 394.821 161.894)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 394.821 166.403)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 394.821 170.912)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 394.821 175.421)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 399.599 188.949)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 399.599 193.459)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 404.375 193.459)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 409.153 193.459)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 428.263 193.459)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 428.263 188.949)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 428.263 184.44)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 433.039 193.459)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 433.039 188.949)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 433.039 184.44)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 437.818 193.459)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 437.818 188.949)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 437.818 184.44)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 399.599 197.968)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 404.375 197.968)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 409.153 197.968)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 409.153 202.478)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 428.263 197.968)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 428.263 202.478)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 433.039 197.968)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 433.039 202.478)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 437.818 197.968)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="9.55467" height="4.50905" transform="matrix(-1 0 0 1 442.594 202.478)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="9.55467" height="4.50905" transform="matrix(-1 0 0 1 447.372 197.968)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="9.0181" height="4.77734" transform="matrix(1.26344e-08 -1 -1 -1.12552e-08 452.15 202.477)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="13.5274" height="4.77734" transform="matrix(1.26344e-08 -1 -1 -1.12552e-08 456.926 197.968)" fill="white" style="fill:white;fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 399.599 202.478)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 394.821 202.478)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 404.375 202.478)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 394.821 157.384)" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 385.267 152.875)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 385.267 161.894)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 385.267 157.384)" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="418.708" y="134.837" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="418.708" y="148.365" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="423.485" y="134.837" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="423.485" y="148.365" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="423.485" y="157.384" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="380.489" y="157.384" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="390.045" y="179.931" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="418.708" y="175.421" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="423.485" y="166.403" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="380.489" y="166.403" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="390.045" y="188.949" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="418.708" y="184.44" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="437.818" y="184.44" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="447.372" y="184.44" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="456.926" y="184.44" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="433.039" y="179.931" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="447.372" y="179.931" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="452.15" y="179.931" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="423.485" y="152.875" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="380.489" y="152.875" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="423.485" y="161.894" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="380.489" y="161.894" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="390.045" y="184.44" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="418.708" y="179.931" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="423.485" y="170.912" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="380.489" y="170.912" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="390.045" y="193.459" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="418.708" y="188.949" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="437.818" y="188.949" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="447.372" y="188.949" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="447.372" y="202.478" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="456.926" y="188.949" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="456.926" y="193.459" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="452.15" y="197.968" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="390.045" y="197.968" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="385.267" y="202.478" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="385.267" y="206.987" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="390.045" y="206.987" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="394.821" y="206.987" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="399.599" y="206.987" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="404.375" y="206.987" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="409.153" y="206.987" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="413.93" y="206.987" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="418.708" y="206.987" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="423.485" y="206.987" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="428.263" y="206.987" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="433.039" y="206.987" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="437.818" y="206.987" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="418.708" y="193.459" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="437.818" y="193.459" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="442.594" y="193.459" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="442.594" y="202.478" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="385.267" y="175.421" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="423.485" y="175.421" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="428.263" y="175.421" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="413.93" y="134.837" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="413.93" y="148.365" width="4.77734" height="4.50905" fill="#A9835A" style="fill:#A9835A;fill:color(display-p3 0.6609 0.5130 0.3511);fill-opacity:1;"/>
+<rect x="413.93" y="139.347" width="14.332" height="9.01867" fill="#FEF76B" style="fill:#FEF76B;fill:color(display-p3 0.9961 0.9686 0.4196);fill-opacity:1;"/>
+<rect x="327.954" y="123.565" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="332.731" y="123.565" width="47.7745" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="380.506" y="123.565" width="47.7745" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="342.286" y="110.037" width="71.6619" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="327.954" y="119.056" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="332.731" y="119.056" width="47.7745" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="380.506" y="119.056" width="35.7971" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="342.286" y="105.528" width="69.2396" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="327.954" y="114.547" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="332.731" y="114.547" width="47.7745" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="380.506" y="114.547" width="38.1856" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="332.731" y="110.037" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="342.286" y="101.019" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="385.284" y="101.019" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="351.841" y="101.019" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="394.838" y="101.019" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="351.841" y="96.5093" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="394.838" y="96.5093" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="399.616" y="96.5093" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="351.841" y="92" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="361.395" y="96.5093" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="361.395" y="101.019" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="361.395" y="92" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="370.95" y="101.019" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="370.95" y="96.5093" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="337.508" y="110.037" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="347.063" y="101.019" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="390.061" y="101.019" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="356.619" y="96.5093" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="347.063" y="96.5093" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="390.061" y="96.5093" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="366.173" y="96.5093" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="356.619" y="101.019" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="399.616" y="101.019" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="404.393" y="101.019" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="404.393" y="96.5093" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="409.17" y="101.019" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="409.17" y="105.528" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="413.914" y="110.037" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="418.692" y="114.547" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="416.303" y="119.056" width="7.16585" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="423.469" y="119.056" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="356.619" y="92" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="366.173" y="101.019" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="366.173" y="92" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect x="375.728" y="101.019" width="4.77734" height="4.50905" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 471.243 123.565)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="47.7745" height="4.50905" transform="matrix(-1 0 0 1 466.466 123.565)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="47.7745" height="4.50905" transform="matrix(-1 0 0 1 418.691 123.565)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="71.6619" height="4.50905" transform="matrix(-1 0 0 1 456.911 110.037)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 471.243 119.056)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="47.7745" height="4.50905" transform="matrix(-1 0 0 1 466.466 119.056)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="35.7971" height="4.50905" transform="matrix(-1 0 0 1 418.691 119.056)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="69.2396" height="4.50905" transform="matrix(-1 0 0 1 456.911 105.528)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 471.243 114.547)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="47.7745" height="4.50905" transform="matrix(-1 0 0 1 466.466 114.547)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="38.1856" height="4.50905" transform="matrix(-1 0 0 1 418.691 114.547)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 466.466 110.037)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 456.911 101.019)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 413.913 101.019)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 447.357 101.019)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 404.358 101.019)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 447.357 96.5093)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 404.358 96.5093)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 399.581 96.5093)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 447.357 92)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 437.802 96.5093)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 437.802 101.019)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 437.802 92)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 428.248 101.019)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 428.248 96.5093)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 461.688 110.037)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 452.134 101.019)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 409.136 101.019)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 442.579 96.5093)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 452.134 96.5093)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 409.136 96.5093)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 433.024 96.5093)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 442.579 101.019)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 399.581 101.019)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 394.804 101.019)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 394.804 96.5093)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 390.027 101.019)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 390.027 105.528)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 385.283 110.037)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 380.505 114.547)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="7.16585" height="4.50905" transform="matrix(-1 0 0 1 382.894 119.056)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 375.728 119.056)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 442.579 92)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 433.024 101.019)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 433.024 92)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+<rect width="4.77734" height="4.50905" transform="matrix(-1 0 0 1 423.47 101.019)" fill="#947859" style="fill:#947859;fill:color(display-p3 0.5816 0.4715 0.3508);fill-opacity:1;"/>
+</g>
+<defs>
+<clipPath id="clip0_1241_25266">
+<path d="M0 16C0 7.16344 7.16344 0 16 0H605C613.837 0 621 7.16344 621 16V261C621 269.837 613.837 277 605 277H16C7.16344 277 0 269.837 0 261V16Z" fill="white" style="fill:white;fill-opacity:1;"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/app/signup/[type]/[step]/page.tsx
+++ b/src/app/signup/[type]/[step]/page.tsx
@@ -2,20 +2,17 @@
 
 import { use } from 'react'
 import { notFound } from 'next/navigation'
-import { StepRenderer, ONBOARDING_STEPS } from '@/features/onboarding'
-import type { UserType } from '@/features/onboarding'
-
-const VALID_TYPES: UserType[] = ['general', 'breeder']
+import { StepRenderer, ONBOARDING_STEPS, isValidUserType } from '@/features/onboarding' // [refactored]
 
 const OnboardingStepPage = ({ params }: { params: Promise<{ type: string; step: string }> }) => {
   const { type, step } = use(params)
 
-  if (!VALID_TYPES.includes(type as UserType)) {
+  if (!isValidUserType(type)) {
     notFound()
   }
 
-  const steps = ONBOARDING_STEPS[type as UserType]
-  const isValidStep = steps.some((s) => s.id === step)
+  // [refactored] 타입 가드 덕분에 as 캐스팅 제거
+  const isValidStep = ONBOARDING_STEPS[type].some((s) => s.id === step)
 
   if (!isValidStep) {
     notFound()

--- a/src/app/signup/[type]/layout.tsx
+++ b/src/app/signup/[type]/layout.tsx
@@ -2,10 +2,12 @@
 
 import { notFound, usePathname } from 'next/navigation'
 import { use } from 'react'
-import { OnboardingProvider, StepProgressBar, ONBOARDING_STEPS } from '@/features/onboarding'
-import type { UserType } from '@/features/onboarding'
-
-const VALID_TYPES: UserType[] = ['general', 'breeder']
+import {
+  OnboardingProvider,
+  StepProgressBar,
+  ONBOARDING_STEPS,
+  isValidUserType, // [refactored]
+} from '@/features/onboarding'
 
 const OnboardingLayout = ({
   children,
@@ -17,11 +19,12 @@ const OnboardingLayout = ({
   const { type } = use(params)
   const pathname = usePathname()
 
-  if (!VALID_TYPES.includes(type as UserType)) {
+  if (!isValidUserType(type)) {
     notFound()
   }
 
-  const steps = ONBOARDING_STEPS[type as UserType]
+  // [refactored] 타입 가드 덕분에 type이 UserType으로 좁혀짐
+  const steps = ONBOARDING_STEPS[type]
   const currentStepId = pathname.split('/').pop()
   const initialStepIndex = Math.max(
     steps.findIndex((s) => s.id === currentStepId),
@@ -29,7 +32,7 @@ const OnboardingLayout = ({
   )
 
   return (
-    <OnboardingProvider userType={type as UserType} initialStepIndex={initialStepIndex}>
+    <OnboardingProvider userType={type} initialStepIndex={initialStepIndex}>
       <StepProgressBar />
       {children}
     </OnboardingProvider>

--- a/src/app/signup/[type]/page.tsx
+++ b/src/app/signup/[type]/page.tsx
@@ -1,17 +1,15 @@
 import { redirect, notFound } from 'next/navigation'
-import { ONBOARDING_STEPS } from '@/features/onboarding'
-import type { UserType } from '@/features/onboarding'
-
-const VALID_TYPES: UserType[] = ['general', 'breeder']
+import { ONBOARDING_STEPS, isValidUserType } from '@/features/onboarding' // [refactored]
 
 const OnboardingTypePage = async ({ params }: { params: Promise<{ type: string }> }) => {
   const { type } = await params
 
-  if (!VALID_TYPES.includes(type as UserType)) {
+  if (!isValidUserType(type)) {
     notFound()
   }
 
-  const firstStep = ONBOARDING_STEPS[type as UserType][0]
+  // [refactored] 타입 가드 덕분에 as 캐스팅 제거
+  const firstStep = ONBOARDING_STEPS[type][0]
   redirect(`/signup/${type}/${firstStep.id}`)
 }
 

--- a/src/features/onboarding/index.ts
+++ b/src/features/onboarding/index.ts
@@ -1,5 +1,5 @@
 export { OnboardingProvider, useOnboarding } from './model/OnboardingContext'
 export { StepRenderer } from './ui/StepRenderer'
 export { StepProgressBar } from './ui/StepProgressBar'
-export { ONBOARDING_STEPS } from './model/types'
+export { ONBOARDING_STEPS, VALID_USER_TYPES, isValidUserType } from './model/types'
 export type { UserType, StepConfig } from './model/types'

--- a/src/features/onboarding/model/schema.ts
+++ b/src/features/onboarding/model/schema.ts
@@ -63,7 +63,6 @@ export const surveySchema = z.object({
     .min(1, { error: '휴대폰번호를 입력해주세요' })
     .regex(PHONE_REGEX, { error: '올바른 휴대폰번호를 입력해주세요' }),
   email: z.string().min(1, { error: '이메일을 입력해주세요' }),
-  emailDomain: z.enum(EMAIL_DOMAINS),
   selfIntro: z.string().min(1, { error: '자기소개를 입력해주세요' }),
   awayTime: z.string().min(1, { error: '집을 비우는 시간을 입력해주세요' }),
   livingSpace: z.string().min(1, { error: '생활 공간을 소개해주세요' }),

--- a/src/features/onboarding/model/types.ts
+++ b/src/features/onboarding/model/types.ts
@@ -1,5 +1,11 @@
 export type UserType = 'general' | 'breeder'
 
+// [refactored] 중복 제거: 3개 파일에서 반복되던 VALID_TYPES + 타입 가드를 여기서 export
+export const VALID_USER_TYPES: UserType[] = ['general', 'breeder']
+
+export const isValidUserType = (type: string): type is UserType =>
+  VALID_USER_TYPES.includes(type as UserType)
+
 export interface StepConfig {
   id: string
   label: string

--- a/src/features/onboarding/ui/ChipSelect.tsx
+++ b/src/features/onboarding/ui/ChipSelect.tsx
@@ -11,23 +11,13 @@ interface ChipSelectProps {
 
 const ChipSelect = ({ label, items, selected, onToggle }: ChipSelectProps) => (
   <>
-    {/* 선택된 칩 표시 영역 */}
-    <div className="flex min-h-[2.5rem] flex-wrap items-center gap-[0.75rem] rounded-[0.375rem] border border-[#a8a8a8] bg-white p-[0.625rem] tab:min-h-[3.25rem] tab:rounded-[1rem] tab:px-[1.25rem] tab:py-[0.9375rem]">
-      <span className="text-[0.875rem] leading-[1.375rem] font-medium text-[#5d5d5d] tab:text-[1rem]">
-        {label}
-      </span>
-      {selected.map((item) => (
-        <span
-          key={item}
-          className="rounded-full border border-[#a8a8a8] px-[0.625rem] py-[0.25rem] text-[0.875rem] font-semibold text-[#a8a8a8]"
-        >
-          #{item}
-        </span>
-      ))}
-    </div>
+    {/* 라벨 */}
+    <p className="text-[0.875rem] font-semibold leading-[1.5] text-[#3e3e3e] tab:text-base tab:font-bold">
+      {label}
+    </p>
 
     {/* 칩 목록 */}
-    <div className="mt-[0.75rem] flex flex-wrap gap-[1rem] px-[0.0175rem] tab:mt-[1.05rem] tab:px-[1.9375rem]">
+    <div className="mt-1 flex flex-wrap content-center justify-center gap-[0.75rem] tab:mt-[0.25rem] tab:gap-[1.25rem]">
       {items.map((item) => {
         const isSelected = selected.includes(item)
         return (
@@ -36,8 +26,10 @@ const ChipSelect = ({ label, items, selected, onToggle }: ChipSelectProps) => (
             type="button"
             onClick={() => onToggle(item)}
             className={cn(
-              'rounded-full px-[0.625rem] py-[0.25rem] text-[0.875rem] leading-[1.375rem] font-semibold',
-              isSelected ? 'bg-[#a8a8a8] text-white' : 'border border-[#a8a8a8] text-[#a8a8a8]',
+              'rounded-full px-2 py-1 text-[0.875rem] font-medium leading-[1.5] tab:text-base',
+              isSelected
+                ? 'border border-[#3e3e3e] bg-[#3e3e3e] text-white'
+                : 'border border-[#cacaca] text-[#6b6b6b]',
             )}
           >
             {item}

--- a/src/features/onboarding/ui/CompleteStep.tsx
+++ b/src/features/onboarding/ui/CompleteStep.tsx
@@ -1,84 +1,54 @@
 'use client'
 
+import Image from 'next/image'
 import { useRouter } from 'next/navigation'
 import { useOnboarding } from '../model/OnboardingContext'
+import { StepLayout } from './StepLayout'
 import { StepTitle } from './StepTitle'
-
-const CONTACT_EMAIL = 'coldingcontact@gmail.com'
+import { StepNavButtons } from './StepNavButtons'
 
 const CompleteStep = () => {
   const router = useRouter()
-  const { goBack, userType } = useOnboarding()
+  const { userType } = useOnboarding()
 
-  const isBreeder = userType === 'breeder'
+  const subtitle =
+    userType === 'breeder' ? '포퐁에 오신걸 환영해요!' : '포퐁에 오신걸 환영해요!'
 
   return (
-    <div className="flex min-h-[calc(100dvh-3rem)] flex-col items-center tab:min-h-0 tab:pb-0">
-      <StepTitle>가입완료</StepTitle>
+    <StepLayout className="flex-1">
+      <StepTitle subtitle={subtitle}>가입완료</StepTitle>
 
-      {/* 로고 (mo only) */}
-      <div className="mt-[2.5rem] flex items-center justify-center tab:hidden">
-        <span className="text-[2rem] font-bold text-[#5d5d5d]">Pawpong</span>
-      </div>
-
-      {/* 환영 + 심사 안내 메시지 */}
-      {isBreeder ? (
-        <div className="mt-[2rem] flex flex-col items-center gap-[0.95rem] tab:mt-[9.72rem]">
-          <p className="text-center text-[1.05rem] leading-[1.5] font-medium text-[rgba(79,59,46,0.8)] tab:text-[1.69rem]">
-            포퐁에 오신 걸 환영해요!
-            <br />
-            브리더 심사는
-            <span className="text-[#4e9cf1]"> 최대 3영업일</span> 정도 소요될 수 있어요.
-            <br />
-            제출한 서류를 변경하고 싶거나,
-            <br />
-            궁금한 점이 있으면 고객센터로 문의해 주세요.
-          </p>
-          <div className="flex items-center gap-[0.625rem]">
-            <span className="text-[1.1rem] font-medium text-[rgba(79,59,46,0.8)] tab:text-[1.31rem]">
-              이메일 문의
-            </span>
-            <a
-              href={`mailto:${CONTACT_EMAIL}`}
-              className="text-[1.1rem] font-normal tracking-[-0.022rem] text-[#4e9cf1] underline tab:text-[1.31rem]"
-            >
-              {CONTACT_EMAIL}
-            </a>
-          </div>
+      <div className="flex flex-col items-center justify-center px-4 py-12 tab:px-20">
+        <div className="h-[17.3125rem] w-[14.875rem] overflow-hidden rounded-2xl bg-[#8ed4ff] tab:w-[38.8125rem]">
+          <Image
+            src="/images/onboarding/onboarding-banner-small.svg"
+            alt="가입완료 배너"
+            width={238}
+            height={277}
+            className="size-full object-cover tab:hidden"
+            priority
+          />
+          <Image
+            src="/images/onboarding/onboarding-banner.svg"
+            alt="가입완료 배너"
+            width={621}
+            height={277}
+            className="hidden size-full object-cover tab:block"
+            priority
+          />
         </div>
-      ) : (
-        <p className="hidden tab:mt-[9.72rem] tab:block tab:text-center tab:text-[1.69rem] tab:leading-[1.5] tab:font-medium tab:text-[rgba(79,59,46,0.8)]">
-          포퐁에 오신 걸 환영해요!
-        </p>
-      )}
-
-      {/* 스페이서 (mo only) */}
-      <div className="flex-1 tab:hidden" />
-
-      {/* 버튼 영역 */}
-      <div className="flex w-full flex-col gap-[0.625rem] p-[1.25rem] tab:static tab:mt-[12.1875rem] tab:w-[31.4375rem] tab:gap-[0.875rem] tab:p-0 tab:pb-[2rem]">
-        <button
-          type="button"
-          onClick={goBack}
-          className="hidden tab:order-last tab:block tab:h-[3rem] tab:w-full tab:rounded-full tab:text-[1rem] tab:font-semibold tab:text-[#5d5d5d]"
-        >
-          뒤로
-        </button>
-        <button
-          type="button"
-          onClick={() => router.push('/')}
-          className="h-[3rem] w-full rounded-full border border-[#d4d4d4] text-[1rem] font-semibold text-[#5d5d5d] transition-colors tab:order-first tab:border-0 tab:bg-[#d4d4d4]"
-        >
-          홈으로
-        </button>
-        <button
-          type="button"
-          className="h-[3rem] w-full rounded-full bg-[#d4d4d4] text-[1rem] font-semibold text-[#5d5d5d] transition-colors"
-        >
-          문의하기
-        </button>
       </div>
-    </div>
+
+      <StepNavButtons
+        onNext={() => router.push('/')}
+        nextLabel="홈으로"
+        extraButtons={
+          <button type="button" className="text-base font-medium text-[#3e3e3e]">
+            문의하기
+          </button>
+        }
+      />
+    </StepLayout>
   )
 }
 

--- a/src/features/onboarding/ui/InfoStep.tsx
+++ b/src/features/onboarding/ui/InfoStep.tsx
@@ -48,7 +48,7 @@ const InfoStep = () => {
       onNext={() => handleSubmit(onSubmit)()}
       onBack={goBack}
     >
-      <div className="mt-[2rem] flex w-full flex-col items-center gap-[2rem] px-5 tab:mt-[3.625rem] tab:max-w-[40.625rem] tab:gap-[3.625rem] tab:px-0">
+      <>
         <ProfileImageUpload />
 
         {/* 닉네임 + 중복검사 */}
@@ -82,7 +82,7 @@ const InfoStep = () => {
             )}
           />
         </div>
-      </div>
+      </>
     </StepContainer>
   )
 }

--- a/src/features/onboarding/ui/InfoStep.tsx
+++ b/src/features/onboarding/ui/InfoStep.tsx
@@ -47,25 +47,23 @@ const InfoStep = () => {
       title="회원 정보를 입력해주세요"
       onNext={() => handleSubmit(onSubmit)()}
       onBack={goBack}
-      navClassName="tab:mt-[9.9375rem]"
     >
-      <ProfileImageUpload />
+      <div className="mt-[2rem] flex w-full flex-col items-center gap-[2rem] px-5 tab:mt-[3.625rem] tab:max-w-[40.625rem] tab:gap-[3.625rem] tab:px-0">
+        <ProfileImageUpload />
 
-      {/* 폼 영역 */}
-      <div className="mt-[2.04rem] flex w-full flex-col px-[1.25rem] tab:mt-[3.0625rem] tab:w-[59.4375rem] tab:px-0">
         {/* 닉네임 + 중복검사 */}
-        <div className="flex gap-[0.25rem] tab:gap-[1.1875rem]">
+        <div className="flex w-full gap-2">
           <StepInput
             type="text"
             placeholder="닉네임"
             {...register('nickname')}
-            className="flex-1 tab:flex-[731]"
+            className="flex-1"
           />
           <StepActionButton>중복 검사</StepActionButton>
         </div>
 
         {/* 관심있는 키워드 */}
-        <div className="mt-[0.625rem] tab:mt-[2.09rem]">
+        <div className="flex w-full flex-col">
           <Controller
             name="selectedKeywords"
             control={control}

--- a/src/features/onboarding/ui/KennelInfoStep.tsx
+++ b/src/features/onboarding/ui/KennelInfoStep.tsx
@@ -40,25 +40,24 @@ const KennelInfoStep = () => {
       title="브리더 정보를 입력해주세요"
       onNext={() => handleSubmit(onSubmit)()}
       onBack={goBack}
-      navClassName="tab:mt-[9.9375rem]"
     >
-      <ProfileImageUpload />
+      <div className="mt-[2rem] flex w-full flex-col items-center gap-[2rem] px-5 tab:mt-[3.625rem] tab:max-w-[40.625rem] tab:gap-[3.625rem] tab:px-0">
+        <ProfileImageUpload />
 
-      {/* 폼 영역 */}
-      <div className="mt-[2.04rem] flex w-full flex-col gap-[0.625rem] px-[1.25rem] tab:mt-[3.0625rem] tab:w-[59.4375rem] tab:gap-0 tab:px-0">
-        {/* 브리더명 + 중복검사 */}
-        <div className="flex gap-[0.25rem] tab:gap-[1.1875rem]">
-          <StepInput
-            type="text"
-            placeholder="브리더명(상호명)"
-            {...register('breederName')}
-            className="flex-1 tab:flex-[731]"
-          />
-          <StepActionButton>중복검사</StepActionButton>
-        </div>
+        {/* 폼 영역 */}
+        <div className="flex w-full flex-col gap-[0.625rem] tab:gap-[2.09rem]">
+          {/* 브리더명 + 중복검사 */}
+          <div className="flex gap-2">
+            <StepInput
+              type="text"
+              placeholder="브리더명(상호명)"
+              {...register('breederName')}
+              className="flex-1"
+            />
+            <StepActionButton>중복검사</StepActionButton>
+          </div>
 
-        {/* 지역 */}
-        <div className="tab:mt-[2.09rem]">
+          {/* 지역 */}
           <Controller
             name="region"
             control={control}
@@ -71,32 +70,32 @@ const KennelInfoStep = () => {
               />
             )}
           />
-        </div>
 
-        {/* 품종 키워드 */}
-        <div className="tab:mt-[2.09rem]">
-          <Controller
-            name="selectedBreeds"
-            control={control}
-            render={({ field }) => (
-              <ChipSelect
-                label={
-                  <>
-                    <span className="hidden tab:inline">품종</span>
-                    <span className="tab:hidden">관심있는 키워드</span>
-                  </>
-                }
-                items={BREED_KEYWORDS}
-                selected={field.value}
-                onToggle={(breed) => {
-                  const next = field.value.includes(breed)
-                    ? field.value.filter((b) => b !== breed)
-                    : [...field.value, breed]
-                  field.onChange(next)
-                }}
-              />
-            )}
-          />
+          {/* 품종 키워드 */}
+          <div className="flex flex-col">
+            <Controller
+              name="selectedBreeds"
+              control={control}
+              render={({ field }) => (
+                <ChipSelect
+                  label={
+                    <>
+                      <span className="hidden tab:inline">품종</span>
+                      <span className="tab:hidden">관심있는 키워드</span>
+                    </>
+                  }
+                  items={BREED_KEYWORDS}
+                  selected={field.value}
+                  onToggle={(breed) => {
+                    const next = field.value.includes(breed)
+                      ? field.value.filter((b) => b !== breed)
+                      : [...field.value, breed]
+                    field.onChange(next)
+                  }}
+                />
+              )}
+            />
+          </div>
         </div>
       </div>
     </StepContainer>

--- a/src/features/onboarding/ui/ProfileImageUpload.tsx
+++ b/src/features/onboarding/ui/ProfileImageUpload.tsx
@@ -6,12 +6,12 @@ interface ProfileImageUploadProps {
 }
 
 const ProfileImageUpload = ({ className }: ProfileImageUploadProps) => (
-  <div className={cn('mt-[2.09rem] tab:mt-[6.343rem]', className)}>
+  <div className={cn(className)}>
     <button
       type="button"
-      className="flex h-[8.9375rem] w-[9.1875rem] items-center justify-center rounded-full bg-[#d4d4d4]"
+      className="flex size-[5rem] items-center justify-center rounded-full bg-[#6b6b6b] tab:size-[6.25rem]"
     >
-      <ImageIcon className="size-[3.5rem] text-white" />
+      <ImageIcon className="size-[2.5rem] text-white tab:size-[3.5rem]" />
     </button>
   </div>
 )

--- a/src/features/onboarding/ui/ProfileStep.tsx
+++ b/src/features/onboarding/ui/ProfileStep.tsx
@@ -65,7 +65,7 @@ const ProfileStep = () => {
         계정 정보를 입력해주세요
       </StepTitle>
 
-      <div className="flex w-full max-w-[40.625rem] flex-col items-center gap-8 px-4 py-12 tab:gap-[3.625rem] tab:px-20 tab:py-12">
+      <div className="flex w-full max-w-[40.625rem] flex-col items-center gap-8 px-4 py-12 tab:gap-[3.625rem]  tab:py-12">
         <StepIndicator />
 
         {/* 폼 영역 */}

--- a/src/features/onboarding/ui/StepContainer.tsx
+++ b/src/features/onboarding/ui/StepContainer.tsx
@@ -34,11 +34,10 @@ const StepContainer = ({
   <StepLayout className={layoutClassName}>
     <StepTitle subtitle={subtitle}>{title}</StepTitle>
 
-    <div className="mt-[1.125rem] tab:mt-[2.09rem]">
+    <div className="flex w-full max-w-[40.625rem] flex-col items-center gap-8 px-4 py-12 tab:gap-[3.625rem] tab:py-12">
       <StepIndicator />
+      {children}
     </div>
-
-    {children}
 
     <StepNavButtons
       onNext={onNext}

--- a/src/features/onboarding/ui/StepInput.tsx
+++ b/src/features/onboarding/ui/StepInput.tsx
@@ -38,7 +38,7 @@ const StepTextarea = forwardRef<HTMLTextAreaElement, StepTextareaProps>(
       ref={ref}
       {...props}
       className={cn(
-        'h-[4.5rem] w-full resize-none rounded-lg border border-[#e4e4e4] bg-white px-3 py-3 text-[0.875rem] font-medium leading-[1.5] text-[#3e3e3e] outline-none placeholder:text-[#a6a6a6] tab:h-[7.8125rem]',
+        'h-[4.5rem] w-full resize-none rounded-lg border border-[#cacaca] bg-white p-3 text-[0.875rem] font-medium leading-[1.5] text-[#3e3e3e] outline-none placeholder:text-[#a6a6a6] tab:h-[6.5625rem]',
         className,
       )}
     />

--- a/src/features/onboarding/ui/StepNavButtons.tsx
+++ b/src/features/onboarding/ui/StepNavButtons.tsx
@@ -21,7 +21,7 @@ const StepNavButtons = ({
 }: StepNavButtonsProps) => (
   <div
     className={cn(
-      'fixed right-0 bottom-0 left-0 z-10 flex flex-col items-center gap-3 bg-white px-4 py-4 tab:static tab:right-auto tab:bottom-auto tab:left-auto tab:z-auto tab:px-20 tab:py-4',
+      'fixed right-0 bottom-0 left-0 z-10 flex flex-col items-center gap-3 bg-white px-4 py-4 tab:static tab:right-auto tab:bottom-auto tab:left-auto tab:z-auto tab:gap-5 tab:px-12 pc:px-20 tab:py-8',
       className,
     )}
   >

--- a/src/features/onboarding/ui/StepProgressBar.tsx
+++ b/src/features/onboarding/ui/StepProgressBar.tsx
@@ -1,9 +1,58 @@
 'use client'
 
-import Image from 'next/image'
 import { cafe24Proup } from '@/shared/lib/fonts'
 import { cn } from '@/shared/lib/Cn'
 import { useOnboarding } from '../model/OnboardingContext'
+
+const FILL_START = 10.4868
+const FILL_END = 544.113
+const FILL_WIDTH = FILL_END - FILL_START
+
+interface ProgressBarSvgProps {
+  percent: number
+}
+
+const ProgressBarSvg = ({ percent }: ProgressBarSvgProps) => {
+  const clampedPercent = Math.min(100, Math.max(0, percent))
+  const fillEndX = FILL_START + (clampedPercent / 100) * FILL_WIDTH
+
+  return (
+    <svg
+      preserveAspectRatio="none"
+      width="100%"
+      height="100%"
+      overflow="visible"
+      style={{ display: 'block' }}
+      viewBox="0 0 557.533 26.3097"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      role="img"
+      aria-label={`진행률 ${clampedPercent}%`}
+    >
+      {/* 외곽 테두리 (갈색) */}
+      <path
+        d="M544.111 3.95215H550.517V11.0586H557.533V26.3096H10.4873V22.3887H6.33594V19.9414H0V11.0586H6.33594V3.95215H10.457V0H544.111V3.95215Z"
+        fill="#A9835A"
+      />
+      {/* 배경 (노란색) */}
+      <path
+        d="M544.112 3.94877V11.0591H550.517V19.7388H6.33601V11.0591H10.4493V3.94877H544.112Z"
+        fill="#FFFA94"
+      />
+      {/* 배경 하단 그림자 */}
+      <path d="M550.517 19.7384H10.4869V22.3889H550.517V19.7384Z" fill="#D9BD44" />
+      {/* 내부 흰색 영역 */}
+      <path d="M544.113 9.25621H14.5593V19.7384H544.113V9.25621Z" fill="white" />
+      {/* 녹색 채움 (진행률) */}
+      {clampedPercent > 0 && (
+        <>
+          <rect x={FILL_START} y={9.25618} width={fillEndX - FILL_START} height={10.48222} fill="#39D264" />
+          <rect x={FILL_START} y={9.25618} width={fillEndX - FILL_START} height={4.02742} fill="#74F08E" />
+        </>
+      )}
+    </svg>
+  )
+}
 
 const StepProgressBar = () => {
   const { currentStepIndex, steps } = useOnboarding()
@@ -24,14 +73,9 @@ const StepProgressBar = () => {
           <span className="text-[#39d264]">{progressPercent}%</span>
         </div>
         <div className="relative px-2 py-[0.125rem]">
-          <Image
-            src="/images/onboarding/progress-bar.svg"
-            alt={`진행률 ${progressPercent}%`}
-            width={558}
-            height={26}
-            className="h-[0.829rem] w-full max-w-[17.562rem] tab:h-[1.644rem] tab:max-w-[34.846rem]"
-            priority
-          />
+          <div className="h-[0.829rem] w-full max-w-[17.562rem] tab:h-[1.644rem] tab:max-w-[34.846rem]">
+            <ProgressBarSvg percent={progressPercent} />
+          </div>
         </div>
       </div>
     </div>

--- a/src/features/onboarding/ui/StepProgressBar.tsx
+++ b/src/features/onboarding/ui/StepProgressBar.tsx
@@ -12,8 +12,8 @@ const StepProgressBar = () => {
   const progressPercent = Math.round(((currentStepIndex + 1) / (visibleSteps.length + 1)) * 100)
 
   return (
-    <div className="flex w-full items-center justify-center bg-white px-4 py-1 tab:px-20 tab:py-2">
-      <div className="flex items-center gap-[0.125rem]">
+    <div className="flex w-full items-center justify-center bg-white px-4 py-1 tab:px-12 pc:px-20 tab:py-2">
+      <div className="flex w-full items-center justify-center gap-[0.125rem]">
         <div
           className={cn(
             cafe24Proup.className,
@@ -29,7 +29,7 @@ const StepProgressBar = () => {
             alt={`진행률 ${progressPercent}%`}
             width={558}
             height={26}
-            className="h-[1rem] w-[12rem] tab:h-[1.644rem] tab:w-[34.846rem]"
+            className="h-[0.829rem] w-full max-w-[17.562rem] tab:h-[1.644rem] tab:max-w-[34.846rem]"
             priority
           />
         </div>

--- a/src/features/onboarding/ui/StepTitle.tsx
+++ b/src/features/onboarding/ui/StepTitle.tsx
@@ -9,7 +9,7 @@ interface StepTitleProps {
 }
 
 const StepTitle = ({ children, subtitle }: StepTitleProps) => (
-  <div className="flex w-full flex-col items-center justify-center px-4 py-8 tab:px-20 tab:py-12">
+  <div className="flex w-full flex-col items-center justify-center px-4 py-8 tab:px-12 pc:px-20 tab:py-12">
     <h1
       className={cn(
         cafe24Proup.className,

--- a/src/features/onboarding/ui/SurveyStep.tsx
+++ b/src/features/onboarding/ui/SurveyStep.tsx
@@ -3,21 +3,20 @@
 import { Controller } from 'react-hook-form'
 import { useOnboarding } from '../model/OnboardingContext'
 import { useStepForm } from '../model/useStepForm'
-import { type SurveyFormData, EMAIL_DOMAINS } from '../model/schema'
+import { type SurveyFormData } from '../model/schema'
 import { StepContainer } from './StepContainer'
-import { StepInput, StepTextarea, StepSelect } from './StepInput'
+import { StepInput, StepTextarea } from './StepInput'
 import { CheckboxField } from './CheckboxField'
 
 const SurveyStep = () => {
   const { goBack } = useOnboarding()
 
-  const { register, control, handleSubmit, onSubmit } =
+  const { register, control, watch, handleSubmit, onSubmit } =
     useStepForm<SurveyFormData>('survey', {
       privacyAgreed: false as unknown as true,
       name: '',
       phone: '',
       email: '',
-      emailDomain: EMAIL_DOMAINS[0],
       selfIntro: '',
       awayTime: '',
       livingSpace: '',
@@ -28,26 +27,16 @@ const SurveyStep = () => {
       title="간단한 조사 양식"
       onNext={() => handleSubmit(onSubmit)()}
       onBack={goBack}
-      layoutClassName="pb-[14rem]"
-      navClassName="bg-white tab:mt-[9.03rem] tab:bg-transparent"
-      navExtraButtons={
-        <button
-          type="button"
-          className="h-12 w-full rounded-full border border-[#d4d4d4] text-[1rem] font-semibold text-[#5d5d5d] tab:hidden"
-        >
-          다음에 하기
-        </button>
-      }
     >
       {/* 콘텐츠 영역 */}
-      <div className="mt-[2.4375rem] flex w-full flex-col px-[1.25rem] tab:mt-[3.125rem] tab:w-[59.4375rem] tab:px-0">
+      <div className="flex w-full flex-col">
         {/* 섹션 1: 개인정보 수집 동의 */}
         <div className="flex flex-col gap-[0.4375rem]">
-          <div className="flex items-center gap-[0.625rem] tab:gap-[1.25rem]">
-            <p className="text-[0.875rem] leading-[1.5] font-bold text-[#5d5d5d] tab:text-[1.25rem]">
+          <div className="flex items-center gap-1">
+            <p className="p-[0.125rem] text-[0.875rem] leading-[1.5] font-semibold text-[#3e3e3e] tab:text-base">
               반려동물 입양 상담을 위한 개인정보 수집과 이용에 동의하시나요?
             </p>
-            <span className="shrink-0 text-[0.875rem] leading-[1.5] font-bold text-[#5d5d5d] tab:text-[0.75rem] tab:text-[1rem] tab:font-semibold">
+            <span className="shrink-0 p-[0.125rem] text-[0.875rem] leading-[1.5] font-medium text-[#6b6b6b]">
               필수
             </span>
           </div>
@@ -72,88 +61,86 @@ const SurveyStep = () => {
           />
         </div>
 
-        {/* 섹션 2: 필수 입력 */}
-        <div className="mt-[2.6875rem] tab:mt-[3.787rem]">
-          <p className="text-[0.875rem] leading-[1.5] font-bold text-[#5d5d5d] tab:text-[1rem] tab:font-semibold">
-            필수
-          </p>
 
-          <div className="mt-[0.625rem] flex flex-col gap-[0.625rem] tab:mt-[0.518rem] tab:gap-[1.5625rem]">
-            <StepInput type="text" placeholder="이름" {...register('name')} />
-            <StepInput type="tel" placeholder="휴대폰번호" {...register('phone')} />
-
-            {/* 이메일 + 도메인 */}
-            <div className="flex gap-[0.25rem] tab:gap-[1.25rem]">
-              <StepInput
-                type="text"
-                placeholder="이메일"
-                {...register('email')}
-                className="flex-1 tab:flex-[731]"
-              />
-              <Controller
-                name="emailDomain"
-                control={control}
-                render={({ field }) => (
-                  <StepSelect
-                    value={field.value}
-                    onValueChange={field.onChange}
-                    options={EMAIL_DOMAINS.map((d) => ({ value: d, label: d }))}
-                    className="shrink-0 tab:w-[12.5rem]"
-                  />
-                )}
-              />
-            </div>
-          </div>
-        </div>
 
         {/* 섹션 3: 자기소개 */}
-        <div className="mt-[2.0625rem] tab:mt-[3.7875rem]">
-          <div className="flex items-center gap-[0.625rem] tab:gap-[1.25rem]">
-            <p className="text-[0.875rem] leading-[1.5] font-bold text-[#5d5d5d] tab:text-[1.25rem]">
+        <div className="mt-[2.0625rem] flex flex-col gap-[0.125rem] tab:mt-[3.625rem]">
+          <button
+            type="button"
+            className="mb-3 flex items-center gap-0 self-end rounded-lg bg-[#3e3e3e] px-2 py-1 text-[0.875rem] font-semibold text-[#f6f6f6]"
+          >
+            다음에 작성하기
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" className="size-6">
+              <path d="M9.7 18.3L15.3 12.7C15.4 12.6 15.475 12.4917 15.525 12.375C15.575 12.2583 15.6 12.1333 15.6 12C15.6 11.8667 15.575 11.7417 15.525 11.625C15.475 11.5083 15.4 11.4 15.3 11.3L9.7 5.7C9.38333 5.38333 9.31267 5.021 9.488 4.613C9.66267 4.20433 9.97467 4 10.424 4C10.8733 4 11.2 4.2 11.4 4.6L17.025 10.225C17.225 10.425 17.375 10.65 17.475 10.9C17.575 11.15 17.625 11.4167 17.625 11.7C17.625 11.9833 17.575 12.25 17.475 12.5C17.375 12.75 17.225 12.975 17.025 13.175L11.4 18.8C11.0833 19.1167 10.721 19.1877 10.313 19.013C9.90433 18.8377 9.7 18.5253 9.7 18.076V18.3Z" fill="#f6f6f6" />
+            </svg>
+          </button>
+          <div className="flex items-center gap-1">
+            <p className="p-[0.125rem] text-[0.875rem] leading-[1.5] font-semibold text-[#3e3e3e] tab:text-base">
               간단하게 자기소개 부탁드려요
             </p>
-            <span className="shrink-0 text-[0.875rem] leading-[1.5] font-bold text-[#5d5d5d] tab:text-[0.75rem] tab:text-[1rem] tab:font-semibold">
+            <span className="shrink-0 p-[0.125rem] text-[0.875rem] leading-[1.5] font-medium text-[#6b6b6b]">
               필수
             </span>
           </div>
 
           <StepTextarea
             placeholder="성별, 연령대, 거주지, 결혼 계획, 생활패턴 등"
+            maxLength={100}
             {...register('selfIntro')}
-            className="mt-[0.625rem] tab:mt-[0.875rem]"
           />
+          <p className="text-end text-[0.625rem] leading-[1.5] font-medium text-[#6b6b6b]">
+            {watch('selfIntro')?.length ?? 0}/100
+          </p>
         </div>
 
         {/* 섹션 4: 공간/생활패턴 */}
         <div className="mt-[2.0375rem] tab:mt-[3.662rem]">
-          <div className="flex items-center gap-[0.625rem] tab:gap-[1.25rem]">
-            <p className="text-[0.875rem] leading-[1.5] font-bold text-[#5d5d5d] tab:text-[1.25rem]">
+          <div className="flex items-center gap-1">
+            <p className="p-[0.125rem] text-[0.875rem] leading-[1.5] font-semibold text-[#3e3e3e] tab:text-base">
               반려동물이 지낼 공간과 생활패턴에 대해 알려주세요
             </p>
-            <span className="shrink-0 text-[0.875rem] leading-[1.5] font-bold text-[#5d5d5d] tab:text-[0.75rem] tab:text-[1rem] tab:font-semibold">
-              필수
+            <span className="shrink-0 p-[0.125rem] text-[0.875rem] leading-[1.5] font-medium text-[#6b6b6b]">
+              선택
             </span>
           </div>
 
-          <div className="mt-[1.25rem] flex flex-col gap-[1.25rem] tab:mt-[2.125rem] tab:gap-[2.125rem]">
-            <div className="flex flex-col gap-[0.625rem] tab:gap-[0.875rem]">
-              <p className="text-[0.875rem] leading-[1.5] font-semibold text-[#5d5d5d] tab:text-[1rem]">
-                평균적으로 집을 비우는 시간은 얼마나 되나요?
-              </p>
+          <div className="mt-[1.25rem] flex flex-col gap-[1.25rem] tab:mt-3 tab:gap-3">
+            <div className="flex flex-col gap-[0.125rem]">
+              <div className="flex items-center gap-1">
+                <p className="p-[0.125rem] text-[0.875rem] leading-[1.5] font-semibold text-[#3e3e3e] tab:text-base">
+                  평균적으로 집을 비우는 시간은 얼마나 되나요?
+                </p>
+                <span className="shrink-0 p-[0.125rem] text-[0.875rem] leading-[1.5] font-medium text-[#6b6b6b]">
+                  선택
+                </span>
+              </div>
               <StepTextarea
                 placeholder="출퇴근 / 외출 시간을 포함해 하루 중 집을 비우는 시간"
+                maxLength={100}
                 {...register('awayTime')}
               />
+              <p className="text-end text-[0.625rem] leading-[1.5] font-medium text-[#6b6b6b]">
+                {watch('awayTime')?.length ?? 0}/100
+              </p>
             </div>
 
-            <div className="flex flex-col gap-[0.625rem] tab:gap-[0.875rem]">
-              <p className="text-[0.875rem] leading-[1.5] font-semibold text-[#5d5d5d] tab:text-[1rem]">
-                반려동물과 함께 지내게 될 공간을 소개해 주세요
-              </p>
+            <div className="flex flex-col gap-[0.125rem]">
+              <div className="flex items-center gap-1">
+                <p className="p-[0.125rem] text-[0.875rem] leading-[1.5] font-semibold text-[#3e3e3e] tab:text-base">
+                  반려동물과 함께 지내게 될 공간을 소개해 주세요
+                </p>
+                <span className="shrink-0 p-[0.125rem] text-[0.875rem] leading-[1.5] font-medium text-[#6b6b6b]">
+                  선택
+                </span>
+              </div>
               <StepTextarea
                 placeholder="반려동물이 주로 생활할 공간(예: 거실 등)과 환경(크기, 구조 등)"
+                maxLength={100}
                 {...register('livingSpace')}
               />
+              <p className="text-end text-[0.625rem] leading-[1.5] font-medium text-[#6b6b6b]">
+                {watch('livingSpace')?.length ?? 0}/100
+              </p>
             </div>
           </div>
         </div>

--- a/src/widgets/signup-type-select/ui/SignupTypeSelect.tsx
+++ b/src/widgets/signup-type-select/ui/SignupTypeSelect.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation'
 import { cafe24Proup } from '@/shared/lib/fonts'
 import { cn } from '@/shared/lib/Cn'
 import { StepLayout } from '@/features/onboarding/ui/StepLayout'
+import { StepNavButtons } from '@/features/onboarding/ui/StepNavButtons'
 import { UserTypeCard } from './UserTypeCard'
 
 const USER_TYPE_OPTIONS = [
@@ -60,23 +61,11 @@ const SignupTypeSelect = () => {
         ))}
       </div>
 
-      <div className="flex w-full flex-col items-center gap-5 py-8">
-        <button
-          type="button"
-          onClick={handleNext}
-          disabled={!selected}
-          className="h-12 w-[16.125rem] rounded-full bg-[#fffa94] text-base font-semibold text-[#3e3e3e] transition-colors disabled:opacity-40"
-        >
-          다음
-        </button>
-        <button
-          type="button"
-          onClick={() => router.back()}
-          className="text-base font-medium text-[#3e3e3e]"
-        >
-          뒤로
-        </button>
-      </div>
+      <StepNavButtons
+        onNext={handleNext}
+        onBack={() => router.back()}
+        nextDisabled={!selected}
+      />
     </StepLayout>
   )
 }

--- a/src/widgets/signup-type-select/ui/SignupTypeSelect.tsx
+++ b/src/widgets/signup-type-select/ui/SignupTypeSelect.tsx
@@ -2,9 +2,8 @@
 
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
-import { cafe24Proup } from '@/shared/lib/fonts'
-import { cn } from '@/shared/lib/Cn'
 import { StepLayout } from '@/features/onboarding/ui/StepLayout'
+import { StepTitle } from '@/features/onboarding/ui/StepTitle'
 import { StepNavButtons } from '@/features/onboarding/ui/StepNavButtons'
 import { UserTypeCard } from './UserTypeCard'
 
@@ -37,18 +36,9 @@ const SignupTypeSelect = () => {
 
   return (
     <StepLayout className="flex-1">
-      <div className="flex w-full items-center justify-center py-12">
-        <h1
-          className={cn(
-            cafe24Proup.className,
-            'text-center font-cafe24 text-[1.25rem] font-bold leading-[1.5] text-[#3e3e3e] tab:text-[1.5rem]',
-          )}
-        >
-          회원유형을 선택해 주세요
-        </h1>
-      </div>
+      <StepTitle>회원유형을 선택해 주세요</StepTitle>
 
-      <div className="flex flex-1 flex-col items-center justify-center gap-5 tab:flex-row tab:gap-12">
+      <div className="flex w-full max-w-[40.625rem] tab:flex-row flex-1 flex-col items-center justify-center gap-8 px-4 py-12 tab:gap-[3.625rem] tab:py-12">
         {USER_TYPE_OPTIONS.map((option) => (
           <UserTypeCard
             key={option.value}


### PR DESCRIPTION
## Summary
- 온보딩 전체 스텝(SignupTypeSelect, InfoStep, SurveyStep, CompleteStep) 피그마 디자인 적용
- StepProgressBar를 정적 SVG에서 동적 인라인 SVG로 변경하여 진행률 실시간 반영
- 가입완료 배너 SVG 추가 (PC/모바일 분기)
- VALID_TYPES 중복 제거 및 isValidUserType 타입 가드 추출

## Test plan
- [ ] /signup 페이지에서 회원유형 선택 UI 확인
- [ ] general/breeder 각 온보딩 스텝별 디자인 확인
- [ ] 프로그레스바가 스텝 진행에 따라 동적으로 채워지는지 확인
- [ ] 가입완료 페이지 배너 이미지 PC/모바일 분기 확인
- [ ] 잘못된 type/step URL 접근 시 notFound 동작 확인

Closes #67