### PR TITLE
refactor(banner): 반복 렌더 map 정리 및 BannerSlide 파일 분리

### DIFF
--- a/src/widgets/banner/ui/Banner.tsx
+++ b/src/widgets/banner/ui/Banner.tsx
@@ -1,14 +1,35 @@
 'use client'
 
-import Image from 'next/image'
-import Link from 'next/link'
 import { Swiper, SwiperSlide } from 'swiper/react'
 import { Autoplay, Navigation, Pagination } from 'swiper/modules'
 import { useQuery } from '@tanstack/react-query'
 import { homeQueries } from '@/entities/home'
-import type { BannerDto } from '@/shared/types'
+import { cn } from '@/shared/lib/cn'
+import { BannerSlide } from './BannerSlide'
 import 'swiper/css'
 import 'swiper/css/pagination'
+
+const AUTOPLAY_DELAY_MS = 4000
+
+// 셀렉터를 상수로 단일화 — navigation prop과 className에서 공유 (drift 방지)
+const NAV_PREV_CLASS = 'banner-nav-prev'
+const NAV_NEXT_CLASS = 'banner-nav-next'
+
+// 좌우 화살표 설정 (방향/라벨/위치/미러)
+const NAV_ARROWS = [
+  {
+    className: NAV_PREV_CLASS,
+    label: '이전 배너',
+    position: 'left-[3rem] pc:left-[5rem]',
+    mirrored: true,
+  },
+  {
+    className: NAV_NEXT_CLASS,
+    label: '다음 배너',
+    position: 'right-[3rem] pc:right-[5rem]',
+    mirrored: false,
+  },
+] as const
 
 /** Figma: 5칸 픽셀 스타일 chevron (#F6F6F6) */
 const ChevronRight = ({ className }: { className?: string }) => (
@@ -27,46 +48,6 @@ const ChevronRight = ({ className }: { className?: string }) => (
   </svg>
 )
 
-const BannerSlide = ({ banner }: { banner: BannerDto }) => {
-  const content = (
-    <section className="relative w-full overflow-hidden bg-[#d9d9d9]">
-      {/* Desktop */}
-      <div className="hidden aspect-[768/347] tab:block pc:aspect-[180/47]">
-        <Image
-          src={banner.desktopImageUrl}
-          alt={banner.title ?? ''}
-          fill
-          className="object-cover"
-          priority
-        />
-      </div>
-      {/* Mobile */}
-      <div className="block aspect-[375/323] tab:hidden">
-        <Image
-          src={banner.mobileImageUrl}
-          alt={banner.title ?? ''}
-          fill
-          className="object-cover"
-          priority
-        />
-      </div>
-    </section>
-  )
-
-  if (banner.linkUrl) {
-    if (banner.linkType === 'external') {
-      return (
-        <a href={banner.linkUrl} target="_blank" rel="noopener noreferrer">
-          {content}
-        </a>
-      )
-    }
-    return <Link href={banner.linkUrl}>{content}</Link>
-  }
-
-  return content
-}
-
 const Banner = () => {
   const { data: banners } = useQuery(homeQueries.banners())
 
@@ -78,9 +59,9 @@ const Banner = () => {
     <div className="relative w-full">
       <Swiper
         modules={[Autoplay, Pagination, Navigation]}
-        autoplay={{ delay: 4000, disableOnInteraction: false }}
+        autoplay={{ delay: AUTOPLAY_DELAY_MS, disableOnInteraction: false }}
         pagination={{ clickable: true }}
-        navigation={{ prevEl: '.banner-nav-prev', nextEl: '.banner-nav-next' }}
+        navigation={{ prevEl: `.${NAV_PREV_CLASS}`, nextEl: `.${NAV_NEXT_CLASS}` }}
         loop={hasMultiple}
         className="banner-swiper w-full"
       >
@@ -92,24 +73,21 @@ const Banner = () => {
       </Swiper>
 
       {/* 좌우 네비게이션 화살표 — 데스크탑/패드만, 모바일 숨김 */}
-      {hasMultiple && (
-        <>
+      {hasMultiple &&
+        NAV_ARROWS.map(({ className, label, position, mirrored }) => (
           <button
+            key={className}
             type="button"
-            aria-label="이전 배너"
-            className="banner-nav-prev absolute top-1/2 left-[3rem] z-10 hidden size-[3rem] -translate-y-1/2 items-center justify-center text-[#f6f6f6] tab:flex pc:left-[5rem]"
+            aria-label={label}
+            className={cn(
+              'absolute top-1/2 z-10 hidden size-[3rem] -translate-y-1/2 items-center justify-center text-[#f6f6f6] tab:flex',
+              position,
+              className,
+            )}
           >
-            <ChevronRight className="h-[2.5rem] w-[1.5625rem] -scale-x-100" />
+            <ChevronRight className={cn('h-[2.5rem] w-[1.5625rem]', mirrored && '-scale-x-100')} />
           </button>
-          <button
-            type="button"
-            aria-label="다음 배너"
-            className="banner-nav-next absolute top-1/2 right-[3rem] z-10 hidden size-[3rem] -translate-y-1/2 items-center justify-center text-[#f6f6f6] tab:flex pc:right-[5rem]"
-          >
-            <ChevronRight className="h-[2.5rem] w-[1.5625rem]" />
-          </button>
-        </>
-      )}
+        ))}
     </div>
   )
 }

--- a/src/widgets/banner/ui/BannerSlide.tsx
+++ b/src/widgets/banner/ui/BannerSlide.tsx
@@ -1,0 +1,46 @@
+import Image from 'next/image'
+import Link from 'next/link'
+import type { BannerDto } from '@/shared/types'
+
+/** 링크 래퍼 — 표시(BannerSlide)와 링크 분기 로직 분리 (SRP) */
+const BannerLink = ({ banner, children }: { banner: BannerDto; children: React.ReactNode }) => {
+  if (!banner.linkUrl) return <>{children}</>
+  if (banner.linkType === 'external') {
+    return (
+      <a href={banner.linkUrl} target="_blank" rel="noopener noreferrer">
+        {children}
+      </a>
+    )
+  }
+  return <Link href={banner.linkUrl}>{children}</Link>
+}
+
+const BannerSlide = ({ banner }: { banner: BannerDto }) => {
+  // Desktop/Mobile 이미지 블록 (src/aspect만 차이)
+  const images = [
+    {
+      key: 'desktop',
+      src: banner.desktopImageUrl,
+      wrapperClass: 'hidden aspect-[768/347] tab:block pc:aspect-[180/47]',
+    },
+    {
+      key: 'mobile',
+      src: banner.mobileImageUrl,
+      wrapperClass: 'block aspect-[375/323] tab:hidden',
+    },
+  ]
+
+  return (
+    <BannerLink banner={banner}>
+      <section className="relative w-full overflow-hidden bg-[#d9d9d9]">
+        {images.map(({ key, src, wrapperClass }) => (
+          <div key={key} className={wrapperClass}>
+            <Image src={src} alt={banner.title ?? ''} fill className="object-cover" priority />
+          </div>
+        ))}
+      </section>
+    </BannerLink>
+  )
+}
+
+export { BannerSlide }


### PR DESCRIPTION
## 배경
PR #80 머지 시 첫 커밋(Figma 정렬)만 반영되고 후속 리팩토링 커밋이 누락되어, 이를 dev에 마저 반영한다.

## 작업 내용
- 좌우 화살표/이미지 블록을 설정 배열 + `map`으로 통합 (DRY)
- nav 셀렉터 상수화로 navigation prop과 className drift 방지
- `AUTOPLAY_DELAY_MS` 매직 넘버 제거
- 슬라이드 렌더링(`BannerSlide`/`BannerLink`)을 별도 파일로 분리 (SRP)

## 검증
- type-check 통과
- Banner.tsx / BannerSlide.tsx 린트 클린
- 동작 변경 없음 (구조 개선만)

Closes #79