### PR TITLE
feat(community): 커뮤니티 댓글 수정/삭제 API 연결

### DIFF
--- a/src/features/community/api/community.api.ts
+++ b/src/features/community/api/community.api.ts
@@ -4,6 +4,7 @@ import type {
   CommunityPostDetail,
   CreateCommunityPostRequest,
   UpdateCommunityPostRequest,
+  UpdateCommunityCommentRequest,
   CommunityPostDeleteResponse,
   CommunityBookmarkResponse,
   CommunityUnsaveResponse,
@@ -50,6 +51,21 @@ export const deleteCommunityPost = async (postId: string): Promise<CommunityPost
     `${API_VERSION}/community/posts/${postId}`,
   )
   return unwrap(response, '게시글 삭제에 실패했습니다.')
+}
+
+/** 댓글 수정 */
+export const updateCommunityComment = async (
+  commentId: string,
+  data: UpdateCommunityCommentRequest,
+): Promise<void> => {
+  const response = await apiClient.patch(`${API_VERSION}/community/comments/${commentId}`, data)
+  unwrapVoid(response, '댓글 수정에 실패했습니다.')
+}
+
+/** 댓글 삭제 */
+export const deleteCommunityComment = async (commentId: string): Promise<void> => {
+  const response = await apiClient.delete(`${API_VERSION}/community/comments/${commentId}`)
+  unwrapVoid(response, '댓글 삭제에 실패했습니다.')
 }
 
 /** 게시글 북마크 */

--- a/src/features/community/api/community.mutations.ts
+++ b/src/features/community/api/community.mutations.ts
@@ -2,11 +2,17 @@
 
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { communityQueries } from '@/entities/community'
-import type { CreateCommunityPostRequest, UpdateCommunityPostRequest } from '@/shared/types'
+import type {
+  CreateCommunityPostRequest,
+  UpdateCommunityPostRequest,
+  UpdateCommunityCommentRequest,
+} from '@/shared/types'
 import {
   createCommunityPost,
   updateCommunityPost,
   deleteCommunityPost,
+  updateCommunityComment,
+  deleteCommunityComment,
   bookmarkCommunityPost,
   unbookmarkCommunityPost,
 } from './community.api'
@@ -35,6 +41,26 @@ export const useDeleteCommunityPost = () => {
   const qc = useQueryClient()
   return useMutation({
     mutationFn: (postId: string) => deleteCommunityPost(postId),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: communityQueries.all() })
+    },
+  })
+}
+
+export const useUpdateCommunityComment = (commentId: string) => {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (data: UpdateCommunityCommentRequest) => updateCommunityComment(commentId, data),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: communityQueries.all() })
+    },
+  })
+}
+
+export const useDeleteCommunityComment = () => {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (commentId: string) => deleteCommunityComment(commentId),
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: communityQueries.all() })
     },

--- a/src/shared/types/CommunityTypes.ts
+++ b/src/shared/types/CommunityTypes.ts
@@ -110,3 +110,8 @@ export interface CommunityBookmarkListParams {
   page?: number
   pageSize?: number
 }
+
+/** 댓글 수정 요청 */
+export interface UpdateCommunityCommentRequest {
+  body: string
+}


### PR DESCRIPTION
## 작업 내용
미연결이던 커뮤니티 댓글 수정/삭제 API 연결.

### 변경 (features/community)
- `updateCommunityComment(commentId, data)` -> void (PATCH /community/comments/{id})
- `deleteCommunityComment(commentId)` -> void (DELETE /community/comments/{id})
- `useUpdateCommunityComment(commentId)` — invalidation: communityQueries.all()
- `useDeleteCommunityComment()` — invalidation: communityQueries.all()

### 타입
- `UpdateCommunityCommentRequest` { body: string }

## 검증
- type-check 통과, 변경 파일 린트 클린
- 기존 게시글 mutation 패턴(unwrapVoid, all() invalidation) 그대로 따름

## 참고
- 응답 data는 빈 Object라 unwrapVoid 사용
- commentId만 받는 엔드포인트라 invalidation은 communityQueries.all()(댓글 목록+상세 포함)

Closes #98