### PR TITLE
fix(banner): 배너 높이/페이지네이션/화살표 Figma 정렬

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -27,3 +27,19 @@
 :root {
   font-family: var(--font-pretendard), sans-serif;
 }
+
+/* 배너 캐러셀 페이지네이션 (Figma: active 노란 알약, inactive 갈색 점) */
+.banner-swiper {
+  --swiper-pagination-color: #fffa94;
+  --swiper-pagination-bullet-inactive-color: #a9835a;
+  --swiper-pagination-bullet-inactive-opacity: 1;
+  --swiper-pagination-bullet-width: 0.5rem;
+  --swiper-pagination-bullet-height: 0.5rem;
+  --swiper-pagination-bullet-horizontal-gap: 0.125rem;
+  --swiper-pagination-bottom: 1rem;
+}
+
+.banner-swiper .swiper-pagination-bullet-active {
+  width: 1.25rem;
+  border-radius: 0.5rem;
+}

--- a/src/widgets/banner/ui/Banner.tsx
+++ b/src/widgets/banner/ui/Banner.tsx
@@ -3,18 +3,35 @@
 import Image from 'next/image'
 import Link from 'next/link'
 import { Swiper, SwiperSlide } from 'swiper/react'
-import { Autoplay, Pagination } from 'swiper/modules'
+import { Autoplay, Navigation, Pagination } from 'swiper/modules'
 import { useQuery } from '@tanstack/react-query'
 import { homeQueries } from '@/entities/home'
 import type { BannerDto } from '@/shared/types'
 import 'swiper/css'
 import 'swiper/css/pagination'
 
+/** Figma: 5칸 픽셀 스타일 chevron (#F6F6F6) */
+const ChevronRight = ({ className }: { className?: string }) => (
+  <svg
+    viewBox="0 0 25 40"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    className={className}
+    aria-hidden
+  >
+    <path d="M10 0H0V10H10V0Z" fill="currentColor" />
+    <path d="M17.5 7.5H7.5V17.5H17.5V7.5Z" fill="currentColor" />
+    <path d="M25 15H15V25H25V15Z" fill="currentColor" />
+    <path d="M17.5 22.5H7.5V32.5H17.5V22.5Z" fill="currentColor" />
+    <path d="M10 30H0V40H10V30Z" fill="currentColor" />
+  </svg>
+)
+
 const BannerSlide = ({ banner }: { banner: BannerDto }) => {
   const content = (
     <section className="relative w-full overflow-hidden bg-[#d9d9d9]">
       {/* Desktop */}
-      <div className="hidden aspect-[16/5] tab:block">
+      <div className="hidden aspect-[768/347] tab:block pc:aspect-[180/47]">
         <Image
           src={banner.desktopImageUrl}
           alt={banner.title ?? ''}
@@ -24,7 +41,7 @@ const BannerSlide = ({ banner }: { banner: BannerDto }) => {
         />
       </div>
       {/* Mobile */}
-      <div className="block aspect-[16/9] tab:hidden">
+      <div className="block aspect-[375/323] tab:hidden">
         <Image
           src={banner.mobileImageUrl}
           alt={banner.title ?? ''}
@@ -55,20 +72,45 @@ const Banner = () => {
 
   if (!banners || banners.length === 0) return null
 
+  const hasMultiple = banners.length > 1
+
   return (
-    <Swiper
-      modules={[Autoplay, Pagination]}
-      autoplay={{ delay: 4000, disableOnInteraction: false }}
-      pagination={{ clickable: true }}
-      loop={banners.length > 1}
-      className="w-full"
-    >
-      {banners.map((banner) => (
-        <SwiperSlide key={banner.bannerId}>
-          <BannerSlide banner={banner} />
-        </SwiperSlide>
-      ))}
-    </Swiper>
+    <div className="relative w-full">
+      <Swiper
+        modules={[Autoplay, Pagination, Navigation]}
+        autoplay={{ delay: 4000, disableOnInteraction: false }}
+        pagination={{ clickable: true }}
+        navigation={{ prevEl: '.banner-nav-prev', nextEl: '.banner-nav-next' }}
+        loop={hasMultiple}
+        className="banner-swiper w-full"
+      >
+        {banners.map((banner) => (
+          <SwiperSlide key={banner.bannerId}>
+            <BannerSlide banner={banner} />
+          </SwiperSlide>
+        ))}
+      </Swiper>
+
+      {/* 좌우 네비게이션 화살표 — 데스크탑/패드만, 모바일 숨김 */}
+      {hasMultiple && (
+        <>
+          <button
+            type="button"
+            aria-label="이전 배너"
+            className="banner-nav-prev absolute top-1/2 left-[3rem] z-10 hidden size-[3rem] -translate-y-1/2 items-center justify-center text-[#f6f6f6] tab:flex pc:left-[5rem]"
+          >
+            <ChevronRight className="h-[2.5rem] w-[1.5625rem] -scale-x-100" />
+          </button>
+          <button
+            type="button"
+            aria-label="다음 배너"
+            className="banner-nav-next absolute top-1/2 right-[3rem] z-10 hidden size-[3rem] -translate-y-1/2 items-center justify-center text-[#f6f6f6] tab:flex pc:right-[5rem]"
+          >
+            <ChevronRight className="h-[2.5rem] w-[1.5625rem]" />
+          </button>
+        </>
+      )}
+    </div>
   )
 }
 


### PR DESCRIPTION
## 작업 내용
홈 배너 UI를 Figma 디자인에 맞춰 정렬. 이미지 캐러셀 구조는 유지하고 UI 크롬만 갱신.

### 페이지네이션 점 (globals.css)
- active: 노란색 `#fffa94`, `1.25rem x 0.5rem` 알약
- inactive: 갈색 `#a9835a`, `0.5rem` 원형
- Swiper CSS 변수 + specificity 오버라이드 (important 미사용)

### 좌우 네비게이션 화살표 (Banner.tsx)
- Figma 5칸 픽셀 chevron(`#F6F6F6`) 인라인 SVG, 왼쪽은 미러링
- 데스크탑/패드 노출, 모바일 숨김
- 인셋: 패드 48px, 데스크탑 80px
- 배너 1개일 때 화살표/페이지네이션 숨김

### 배너 높이 (Figma 프레임 실측 정렬)
| 기기 | Figma | aspect |
|---|---|---|
| 모바일(375) | 375x323 | `aspect-[375/323]` |
| 패드(768) | 768x347 | `aspect-[768/347]` |
| 데스크탑(1440) | 1440x376 | `pc:aspect-[180/47]` |

## 검증
- type-check 통과
- Banner.tsx 린트 클린

Closes #79