### PR TITLE
feat(inquiry): 내 문의 목록/문의 수정·삭제 API 연결

### DIFF
--- a/src/entities/inquiry/api/inquiry.api.ts
+++ b/src/entities/inquiry/api/inquiry.api.ts
@@ -20,6 +20,18 @@ export const getInquiries = async (
     .then((res) => unwrap(res, '문의 목록 조회에 실패했습니다.'))
 }
 
+/** 내 문의 목록 조회 */
+export const getMyInquiries = async (
+  page: number,
+  animalType: AnimalType,
+): Promise<InquiryListResponse> => {
+  return apiClient
+    .get<ApiResponse<InquiryListResponse>>(`${API_VERSION}/inquiry/my`, {
+      params: { page, limit: 15, animalType },
+    })
+    .then((res) => unwrap(res, '내 문의 목록 조회에 실패했습니다.'))
+}
+
 /** 문의 상세 조회 */
 export const getInquiryDetail = async (inquiryId: string): Promise<Inquiry | null> => {
   try {

--- a/src/entities/inquiry/api/inquiry.queries.ts
+++ b/src/entities/inquiry/api/inquiry.queries.ts
@@ -1,6 +1,6 @@
 import { createQuery, createInfiniteQueryWithHasMore } from '@/shared/api'
 import type { AnimalType, InquirySortType } from '@/shared/types'
-import { getInquiries, getInquiryDetail, getBreederInquiries } from './inquiry.api'
+import { getInquiries, getMyInquiries, getInquiryDetail, getBreederInquiries } from './inquiry.api'
 
 export const inquiryQueries = {
   all: () => ['inquiry'] as const,
@@ -9,6 +9,12 @@ export const inquiryQueries = {
     createInfiniteQueryWithHasMore({
       queryKey: [...inquiryQueries.all(), 'list', animalType, sort],
       queryFn: (page) => getInquiries(page, animalType, sort),
+    }),
+
+  myList: (animalType: AnimalType) =>
+    createInfiniteQueryWithHasMore({
+      queryKey: [...inquiryQueries.all(), 'my', animalType],
+      queryFn: (page) => getMyInquiries(page, animalType),
     }),
 
   detail: (inquiryId: string) =>

--- a/src/features/inquiry/api/inquiry.api.ts
+++ b/src/features/inquiry/api/inquiry.api.ts
@@ -1,11 +1,29 @@
 import { apiClient, API_VERSION, unwrap, unwrapVoid } from '@/shared/api'
-import type { ApiResponse, CreateInquiryRequest } from '@/shared/types'
+import type { ApiResponse, CreateInquiryRequest, UpdateInquiryRequest } from '@/shared/types'
 
 /** 문의 작성 */
 export const createInquiry = async (data: CreateInquiryRequest): Promise<{ inquiryId: string }> => {
   return apiClient
     .post<ApiResponse<{ inquiryId: string }>>(`${API_VERSION}/inquiry`, data)
     .then((res) => unwrap(res, '문의 작성에 실패했습니다.'))
+}
+
+/** 문의 수정 */
+export const updateInquiry = async (
+  inquiryId: string,
+  data: UpdateInquiryRequest,
+): Promise<void> => {
+  const response = await apiClient.patch<ApiResponse<null>>(
+    `${API_VERSION}/inquiry/${inquiryId}`,
+    data,
+  )
+  unwrapVoid(response, '문의 수정에 실패했습니다.')
+}
+
+/** 문의 삭제 */
+export const deleteInquiry = async (inquiryId: string): Promise<void> => {
+  const response = await apiClient.delete<ApiResponse<null>>(`${API_VERSION}/inquiry/${inquiryId}`)
+  unwrapVoid(response, '문의 삭제에 실패했습니다.')
 }
 
 /** 답변 작성 */

--- a/src/features/inquiry/api/inquiry.mutations.ts
+++ b/src/features/inquiry/api/inquiry.mutations.ts
@@ -2,13 +2,34 @@
 
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { inquiryQueries } from '@/entities/inquiry'
-import type { CreateInquiryRequest } from '@/shared/types'
-import { createInquiry, createInquiryAnswer } from './inquiry.api'
+import type { CreateInquiryRequest, UpdateInquiryRequest } from '@/shared/types'
+import { createInquiry, updateInquiry, deleteInquiry, createInquiryAnswer } from './inquiry.api'
 
 export const useCreateInquiry = () => {
   const qc = useQueryClient()
   return useMutation({
     mutationFn: (data: CreateInquiryRequest) => createInquiry(data),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: inquiryQueries.all() })
+    },
+  })
+}
+
+export const useUpdateInquiry = (inquiryId: string) => {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (data: UpdateInquiryRequest) => updateInquiry(inquiryId, data),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: inquiryQueries.detail(inquiryId).queryKey })
+      void qc.invalidateQueries({ queryKey: inquiryQueries.all() })
+    },
+  })
+}
+
+export const useDeleteInquiry = () => {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (inquiryId: string) => deleteInquiry(inquiryId),
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: inquiryQueries.all() })
     },

--- a/src/shared/types/InquiryTypes.ts
+++ b/src/shared/types/InquiryTypes.ts
@@ -53,3 +53,9 @@ export interface CreateInquiryRequest {
   targetBreederId?: string
   imageUrls?: string[]
 }
+
+export interface UpdateInquiryRequest {
+  title?: string
+  content?: string
+  imageUrls?: string[]
+}


### PR DESCRIPTION
## 작업 내용
문의 도메인 미연결 API 3종 연결. (라이브 스펙 dev-api.pawpong.kr/docs-json 기준)

### 조회 (entities/inquiry)
- `getMyInquiries(page, animalType)` -> `InquiryListResponse` (GET /inquiry/my)
- `inquiryQueries.myList(animalType)` — infinite (hasMore)

### 변경 (features/inquiry)
- `updateInquiry(inquiryId, data)` -> void (PATCH /inquiry/{id})
- `deleteInquiry(inquiryId)` -> void (DELETE /inquiry/{id})
- `useUpdateInquiry(inquiryId)` — invalidation: detail + all
- `useDeleteInquiry()` — invalidation: all

### 타입
- `UpdateInquiryRequest` `{ title?; content?; imageUrls? }` 추가
- `/inquiry/my` 응답은 기존 `InquiryListResponse` 재사용

## 검증
- type-check 통과, 변경 5개 파일 린트 클린
- 기존 inquiry 패턴(ApiResponse, .then, createInfiniteQueryWithHasMore, unwrapVoid) 준수

Closes #84