### PR TITLE
feat(breeder): 브리더 검색(레거시) 조회 API 연결

### DIFF
--- a/src/entities/breeder/api/breeder.api.ts
+++ b/src/entities/breeder/api/breeder.api.ts
@@ -7,6 +7,8 @@ import type {
   DashboardResponseDto,
   Breeder,
   SearchBreederParams,
+  BreederSearchItem,
+  BreederSearchParams,
   PaginationResponse,
   AvailablePetSummaryDto,
   ParentPetSummaryDto,
@@ -63,6 +65,19 @@ export const exploreBreeders = (params: SearchBreederParams = {}) =>
       data: PaginationResponse<Breeder>
       message?: string
     }>(`${API_VERSION}/breeder/explore`, params)
+    .then(unwrap)
+
+/** 브리더 검색 (레거시) */
+export const searchBreeders = (params: BreederSearchParams = {}) =>
+  apiClient
+    .get<{
+      success: boolean
+      data: PaginationResponse<BreederSearchItem>
+      message?: string
+    }>(`${API_VERSION}/breeder/search`, {
+      params,
+      skipAuth: true,
+    } as ApiRequestConfig)
     .then(unwrap)
 
 /** 인기 브리더 목록 */

--- a/src/entities/breeder/api/breeder.queries.ts
+++ b/src/entities/breeder/api/breeder.queries.ts
@@ -2,6 +2,8 @@ import { createQuery, createInfiniteQuery, STALE_TIME } from '@/shared/api'
 import type {
   SearchBreederParams,
   Breeder,
+  BreederSearchItem,
+  BreederSearchParams,
   AvailablePetSummaryDto,
   ParentPetSummaryDto,
   PublicReviewDto,
@@ -13,6 +15,7 @@ import {
   getMyBreederProfile,
   getBreederDashboard,
   exploreBreeders,
+  searchBreeders,
   getPopularBreeders,
   getBreederPets,
   getParentPets,
@@ -57,6 +60,12 @@ export const breederQueries = {
     createInfiniteQuery<Breeder>({
       queryKey: [...breederQueries.all(), 'explore', params],
       queryFn: (page) => exploreBreeders({ ...params, page }),
+    }),
+
+  search: (params: BreederSearchParams) =>
+    createInfiniteQuery<BreederSearchItem>({
+      queryKey: [...breederQueries.all(), 'search', params],
+      queryFn: (page) => searchBreeders({ ...params, page }),
     }),
 
   popular: () =>

--- a/src/shared/types/BreederTypes.ts
+++ b/src/shared/types/BreederTypes.ts
@@ -226,6 +226,34 @@ export interface SearchBreederParams {
   limit?: number
 }
 
+// ==================== 브리더 검색 (레거시 /breeder/search) ====================
+
+export interface BreederSearchItem {
+  breederId: string
+  breederName: string
+  location: string
+  specialization: string[]
+  averageRating: number
+  totalReviews: number
+  profileImage?: string
+  profilePhotos: string[]
+  verificationStatus: string
+  availablePets: number
+}
+
+export interface BreederSearchParams {
+  petType?: 'dog' | 'cat'
+  breedName?: string
+  cityName?: string
+  districtName?: string
+  isImmediatelyAvailable?: boolean
+  minPrice?: number
+  maxPrice?: number
+  page?: number
+  limit?: number
+  sortCriteria?: 'rating' | 'reviews' | 'latest' | 'price_low' | 'price_high'
+}
+
 // ==================== 브리더 대시보드 ====================
 
 export interface DashboardResponseDto {


### PR DESCRIPTION
## 작업 내용
미연결이던 GET /api/v2/breeder/search (레거시) 연결.

### 조회 (entities/breeder)
- `searchBreeders(params)` -> `PaginationResponse<BreederSearchItem>` (GET /breeder/search)
- `breederQueries.search(params)` — infinite

### 타입 (shared/types/BreederTypes.ts)
- `BreederSearchItem` { breederId, breederName, location, specialization: string[], averageRating, totalReviews, profileImage?, profilePhotos, verificationStatus, availablePets }
- `BreederSearchParams` { petType?, breedName?, cityName?, districtName?, isImmediatelyAvailable?, minPrice?, maxPrice?, page?, limit?, sortCriteria? }

## 검증
- type-check 통과, 변경 파일 린트 클린
- 실제 응답 호출로 타입 확정 (specialization: string[], 표준 pagination)
- 기존 breeder.api 패턴(inline 타입 + skipAuth) 유지

## 참고
- 스펙상 "레거시"로 표기된 엔드포인트. 신규 탐색은 `/breeder/explore`가 담당하나, 요청에 따라 search도 연결
- 무인증 GET (skipAuth)

Closes #96