### PR TITLE
feat(breeder): 브리더 관리 개체/부모견/후기답글/인증/신청폼/탈퇴 API 연결

### DIFF
--- a/src/entities/breeder/api/breeder.api.ts
+++ b/src/entities/breeder/api/breeder.api.ts
@@ -15,6 +15,11 @@ import type {
   ReceivedApplicationDetailDto,
   BreederApplicationFormDto,
   ChatMessageDto,
+  BreederMyPetItem,
+  MyPetsParams,
+  BreederMyReviewItem,
+  MyReviewsParams,
+  VerificationStatusResponse,
 } from '@/shared/types'
 
 /** 브리더 공개 프로필 조회 (브리더홈) */
@@ -144,6 +149,36 @@ export const getReceivedApplicationDetail = (applicationId: string) =>
       data: ReceivedApplicationDetailDto
       message?: string
     }>(`${API_VERSION}/breeder-management/applications/${applicationId}`)
+    .then(unwrap)
+
+/** 내 개체 목록 조회 (브리더 관리) */
+export const getMyPets = (params: MyPetsParams = {}) =>
+  apiClient
+    .get<{
+      success: boolean
+      data: PaginationResponse<BreederMyPetItem>
+      message?: string
+    }>(`${API_VERSION}/breeder-management/my-pets`, { params })
+    .then(unwrap)
+
+/** 내게 달린 후기 목록 조회 (브리더 관리) */
+export const getMyReceivedReviews = (params: MyReviewsParams = {}) =>
+  apiClient
+    .get<{
+      success: boolean
+      data: PaginationResponse<BreederMyReviewItem>
+      message?: string
+    }>(`${API_VERSION}/breeder-management/my-reviews`, { params })
+    .then(unwrap)
+
+/** 브리더 인증 상태 조회 */
+export const getBreederVerification = () =>
+  apiClient
+    .get<{
+      success: boolean
+      data: VerificationStatusResponse
+      message?: string
+    }>(`${API_VERSION}/breeder-management/verification`)
     .then(unwrap)
 
 /** 채팅 메시지 조회 */

--- a/src/entities/breeder/api/breeder.queries.ts
+++ b/src/entities/breeder/api/breeder.queries.ts
@@ -6,6 +6,10 @@ import type {
   ParentPetSummaryDto,
   PublicReviewDto,
   ReceivedApplicationItemDto,
+  BreederMyPetItem,
+  MyPetsParams,
+  BreederMyReviewItem,
+  MyReviewsParams,
 } from '@/shared/types'
 import {
   getBreederPublicProfile,
@@ -21,6 +25,9 @@ import {
   getReceivedApplications,
   getReceivedApplicationDetail,
   getApplicationChatMessages,
+  getMyPets,
+  getMyReceivedReviews,
+  getBreederVerification,
 } from './breeder.api'
 
 export const breederQueries = {
@@ -113,5 +120,24 @@ export const breederQueries = {
       queryFn: () => getApplicationChatMessages(applicationId),
       enabled: !!applicationId,
       staleTime: STALE_TIME.REALTIME,
+    }),
+
+  myPets: (params: MyPetsParams = {}, limit = 20) =>
+    createInfiniteQuery<BreederMyPetItem>({
+      queryKey: [...breederQueries.all(), 'my-pets', params, limit],
+      queryFn: (page) => getMyPets({ ...params, page, limit }),
+    }),
+
+  myReviews: (params: MyReviewsParams = {}, limit = 10) =>
+    createInfiniteQuery<BreederMyReviewItem>({
+      queryKey: [...breederQueries.all(), 'my-reviews', params, limit],
+      queryFn: (page) => getMyReceivedReviews({ ...params, page, limit }),
+    }),
+
+  verification: () =>
+    createQuery({
+      queryKey: [...breederQueries.all(), 'verification'],
+      queryFn: getBreederVerification,
+      staleTime: STALE_TIME.VERY_LONG,
     }),
 }

--- a/src/features/breeder/api/breeder.api.ts
+++ b/src/features/breeder/api/breeder.api.ts
@@ -6,6 +6,23 @@ import type {
   ApplicationStatusUpdateResponseDto,
   ChatMessageDto,
   SendChatMessageRequest,
+  AvailablePetAddRequest,
+  ParentPetAddRequest,
+  ParentPetUpdateRequest,
+  PetAddResponse,
+  PetMessageResponse,
+  PetStatusUpdateRequest,
+  ReviewReplyRequest,
+  ReviewReplyResponseDto,
+  ReviewReplyDeleteResponseDto,
+  VerificationSubmitRequest,
+  VerificationSubmitResponse,
+  SubmitDocumentsRequest,
+  UploadDocumentsResponseDto,
+  SimpleApplicationFormUpdateRequest,
+  SimpleApplicationFormUpdateResponse,
+  BreederAccountDeleteRequest,
+  BreederAccountDeleteResponse,
 } from '@/shared/types'
 
 /** 브리더 프로필 수정 */
@@ -40,3 +57,174 @@ export const sendApplicationChatMessage = (applicationId: string, data: SendChat
       message?: string
     }>(`${API_VERSION}/breeder-management/applications/${applicationId}/chat/messages`, data)
     .then((res) => unwrapNullable(res, '채팅 메시지 전송에 실패했습니다.'))
+
+// ==================== 분양 개체 (available-pets) ====================
+
+/** 분양 개체 추가 */
+export const addAvailablePet = (data: AvailablePetAddRequest) =>
+  apiClient
+    .post<{
+      success: boolean
+      data: PetAddResponse
+      message?: string
+    }>(`${API_VERSION}/breeder-management/available-pets`, data)
+    .then(unwrap)
+
+/** 분양 개체 수정 */
+export const updateAvailablePet = (petId: string, data: AvailablePetAddRequest) =>
+  apiClient
+    .patch<{
+      success: boolean
+      data: PetMessageResponse
+      message?: string
+    }>(`${API_VERSION}/breeder-management/available-pets/${petId}`, data)
+    .then(unwrap)
+
+/** 분양 개체 삭제 */
+export const deleteAvailablePet = (petId: string) =>
+  apiClient
+    .delete<{
+      success: boolean
+      data: PetMessageResponse
+      message?: string
+    }>(`${API_VERSION}/breeder-management/available-pets/${petId}`)
+    .then(unwrap)
+
+/** 분양 개체 상태 변경 */
+export const updateAvailablePetStatus = (petId: string, data: PetStatusUpdateRequest) =>
+  apiClient
+    .patch<{
+      success: boolean
+      data: PetMessageResponse
+      message?: string
+    }>(`${API_VERSION}/breeder-management/available-pets/${petId}/status`, data)
+    .then(unwrap)
+
+// ==================== 부모견/묘 (parent-pets) ====================
+
+/** 부모견/묘 추가 */
+export const addParentPet = (data: ParentPetAddRequest) =>
+  apiClient
+    .post<{
+      success: boolean
+      data: PetAddResponse
+      message?: string
+    }>(`${API_VERSION}/breeder-management/parent-pets`, data)
+    .then(unwrap)
+
+/** 부모견/묘 수정 */
+export const updateParentPet = (petId: string, data: ParentPetUpdateRequest) =>
+  apiClient
+    .patch<{
+      success: boolean
+      data: PetMessageResponse
+      message?: string
+    }>(`${API_VERSION}/breeder-management/parent-pets/${petId}`, data)
+    .then(unwrap)
+
+/** 부모견/묘 삭제 */
+export const deleteParentPet = (petId: string) =>
+  apiClient
+    .delete<{
+      success: boolean
+      data: PetMessageResponse
+      message?: string
+    }>(`${API_VERSION}/breeder-management/parent-pets/${petId}`)
+    .then(unwrap)
+
+// ==================== 후기 답글 (reviews/{reviewId}/reply) ====================
+
+/** 후기 답글 등록 */
+export const createReviewReply = (reviewId: string, data: ReviewReplyRequest) =>
+  apiClient
+    .post<{
+      success: boolean
+      data: ReviewReplyResponseDto
+      message?: string
+    }>(`${API_VERSION}/breeder-management/reviews/${reviewId}/reply`, data)
+    .then(unwrap)
+
+/** 후기 답글 수정 */
+export const updateReviewReply = (reviewId: string, data: ReviewReplyRequest) =>
+  apiClient
+    .patch<{
+      success: boolean
+      data: ReviewReplyResponseDto
+      message?: string
+    }>(`${API_VERSION}/breeder-management/reviews/${reviewId}/reply`, data)
+    .then(unwrap)
+
+/** 후기 답글 삭제 */
+export const deleteReviewReply = (reviewId: string) =>
+  apiClient
+    .delete<{
+      success: boolean
+      data: ReviewReplyDeleteResponseDto
+      message?: string
+    }>(`${API_VERSION}/breeder-management/reviews/${reviewId}/reply`)
+    .then(unwrap)
+
+// ==================== 인증 (verification) ====================
+
+/** 브리더 인증 신청 */
+export const submitVerification = (data: VerificationSubmitRequest) =>
+  apiClient
+    .post<{
+      success: boolean
+      data: VerificationSubmitResponse
+      message?: string
+    }>(`${API_VERSION}/breeder-management/verification`, data)
+    .then(unwrap)
+
+/** 브리더 인증 서류 제출 (간소화) */
+export const submitVerificationDocuments = (data: SubmitDocumentsRequest) =>
+  apiClient
+    .post<{
+      success: boolean
+      data: VerificationSubmitResponse
+      message?: string
+    }>(`${API_VERSION}/breeder-management/verification/submit`, data)
+    .then(unwrap)
+
+/** 브리더 인증 서류 업로드 (multipart) */
+export const uploadVerificationDocuments = (
+  files: { type: string; file: File }[],
+  level: 'new' | 'elite',
+) => {
+  const formData = new FormData()
+  files.forEach(({ file }) => formData.append('files', file))
+  formData.append('types', JSON.stringify(files.map(({ type }) => type)))
+  formData.append('level', level)
+
+  return apiClient
+    .post<{
+      success: boolean
+      data: UploadDocumentsResponseDto
+      message?: string
+    }>(`${API_VERSION}/breeder-management/verification/upload`, formData)
+    .then(unwrap)
+}
+
+// ==================== 입양 신청 폼 (간소화) ====================
+
+/** 입양 신청 폼 수정 (간소화) */
+export const updateSimpleApplicationForm = (data: SimpleApplicationFormUpdateRequest) =>
+  apiClient
+    .patch<{
+      success: boolean
+      data: SimpleApplicationFormUpdateResponse
+      message?: string
+    }>(`${API_VERSION}/breeder-management/application-form/simple`, data)
+    .then(unwrap)
+
+// ==================== 회원 탈퇴 ====================
+
+/** 브리더 계정 탈퇴 */
+export const deleteBreederAccount = (data: BreederAccountDeleteRequest) =>
+  apiClient
+    .delete<{
+      success: boolean
+      data: BreederAccountDeleteResponse
+      message?: string
+    }>(`${API_VERSION}/breeder-management/account`, { data })
+    .then(unwrap)

--- a/src/features/breeder/api/breeder.mutations.ts
+++ b/src/features/breeder/api/breeder.mutations.ts
@@ -6,11 +6,35 @@ import type {
   ProfileUpdateRequestDto,
   ApplicationStatusUpdateRequest,
   SendChatMessageRequest,
+  AvailablePetAddRequest,
+  ParentPetAddRequest,
+  ParentPetUpdateRequest,
+  PetStatusUpdateRequest,
+  ReviewReplyRequest,
+  VerificationSubmitRequest,
+  SubmitDocumentsRequest,
+  SimpleApplicationFormUpdateRequest,
+  BreederAccountDeleteRequest,
 } from '@/shared/types'
 import {
   updateBreederProfile,
   updateBreederApplicationStatus,
   sendApplicationChatMessage,
+  addAvailablePet,
+  updateAvailablePet,
+  deleteAvailablePet,
+  updateAvailablePetStatus,
+  addParentPet,
+  updateParentPet,
+  deleteParentPet,
+  createReviewReply,
+  updateReviewReply,
+  deleteReviewReply,
+  submitVerification,
+  submitVerificationDocuments,
+  uploadVerificationDocuments,
+  updateSimpleApplicationForm,
+  deleteBreederAccount,
 } from './breeder.api'
 
 export const useUpdateBreederProfile = () => {
@@ -46,5 +70,170 @@ export const useSendChatMessage = (applicationId: string) => {
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: breederQueries.chatMessages(applicationId).queryKey })
     },
+  })
+}
+
+// ==================== 분양 개체 ====================
+
+export const useAddAvailablePet = () => {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (data: AvailablePetAddRequest) => addAvailablePet(data),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: breederQueries.all() })
+    },
+  })
+}
+
+export const useUpdateAvailablePet = () => {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ petId, data }: { petId: string; data: AvailablePetAddRequest }) =>
+      updateAvailablePet(petId, data),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: breederQueries.all() })
+    },
+  })
+}
+
+export const useDeleteAvailablePet = () => {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (petId: string) => deleteAvailablePet(petId),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: breederQueries.all() })
+    },
+  })
+}
+
+export const useUpdateAvailablePetStatus = () => {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ petId, data }: { petId: string; data: PetStatusUpdateRequest }) =>
+      updateAvailablePetStatus(petId, data),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: breederQueries.all() })
+    },
+  })
+}
+
+// ==================== 부모견/묘 ====================
+
+export const useAddParentPet = () => {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (data: ParentPetAddRequest) => addParentPet(data),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: breederQueries.all() })
+    },
+  })
+}
+
+export const useUpdateParentPet = () => {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ petId, data }: { petId: string; data: ParentPetUpdateRequest }) =>
+      updateParentPet(petId, data),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: breederQueries.all() })
+    },
+  })
+}
+
+export const useDeleteParentPet = () => {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (petId: string) => deleteParentPet(petId),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: breederQueries.all() })
+    },
+  })
+}
+
+// ==================== 후기 답글 ====================
+
+export const useCreateReviewReply = () => {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ reviewId, data }: { reviewId: string; data: ReviewReplyRequest }) =>
+      createReviewReply(reviewId, data),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: breederQueries.all() })
+    },
+  })
+}
+
+export const useUpdateReviewReply = () => {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ reviewId, data }: { reviewId: string; data: ReviewReplyRequest }) =>
+      updateReviewReply(reviewId, data),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: breederQueries.all() })
+    },
+  })
+}
+
+export const useDeleteReviewReply = () => {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (reviewId: string) => deleteReviewReply(reviewId),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: breederQueries.all() })
+    },
+  })
+}
+
+// ==================== 인증 ====================
+
+export const useSubmitVerification = () => {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (data: VerificationSubmitRequest) => submitVerification(data),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: breederQueries.verification().queryKey })
+    },
+  })
+}
+
+export const useSubmitVerificationDocuments = () => {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (data: SubmitDocumentsRequest) => submitVerificationDocuments(data),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: breederQueries.verification().queryKey })
+    },
+  })
+}
+
+export const useUploadVerificationDocuments = () => {
+  return useMutation({
+    mutationFn: ({
+      files,
+      level,
+    }: {
+      files: { type: string; file: File }[]
+      level: 'new' | 'elite'
+    }) => uploadVerificationDocuments(files, level),
+  })
+}
+
+// ==================== 입양 신청 폼 ====================
+
+export const useUpdateSimpleApplicationForm = () => {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (data: SimpleApplicationFormUpdateRequest) => updateSimpleApplicationForm(data),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: breederQueries.all() })
+    },
+  })
+}
+
+// ==================== 회원 탈퇴 ====================
+
+export const useDeleteBreederAccount = () => {
+  return useMutation({
+    mutationFn: (data: BreederAccountDeleteRequest) => deleteBreederAccount(data),
   })
 }

--- a/src/shared/types/BreederTypes.ts
+++ b/src/shared/types/BreederTypes.ts
@@ -81,18 +81,23 @@ interface PetBase {
   description?: string
 }
 
-/** 등록 요청: 부모 동물 */
+/** 등록 요청: 부모 동물 (POST /breeder-management/parent-pets) */
 export interface ParentPetAddRequest extends PetBase {
-  photoFileName: string
+  photoFileName?: string
+  photos?: string[]
 }
 
-/** 등록 요청: 분양 동물 */
+/** 수정 요청: 부모 동물 (PATCH) — 전 필드 선택 */
+export type ParentPetUpdateRequest = Partial<ParentPetAddRequest>
+
+/** 등록/수정 요청: 분양 동물 (POST/PATCH /breeder-management/available-pets) */
 export interface AvailablePetAddRequest extends PetBase {
   price: number
   parentInfo?: {
     mother?: string
     father?: string
   }
+  photos?: string[]
 }
 
 /** 공개 프로필용 부모 동물 요약 */
@@ -256,23 +261,75 @@ export interface DashboardResponseDto {
   }>
 }
 
+// ==================== 내 개체 목록 (breeder-management) ====================
+
+/** 내 개체 목록 아이템 (GET /breeder-management/my-pets) */
+export interface BreederMyPetItem {
+  petId: string
+  name: string
+  breed: string
+  gender: PetGender
+  birthDate: string
+  ageInMonths: number
+  price: number
+  status: PetStatus
+  isActive: boolean
+  mainPhoto: string
+  photoCount: number
+  viewCount: number
+  applicationCount: number
+  createdAt: string
+  updatedAt: string
+}
+
+/** 내 개체 목록 조회 파라미터 */
+export interface MyPetsParams {
+  status?: PetStatus
+  includeInactive?: boolean
+  page?: number
+  limit?: number
+}
+
+// ==================== 개체 등록/수정/상태 응답 ====================
+
+export interface PetAddResponse {
+  petId: string
+  message: string
+}
+
+export interface PetMessageResponse {
+  message: string
+}
+
+/** 개체 상태 변경 요청 (PATCH available-pets/{petId}/status) */
+export interface PetStatusUpdateRequest {
+  petStatus: PetStatus
+}
+
 // ==================== 브리더 후기 (브리더 수신) ====================
 
-export interface BreederReceivedReviewItemDto {
+/** 내게 달린 후기 목록 아이템 (GET /breeder-management/my-reviews) */
+export interface BreederMyReviewItem {
   reviewId: string
-  adopterId: string
-  adopterName: string
-  petId?: string
-  petName?: string
-  rating: number
-  comment: string
-  photos?: string[]
-  visibility: 'public' | 'private'
-  isReported: boolean
-  createdAt: string
-  replyContent?: string
-  replyWrittenAt?: string
-  replyUpdatedAt?: string
+  breederNickname: string
+  breederProfileImage: string
+  breederLevel: string
+  breedingPetType: string
+  content: string
+  reviewType: string
+  writtenAt: string
+}
+
+/** 내 후기 목록 조회 파라미터 */
+export interface MyReviewsParams {
+  visibility?: string
+  page?: number
+  limit?: number
+}
+
+/** 후기 답글 요청 (POST/PATCH reviews/{reviewId}/reply) */
+export interface ReviewReplyRequest {
+  content: string
 }
 
 export interface ReviewReplyResponseDto {
@@ -287,12 +344,40 @@ export interface ReviewReplyDeleteResponseDto {
   message: string
 }
 
-// ==================== 인증 서류 ====================
+// ==================== 인증 ====================
 
-export interface VerificationStatusDto extends Omit<BreederVerificationDto, 'plan'> {
-  breederId: string
+/** 브리더 인증 상태 조회 응답 (GET /breeder-management/verification) */
+export interface VerificationStatusResponse {
+  status: 'pending' | 'reviewing' | 'approved' | 'rejected'
+  plan?: 'basic' | 'premium' | 'enterprise'
+  level?: 'new' | 'intermediate' | 'advanced' | 'expert'
+  submittedAt?: string
+  reviewedAt?: string
+  documents?: BreederDocumentDto[]
+  rejectionReason?: string
   submittedByEmail?: boolean
 }
+
+/** 브리더 인증 신청 요청 (POST /breeder-management/verification) */
+export interface VerificationSubmitRequest {
+  businessNumber: string
+  businessName: string
+  plan: 'basic' | 'premium' | 'enterprise'
+  documents: string[]
+  businessAddress: string
+  experienceYears: string
+  specialBreeds: string
+  facilityDescription: string
+  veterinaryPartnership?: string
+  submittedByEmail?: boolean
+  additionalMessage?: string
+}
+
+export interface VerificationSubmitResponse {
+  message: string
+}
+
+// ==================== 인증 서류 ====================
 
 export interface UploadedDocumentDto extends BreederDocumentDto {
   fileName: string
@@ -305,16 +390,49 @@ export interface UploadDocumentsResponseDto {
   documents: UploadedDocumentDto[]
 }
 
+/** 인증 서류 제출 (간소화) 요청 (POST /breeder-management/verification/submit) */
 export interface SubmitDocumentsRequest {
   level: BreederLevel
-  documents: Array<Pick<BreederDocumentDto, 'type'> & { fileName: string }>
+  documents: Array<{ type: string; fileName: string; originalFileName?: string }>
   submittedByEmail?: boolean
+}
+
+// ==================== 입양 신청 폼 (간소화) ====================
+
+/** 간소화 신청 폼 수정 요청 (PATCH /breeder-management/application-form/simple) */
+export interface SimpleApplicationFormUpdateRequest {
+  questions: Array<{ question: string }>
+}
+
+export interface CustomQuestionDto {
+  id: string
+  type: string
+  label: string
+  required: boolean
+  options?: string[]
+  placeholder?: string
+  order: number
+  isStandard: boolean
+}
+
+export interface SimpleApplicationFormUpdateResponse {
+  message: string
+  customQuestions: CustomQuestionDto[]
+  totalQuestions: number
 }
 
 // ==================== 회원 탈퇴 ====================
 
+export type BreederAccountDeleteReason =
+  | 'no_inquiry'
+  | 'time_consuming'
+  | 'verification_difficult'
+  | 'policy_mismatch'
+  | 'uncomfortable_ui'
+  | 'other'
+
 export interface BreederAccountDeleteRequest {
-  reason?: string
+  reason: BreederAccountDeleteReason
   otherReason?: string
 }
 


### PR DESCRIPTION
## 작업 내용
미연결 breeder-management 13개 엔드포인트(18 오퍼레이션) 연결. 라이브 스펙 dev-api.pawpong.kr/docs-json 기준.

### 조회 (entities/breeder)
- `getMyPets(params)` -> `PaginationResponse<BreederMyPetItem>` — `breederQueries.myPets`
- `getMyReceivedReviews(params)` -> `PaginationResponse<BreederMyReviewItem>` — `breederQueries.myReviews`
- `getBreederVerification()` -> `VerificationStatusResponse` — `breederQueries.verification`

### 변경 (features/breeder)
- 분양 개체: `useAddAvailablePet` / `useUpdateAvailablePet` / `useDeleteAvailablePet` / `useUpdateAvailablePetStatus`
- 부모견/묘: `useAddParentPet` / `useUpdateParentPet` / `useDeleteParentPet`
- 후기 답글: `useCreateReviewReply` / `useUpdateReviewReply` / `useDeleteReviewReply`
- 인증: `useSubmitVerification` / `useSubmitVerificationDocuments` / `useUploadVerificationDocuments`(multipart)
- 신청 폼: `useUpdateSimpleApplicationForm`
- 탈퇴: `useDeleteBreederAccount`

### 타입
- 기존에 정의만 돼 있던(외부 사용 0건) 브리더관리 타입을 스펙에 맞게 정리/추가
- 신규: BreederMyPetItem, BreederMyReviewItem, Pet 응답/상태, Verification 요청/응답, SimpleApplicationForm, AccountDelete enum 등

## 검증
- type-check 통과, 변경 5개 파일 린트 클린
- 기존 breeder.api inline 스타일 / 멀티파트는 uploadBreederDocuments 패턴 따름

## 참고
- id 있는 mutation은 `mutate({ petId/reviewId, data })` 형태
- **my-reviews 응답 DTO**는 swagger 기준(breederNickname 등 필드 구성이 특이) — 실제 화면 연결 시 응답 재확인 권장
- 업로드/탈퇴 훅은 invalidation 없음(업로드만/로그아웃 흐름)

Closes #100