### PR TITLE
feat(filter): 개별 필터 옵션 조회 5종 API 연결

### DIFF
--- a/src/entities/filter/api/filter.api.ts
+++ b/src/entities/filter/api/filter.api.ts
@@ -1,5 +1,12 @@
 import { apiClient, API_VERSION, unwrap } from '@/shared/api'
-import type { AllFilterOptions } from '@/shared/types'
+import type {
+  AllFilterOptions,
+  BreederLevelOption,
+  SortOption,
+  DogSizeOption,
+  CatFurLengthOption,
+  AdoptionStatusOption,
+} from '@/shared/types'
 
 /** 전체 필터 옵션 조회 */
 export const getAllFilterOptions = () =>
@@ -9,4 +16,54 @@ export const getAllFilterOptions = () =>
       data: AllFilterOptions
       message?: string
     }>(`${API_VERSION}/filter-options`)
+    .then(unwrap)
+
+/** 브리더 레벨 옵션 조회 */
+export const getBreederLevels = () =>
+  apiClient
+    .get<{
+      success: boolean
+      data: BreederLevelOption[]
+      message?: string
+    }>(`${API_VERSION}/filter-options/breeder-levels`)
+    .then(unwrap)
+
+/** 정렬 옵션 조회 */
+export const getSortOptions = () =>
+  apiClient
+    .get<{
+      success: boolean
+      data: SortOption[]
+      message?: string
+    }>(`${API_VERSION}/filter-options/sort-options`)
+    .then(unwrap)
+
+/** 강아지 크기 옵션 조회 */
+export const getDogSizes = () =>
+  apiClient
+    .get<{
+      success: boolean
+      data: DogSizeOption[]
+      message?: string
+    }>(`${API_VERSION}/filter-options/dog-sizes`)
+    .then(unwrap)
+
+/** 고양이 털 길이 옵션 조회 */
+export const getCatFurLengths = () =>
+  apiClient
+    .get<{
+      success: boolean
+      data: CatFurLengthOption[]
+      message?: string
+    }>(`${API_VERSION}/filter-options/cat-fur-lengths`)
+    .then(unwrap)
+
+/** 입양 가능 여부 옵션 조회 */
+export const getAdoptionStatus = () =>
+  apiClient
+    .get<{
+      success: boolean
+      data: AdoptionStatusOption[]
+      message?: string
+    }>(`${API_VERSION}/filter-options/adoption-status`)
     .then(unwrap)

--- a/src/entities/filter/api/filter.api.ts
+++ b/src/entities/filter/api/filter.api.ts
@@ -1,5 +1,7 @@
 import { apiClient, API_VERSION, unwrap } from '@/shared/api'
+// [refactored] inline 응답 타입 제거 → 표준 ApiResponseFull 타입 import
 import type {
+  ApiResponseFull,
   AllFilterOptions,
   BreederLevelOption,
   SortOption,
@@ -8,62 +10,38 @@ import type {
   AdoptionStatusOption,
 } from '@/shared/types'
 
+// [refactored] { success, data, message? } inline 6회 반복 → ApiResponseFull<T>로 통일
+
 /** 전체 필터 옵션 조회 */
 export const getAllFilterOptions = () =>
-  apiClient
-    .get<{
-      success: boolean
-      data: AllFilterOptions
-      message?: string
-    }>(`${API_VERSION}/filter-options`)
-    .then(unwrap)
+  apiClient.get<ApiResponseFull<AllFilterOptions>>(`${API_VERSION}/filter-options`).then(unwrap)
 
 /** 브리더 레벨 옵션 조회 */
 export const getBreederLevels = () =>
   apiClient
-    .get<{
-      success: boolean
-      data: BreederLevelOption[]
-      message?: string
-    }>(`${API_VERSION}/filter-options/breeder-levels`)
+    .get<ApiResponseFull<BreederLevelOption[]>>(`${API_VERSION}/filter-options/breeder-levels`)
     .then(unwrap)
 
 /** 정렬 옵션 조회 */
 export const getSortOptions = () =>
   apiClient
-    .get<{
-      success: boolean
-      data: SortOption[]
-      message?: string
-    }>(`${API_VERSION}/filter-options/sort-options`)
+    .get<ApiResponseFull<SortOption[]>>(`${API_VERSION}/filter-options/sort-options`)
     .then(unwrap)
 
 /** 강아지 크기 옵션 조회 */
 export const getDogSizes = () =>
   apiClient
-    .get<{
-      success: boolean
-      data: DogSizeOption[]
-      message?: string
-    }>(`${API_VERSION}/filter-options/dog-sizes`)
+    .get<ApiResponseFull<DogSizeOption[]>>(`${API_VERSION}/filter-options/dog-sizes`)
     .then(unwrap)
 
 /** 고양이 털 길이 옵션 조회 */
 export const getCatFurLengths = () =>
   apiClient
-    .get<{
-      success: boolean
-      data: CatFurLengthOption[]
-      message?: string
-    }>(`${API_VERSION}/filter-options/cat-fur-lengths`)
+    .get<ApiResponseFull<CatFurLengthOption[]>>(`${API_VERSION}/filter-options/cat-fur-lengths`)
     .then(unwrap)
 
 /** 입양 가능 여부 옵션 조회 */
 export const getAdoptionStatus = () =>
   apiClient
-    .get<{
-      success: boolean
-      data: AdoptionStatusOption[]
-      message?: string
-    }>(`${API_VERSION}/filter-options/adoption-status`)
+    .get<ApiResponseFull<AdoptionStatusOption[]>>(`${API_VERSION}/filter-options/adoption-status`)
     .then(unwrap)

--- a/src/entities/filter/api/filter.queries.ts
+++ b/src/entities/filter/api/filter.queries.ts
@@ -1,5 +1,12 @@
 import { createQuery, STALE_TIME } from '@/shared/api'
-import { getAllFilterOptions } from './filter.api'
+import {
+  getAllFilterOptions,
+  getBreederLevels,
+  getSortOptions,
+  getDogSizes,
+  getCatFurLengths,
+  getAdoptionStatus,
+} from './filter.api'
 
 export const filterQueries = {
   all: () => ['filter'] as const,
@@ -8,6 +15,41 @@ export const filterQueries = {
     createQuery({
       queryKey: [...filterQueries.all(), 'options'],
       queryFn: getAllFilterOptions,
+      staleTime: STALE_TIME.STATIC,
+    }),
+
+  breederLevels: () =>
+    createQuery({
+      queryKey: [...filterQueries.all(), 'breederLevels'],
+      queryFn: getBreederLevels,
+      staleTime: STALE_TIME.STATIC,
+    }),
+
+  sortOptions: () =>
+    createQuery({
+      queryKey: [...filterQueries.all(), 'sortOptions'],
+      queryFn: getSortOptions,
+      staleTime: STALE_TIME.STATIC,
+    }),
+
+  dogSizes: () =>
+    createQuery({
+      queryKey: [...filterQueries.all(), 'dogSizes'],
+      queryFn: getDogSizes,
+      staleTime: STALE_TIME.STATIC,
+    }),
+
+  catFurLengths: () =>
+    createQuery({
+      queryKey: [...filterQueries.all(), 'catFurLengths'],
+      queryFn: getCatFurLengths,
+      staleTime: STALE_TIME.STATIC,
+    }),
+
+  adoptionStatus: () =>
+    createQuery({
+      queryKey: [...filterQueries.all(), 'adoptionStatus'],
+      queryFn: getAdoptionStatus,
       staleTime: STALE_TIME.STATIC,
     }),
 }


### PR DESCRIPTION
## 작업 내용
전체 집계(/filter-options)만 있던 필터에 개별 옵션 5종 연결. 조건부/lazy 조회용.

### 조회 (entities/filter)
- `getBreederLevels()` -> `BreederLevelOption[]`
- `getSortOptions()` -> `SortOption[]`
- `getDogSizes()` -> `DogSizeOption[]`
- `getCatFurLengths()` -> `CatFurLengthOption[]`
- `getAdoptionStatus()` -> `AdoptionStatusOption[]`
- `filterQueries.breederLevels/sortOptions/dogSizes/catFurLengths/adoptionStatus` — STATIC

### 타입
- 기존 `FilterTypes`의 옵션 타입 전부 재사용 (신규 타입 없음)

## 검증
- type-check 통과, 변경 파일 린트 클린
- 기존 getAllFilterOptions 스타일 그대로 유지

## 참고
- 개별 5종은 전체(`options()`)에도 포함됨. 펫 타입별 조건부 조회(dog-sizes/cat-fur-lengths) 등 lazy load 시 활용

Closes #90