### PR TITLE
feat(contest): 랜덤 후보/지난주·어제 TOP 3 조회 API 연결

### DIFF
--- a/src/entities/contest/api/contest.api.ts
+++ b/src/entities/contest/api/contest.api.ts
@@ -6,6 +6,9 @@ import type {
   ContestEntry,
   ContestPreviousRanking,
   ContestEntriesParams,
+  ContestRandomEntry,
+  ContestWeeklyTop,
+  ContestYesterdayTop,
   HallOfFameItem,
   HallOfFameParams,
 } from '@/shared/types'
@@ -46,6 +49,30 @@ export const getPreviousRanking = async (): Promise<ContestPreviousRanking | nul
     `${API_VERSION}/contest/previous-ranking`,
   )
   return unwrapNullable(response, '저번 콘테스트 랭킹 조회에 실패했습니다.')
+}
+
+/** 랜덤 투표 후보 조회 */
+export const getRandomContestEntry = async (): Promise<ContestRandomEntry> => {
+  const response = await apiClient.get<ApiResponseFull<ContestRandomEntry>>(
+    `${API_VERSION}/contest/random-entry`,
+  )
+  return unwrap(response, '랜덤 투표 후보 조회에 실패했습니다.')
+}
+
+/** 지난주 TOP 3 조회 */
+export const getContestWeeklyTop = async (): Promise<ContestWeeklyTop> => {
+  const response = await apiClient.get<ApiResponseFull<ContestWeeklyTop>>(
+    `${API_VERSION}/contest/weekly-top`,
+  )
+  return unwrap(response, '지난주 TOP 3 조회에 실패했습니다.')
+}
+
+/** 어제 기준 TOP 3 조회 */
+export const getContestYesterdayTop = async (): Promise<ContestYesterdayTop> => {
+  const response = await apiClient.get<ApiResponseFull<ContestYesterdayTop>>(
+    `${API_VERSION}/contest/yesterday-top`,
+  )
+  return unwrap(response, '어제 기준 TOP 3 조회에 실패했습니다.')
 }
 
 /** 명예의 전당 목록 */

--- a/src/entities/contest/api/contest.queries.ts
+++ b/src/entities/contest/api/contest.queries.ts
@@ -4,6 +4,9 @@ import {
   getContestEntries,
   getMyContestEntry,
   getPreviousRanking,
+  getRandomContestEntry,
+  getContestWeeklyTop,
+  getContestYesterdayTop,
   getHallOfFame,
 } from './contest.api'
 
@@ -42,6 +45,27 @@ export const contestQueries = {
     createInfiniteQuery({
       queryKey: [...contestQueries.all(), 'hallOfFame', limit],
       queryFn: (page) => getHallOfFame({ page, limit }),
+      staleTime: STALE_TIME.LONG,
+    }),
+
+  randomEntry: () =>
+    createQuery({
+      queryKey: [...contestQueries.all(), 'randomEntry'],
+      queryFn: () => getRandomContestEntry(),
+      staleTime: STALE_TIME.REALTIME,
+    }),
+
+  weeklyTop: () =>
+    createQuery({
+      queryKey: [...contestQueries.all(), 'weeklyTop'],
+      queryFn: () => getContestWeeklyTop(),
+      staleTime: STALE_TIME.LONG,
+    }),
+
+  yesterdayTop: () =>
+    createQuery({
+      queryKey: [...contestQueries.all(), 'yesterdayTop'],
+      queryFn: () => getContestYesterdayTop(),
       staleTime: STALE_TIME.LONG,
     }),
 }

--- a/src/shared/types/ContestTypes.ts
+++ b/src/shared/types/ContestTypes.ts
@@ -65,6 +65,35 @@ export interface HallOfFameItem {
   winner: ContestEntry
 }
 
+/** 랜덤 투표 후보 조회 응답 */
+export interface ContestRandomEntry {
+  /** 랜덤 투표 후보. 후보 없음 또는 이미 투표한 경우 null */
+  entry: ContestEntry | null
+  /** 이번 콘테스트에서 이미 투표 완료 여부 */
+  alreadyVoted: boolean
+}
+
+/** 지난주 TOP 3 조회 응답 */
+export interface ContestWeeklyTop {
+  weekKey: string
+  topEntries: ContestEntry[]
+  calculatedAt: string
+}
+
+/** 어제 기준 TOP 항목 */
+export interface YesterdayTopEntry {
+  rank: number
+  entry: ContestEntry
+  /** 득표율 */
+  voteRate: number
+}
+
+/** 어제 기준 TOP 3 조회 응답 */
+export interface ContestYesterdayTop {
+  contestId: string
+  ranking: YesterdayTopEntry[]
+}
+
 /** 엔트리 목록 조회 파라미터 */
 export interface ContestEntriesParams {
   limit?: number


### PR DESCRIPTION
## 작업 내용
콘테스트 도메인 미연결 조회 API 3종 연결. (라이브 스펙 dev-api.pawpong.kr/docs-json 기준 — swagger.json 미반영분)

### 타입 (shared/types/ContestTypes.ts)
- `ContestRandomEntry` `{ entry: ContestEntry | null; alreadyVoted: boolean }`
- `ContestWeeklyTop` `{ weekKey; topEntries: ContestEntry[]; calculatedAt }`
- `YesterdayTopEntry` `{ rank; entry: ContestEntry; voteRate }`
- `ContestYesterdayTop` `{ contestId; ranking: YesterdayTopEntry[] }`
- `ContestEntryDto`가 기존 `ContestEntry`와 동일해 재사용

### fetch 함수 (entities/contest/api/contest.api.ts)
- `getRandomContestEntry()` -> `ContestRandomEntry`
- `getContestWeeklyTop()` -> `ContestWeeklyTop`
- `getContestYesterdayTop()` -> `ContestYesterdayTop`

### 쿼리 팩토리 (entities/contest/api/contest.queries.ts)
- `contestQueries.randomEntry()` — REALTIME
- `contestQueries.weeklyTop()` — LONG
- `contestQueries.yesterdayTop()` — LONG

## 검증
- type-check 통과, 변경 파일 린트 클린

## 참고
- 모두 조회(READ)라 entities에 배치, 응답 data 항상 존재해 unwrap 사용
- weekly-top/yesterday-top은 거의 고정 데이터라 서버 컴포넌트에서 fetch 함수 직접 호출도 가능 (쿼리 팩토리는 클라 캐싱/invalidation 필요 시)

Closes #82