### PR TITLE
feat(gnb): 로그인/회원가입 버튼 추가

### DIFF
--- a/src/widgets/gnb/ui/Gnb.tsx
+++ b/src/widgets/gnb/ui/Gnb.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import Link from 'next/link'
 import { MenuIcon } from '@/shared/assets/icons'
 import { LogoButton } from './LogoButton'
 import { NavBar } from './NavBar'
@@ -14,8 +15,24 @@ const Gnb = () => {
       <header className="sticky top-0 z-50 flex w-full items-center justify-center bg-white py-0 tab:static tab:z-auto tab:py-[0.5rem]">
         <div className="flex w-full items-center justify-between px-[1.25rem] tab:px-[3rem] pc:px-[6.25rem]">
           <LogoButton />
-          {/* PC: 네비게이션 */}
-          <NavBar className="hidden tab:flex" />
+          {/* PC: 네비게이션 + 로그인/회원가입 */}
+          <div className="hidden items-center gap-[1.75rem] tab:flex">
+            <NavBar />
+            <div className="flex items-center gap-3">
+              <Link
+                href="/login"
+                className="rounded-full border border-[#a8a8a8] px-4 py-2 text-sm font-medium text-[#666] transition-colors hover:bg-[#f5f5f5]"
+              >
+                로그인
+              </Link>
+              <Link
+                href="/signup"
+                className="rounded-full bg-[#fffa94] px-4 py-2 text-sm font-semibold text-[#3e3e3e] transition-colors hover:bg-[#fff066]"
+              >
+                회원가입
+              </Link>
+            </div>
+          </div>
           {/* 모바일: 햄버거 메뉴 */}
           <button
             type="button"

--- a/src/widgets/gnb/ui/MobileMenu.tsx
+++ b/src/widgets/gnb/ui/MobileMenu.tsx
@@ -25,8 +25,26 @@ const MobileMenu = ({ onClose }: MobileMenuProps) => {
         </button>
       </div>
 
+      {/* 로그인/회원가입 */}
+      <div className="flex gap-3 px-[2.701rem] pt-[2.438rem]">
+        <Link
+          href="/login"
+          onClick={onClose}
+          className="flex-1 rounded-full border border-[#a8a8a8] py-3 text-center text-base font-medium text-[#666]"
+        >
+          로그인
+        </Link>
+        <Link
+          href="/signup"
+          onClick={onClose}
+          className="flex-1 rounded-full bg-[#fffa94] py-3 text-center text-base font-semibold text-[#3e3e3e]"
+        >
+          회원가입
+        </Link>
+      </div>
+
       {/* 메뉴 항목 */}
-      <nav className="flex flex-col px-[2.701rem] pt-[2.438rem]">
+      <nav className="flex flex-col px-[2.701rem] pt-[1.5rem]">
         {MOBILE_MENU_ITEMS.map((item) => (
           <Link
             key={item.href}


### PR DESCRIPTION
## Summary
- PC 헤더(Gnb) NavBar 오른쪽에 로그인/회원가입 버튼 추가
- 모바일 메뉴(MobileMenu) 상단에 로그인/회원가입 버튼 추가

Closes #69

## Test plan
- [ ] PC에서 헤더 오른쪽에 로그인(아웃라인)/회원가입(노란색) 버튼 노출 확인
- [ ] 모바일에서 햄버거 메뉴 열었을 때 상단에 버튼 2개 노출 확인
- [ ] 로그인 버튼 클릭 시 /login 이동 확인
- [ ] 회원가입 버튼 클릭 시 /signup 이동 확인