### PR TITLE
refactor(breeder): breeder.api inline 응답 타입을 ApiResponseFull로 통일

### DIFF
--- a/src/entities/breeder/api/breeder.api.ts
+++ b/src/entities/breeder/api/breeder.api.ts
@@ -33,163 +33,131 @@ export const getBreederPublicProfile = (breederId: string) =>
 /** 브리더 상세 프로필 조회 (기존) */
 export const getBreederProfile = (breederId: string) =>
   apiClient
-    .get<{
-      success: boolean
-      data: BreederProfileResponseDto
-      message?: string
-    }>(`${API_VERSION}/breeder/${breederId}`, { skipAuth: true } as ApiRequestConfig)
+    .get<
+      ApiResponseFull<BreederProfileResponseDto>
+    >(`${API_VERSION}/breeder/${breederId}`, { skipAuth: true } as ApiRequestConfig)
     .then(unwrap)
 
 /** 내 브리더 프로필 조회 */
 export const getMyBreederProfile = () =>
   apiClient
-    .get<{
-      success: boolean
-      data: BreederProfileResponseDto
-      message?: string
-    }>(`${API_VERSION}/breeder-management/profile`)
+    .get<ApiResponseFull<BreederProfileResponseDto>>(`${API_VERSION}/breeder-management/profile`)
     .then(unwrap)
 
 /** 브리더 대시보드 조회 */
 export const getBreederDashboard = () =>
   apiClient
-    .get<{
-      success: boolean
-      data: DashboardResponseDto
-      message?: string
-    }>(`${API_VERSION}/breeder-management/dashboard`)
+    .get<ApiResponseFull<DashboardResponseDto>>(`${API_VERSION}/breeder-management/dashboard`)
     .then(unwrap)
 
 /** 브리더 탐색/검색 */
 export const exploreBreeders = (params: SearchBreederParams = {}) =>
   apiClient
-    .post<{
-      success: boolean
-      data: PaginationResponse<Breeder>
-      message?: string
-    }>(`${API_VERSION}/breeder/explore`, params)
+    .post<ApiResponseFull<PaginationResponse<Breeder>>>(`${API_VERSION}/breeder/explore`, params)
     .then(unwrap)
 
 /** 인기 브리더 목록 */
 export const getPopularBreeders = () =>
   apiClient
-    .get<{
-      success: boolean
-      data: Breeder[]
-      message?: string
-    }>(`${API_VERSION}/breeder/popular`, { skipAuth: true } as ApiRequestConfig)
+    .get<
+      ApiResponseFull<Breeder[]>
+    >(`${API_VERSION}/breeder/popular`, { skipAuth: true } as ApiRequestConfig)
     .then(unwrap)
 
 /** 분양 개체 목록 */
 export const getBreederPets = (breederId: string, page = 1, limit = 20) =>
   apiClient
-    .get<{
-      success: boolean
-      data: PaginationResponse<AvailablePetSummaryDto>
-      message?: string
-    }>(`${API_VERSION}/breeder/${breederId}/pets`, {
-      params: { page, limit },
-      skipAuth: true,
-    } as ApiRequestConfig)
+    .get<ApiResponseFull<PaginationResponse<AvailablePetSummaryDto>>>(
+      `${API_VERSION}/breeder/${breederId}/pets`,
+      {
+        params: { page, limit },
+        skipAuth: true,
+      } as ApiRequestConfig,
+    )
     .then(unwrap)
 
 /** 부모견/묘 목록 */
 export const getParentPets = (breederId: string, page = 1, limit = 4) =>
   apiClient
-    .get<{
-      success: boolean
-      data: PaginationResponse<ParentPetSummaryDto>
-      message?: string
-    }>(`${API_VERSION}/breeder/${breederId}/parent-pets`, {
-      params: { page, limit },
-      skipAuth: true,
-    } as ApiRequestConfig)
+    .get<ApiResponseFull<PaginationResponse<ParentPetSummaryDto>>>(
+      `${API_VERSION}/breeder/${breederId}/parent-pets`,
+      {
+        params: { page, limit },
+        skipAuth: true,
+      } as ApiRequestConfig,
+    )
     .then(unwrap)
 
 /** 브리더 후기 목록 */
 export const getBreederReviews = (breederId: string, page = 1, limit = 10) =>
   apiClient
-    .get<{
-      success: boolean
-      data: PaginationResponse<PublicReviewDto>
-      message?: string
-    }>(`${API_VERSION}/breeder/${breederId}/reviews`, {
-      params: { page, limit },
-      skipAuth: true,
-    } as ApiRequestConfig)
+    .get<ApiResponseFull<PaginationResponse<PublicReviewDto>>>(
+      `${API_VERSION}/breeder/${breederId}/reviews`,
+      {
+        params: { page, limit },
+        skipAuth: true,
+      } as ApiRequestConfig,
+    )
     .then(unwrap)
 
 /** 입양 신청 폼 조회 (공개) */
 export const getBreederApplicationForm = (breederId: string) =>
   apiClient
-    .get<{
-      success: boolean
-      data: BreederApplicationFormDto
-      message?: string
-    }>(`${API_VERSION}/breeder/${breederId}/application-form`, {
-      skipAuth: true,
-    } as ApiRequestConfig)
+    .get<ApiResponseFull<BreederApplicationFormDto>>(
+      `${API_VERSION}/breeder/${breederId}/application-form`,
+      {
+        skipAuth: true,
+      } as ApiRequestConfig,
+    )
     .then(unwrap)
 
 /** 받은 신청 목록 (브리더용) */
 export const getReceivedApplications = (page = 1, limit = 10) =>
   apiClient
-    .get<{
-      success: boolean
-      data: PaginationResponse<ReceivedApplicationItemDto>
-      message?: string
-    }>(`${API_VERSION}/breeder-management/applications`, { params: { page, limit } })
+    .get<
+      ApiResponseFull<PaginationResponse<ReceivedApplicationItemDto>>
+    >(`${API_VERSION}/breeder-management/applications`, { params: { page, limit } })
     .then(unwrap)
 
 /** 받은 신청 상세 (브리더용) */
 export const getReceivedApplicationDetail = (applicationId: string) =>
   apiClient
-    .get<{
-      success: boolean
-      data: ReceivedApplicationDetailDto
-      message?: string
-    }>(`${API_VERSION}/breeder-management/applications/${applicationId}`)
+    .get<
+      ApiResponseFull<ReceivedApplicationDetailDto>
+    >(`${API_VERSION}/breeder-management/applications/${applicationId}`)
     .then(unwrap)
 
 /** 내 개체 목록 조회 (브리더 관리) */
 export const getMyPets = (params: MyPetsParams = {}) =>
   apiClient
-    .get<{
-      success: boolean
-      data: PaginationResponse<BreederMyPetItem>
-      message?: string
-    }>(`${API_VERSION}/breeder-management/my-pets`, { params })
+    .get<
+      ApiResponseFull<PaginationResponse<BreederMyPetItem>>
+    >(`${API_VERSION}/breeder-management/my-pets`, { params })
     .then(unwrap)
 
 /** 내게 달린 후기 목록 조회 (브리더 관리) */
 export const getMyReceivedReviews = (params: MyReviewsParams = {}) =>
   apiClient
-    .get<{
-      success: boolean
-      data: PaginationResponse<BreederMyReviewItem>
-      message?: string
-    }>(`${API_VERSION}/breeder-management/my-reviews`, { params })
+    .get<
+      ApiResponseFull<PaginationResponse<BreederMyReviewItem>>
+    >(`${API_VERSION}/breeder-management/my-reviews`, { params })
     .then(unwrap)
 
 /** 브리더 인증 상태 조회 */
 export const getBreederVerification = () =>
   apiClient
-    .get<{
-      success: boolean
-      data: VerificationStatusResponse
-      message?: string
-    }>(`${API_VERSION}/breeder-management/verification`)
+    .get<
+      ApiResponseFull<VerificationStatusResponse>
+    >(`${API_VERSION}/breeder-management/verification`)
     .then(unwrap)
 
 /** 채팅 메시지 조회 */
 export const getApplicationChatMessages = async (
   applicationId: string,
 ): Promise<ChatMessageDto[]> => {
-  const res = await apiClient.get<{
-    success: boolean
-    data: ChatMessageDto[] | { messages?: ChatMessageDto[]; items?: ChatMessageDto[] }
-    message?: string
-  }>(`${API_VERSION}/breeder-management/applications/${applicationId}/chat/messages`)
+  const res = await apiClient.get<
+    ApiResponseFull<ChatMessageDto[] | { messages?: ChatMessageDto[]; items?: ChatMessageDto[] }>
+  >(`${API_VERSION}/breeder-management/applications/${applicationId}/chat/messages`)
 
   const data = unwrap(res)
   if (Array.isArray(data)) return data

--- a/src/features/breeder/api/breeder.api.ts
+++ b/src/features/breeder/api/breeder.api.ts
@@ -1,5 +1,6 @@
 import { apiClient, API_VERSION, unwrap, unwrapNullable } from '@/shared/api'
 import type {
+  ApiResponseFull,
   ProfileUpdateRequestDto,
   BreederProfileUpdateResponseDto,
   ApplicationStatusUpdateRequest,
@@ -28,11 +29,9 @@ import type {
 /** 브리더 프로필 수정 */
 export const updateBreederProfile = (data: ProfileUpdateRequestDto) =>
   apiClient
-    .patch<{
-      success: boolean
-      data: BreederProfileUpdateResponseDto
-      message?: string
-    }>(`${API_VERSION}/breeder-management/profile`, data)
+    .patch<
+      ApiResponseFull<BreederProfileUpdateResponseDto>
+    >(`${API_VERSION}/breeder-management/profile`, data)
     .then(unwrap)
 
 /** 신청 상태 변경 (브리더용) */
@@ -41,21 +40,17 @@ export const updateBreederApplicationStatus = (
   data: ApplicationStatusUpdateRequest,
 ) =>
   apiClient
-    .patch<{
-      success: boolean
-      data: ApplicationStatusUpdateResponseDto
-      message?: string
-    }>(`${API_VERSION}/breeder-management/applications/${applicationId}`, data)
+    .patch<
+      ApiResponseFull<ApplicationStatusUpdateResponseDto>
+    >(`${API_VERSION}/breeder-management/applications/${applicationId}`, data)
     .then(unwrap)
 
 /** 채팅 메시지 전송 */
 export const sendApplicationChatMessage = (applicationId: string, data: SendChatMessageRequest) =>
   apiClient
-    .post<{
-      success: boolean
-      data: ChatMessageDto | null
-      message?: string
-    }>(`${API_VERSION}/breeder-management/applications/${applicationId}/chat/messages`, data)
+    .post<
+      ApiResponseFull<ChatMessageDto | null>
+    >(`${API_VERSION}/breeder-management/applications/${applicationId}/chat/messages`, data)
     .then((res) => unwrapNullable(res, '채팅 메시지 전송에 실패했습니다.'))
 
 // ==================== 분양 개체 (available-pets) ====================
@@ -63,41 +58,31 @@ export const sendApplicationChatMessage = (applicationId: string, data: SendChat
 /** 분양 개체 추가 */
 export const addAvailablePet = (data: AvailablePetAddRequest) =>
   apiClient
-    .post<{
-      success: boolean
-      data: PetAddResponse
-      message?: string
-    }>(`${API_VERSION}/breeder-management/available-pets`, data)
+    .post<ApiResponseFull<PetAddResponse>>(`${API_VERSION}/breeder-management/available-pets`, data)
     .then(unwrap)
 
 /** 분양 개체 수정 */
 export const updateAvailablePet = (petId: string, data: AvailablePetAddRequest) =>
   apiClient
-    .patch<{
-      success: boolean
-      data: PetMessageResponse
-      message?: string
-    }>(`${API_VERSION}/breeder-management/available-pets/${petId}`, data)
+    .patch<
+      ApiResponseFull<PetMessageResponse>
+    >(`${API_VERSION}/breeder-management/available-pets/${petId}`, data)
     .then(unwrap)
 
 /** 분양 개체 삭제 */
 export const deleteAvailablePet = (petId: string) =>
   apiClient
-    .delete<{
-      success: boolean
-      data: PetMessageResponse
-      message?: string
-    }>(`${API_VERSION}/breeder-management/available-pets/${petId}`)
+    .delete<
+      ApiResponseFull<PetMessageResponse>
+    >(`${API_VERSION}/breeder-management/available-pets/${petId}`)
     .then(unwrap)
 
 /** 분양 개체 상태 변경 */
 export const updateAvailablePetStatus = (petId: string, data: PetStatusUpdateRequest) =>
   apiClient
-    .patch<{
-      success: boolean
-      data: PetMessageResponse
-      message?: string
-    }>(`${API_VERSION}/breeder-management/available-pets/${petId}/status`, data)
+    .patch<
+      ApiResponseFull<PetMessageResponse>
+    >(`${API_VERSION}/breeder-management/available-pets/${petId}/status`, data)
     .then(unwrap)
 
 // ==================== 부모견/묘 (parent-pets) ====================
@@ -105,31 +90,23 @@ export const updateAvailablePetStatus = (petId: string, data: PetStatusUpdateReq
 /** 부모견/묘 추가 */
 export const addParentPet = (data: ParentPetAddRequest) =>
   apiClient
-    .post<{
-      success: boolean
-      data: PetAddResponse
-      message?: string
-    }>(`${API_VERSION}/breeder-management/parent-pets`, data)
+    .post<ApiResponseFull<PetAddResponse>>(`${API_VERSION}/breeder-management/parent-pets`, data)
     .then(unwrap)
 
 /** 부모견/묘 수정 */
 export const updateParentPet = (petId: string, data: ParentPetUpdateRequest) =>
   apiClient
-    .patch<{
-      success: boolean
-      data: PetMessageResponse
-      message?: string
-    }>(`${API_VERSION}/breeder-management/parent-pets/${petId}`, data)
+    .patch<
+      ApiResponseFull<PetMessageResponse>
+    >(`${API_VERSION}/breeder-management/parent-pets/${petId}`, data)
     .then(unwrap)
 
 /** 부모견/묘 삭제 */
 export const deleteParentPet = (petId: string) =>
   apiClient
-    .delete<{
-      success: boolean
-      data: PetMessageResponse
-      message?: string
-    }>(`${API_VERSION}/breeder-management/parent-pets/${petId}`)
+    .delete<
+      ApiResponseFull<PetMessageResponse>
+    >(`${API_VERSION}/breeder-management/parent-pets/${petId}`)
     .then(unwrap)
 
 // ==================== 후기 답글 (reviews/{reviewId}/reply) ====================
@@ -137,31 +114,25 @@ export const deleteParentPet = (petId: string) =>
 /** 후기 답글 등록 */
 export const createReviewReply = (reviewId: string, data: ReviewReplyRequest) =>
   apiClient
-    .post<{
-      success: boolean
-      data: ReviewReplyResponseDto
-      message?: string
-    }>(`${API_VERSION}/breeder-management/reviews/${reviewId}/reply`, data)
+    .post<
+      ApiResponseFull<ReviewReplyResponseDto>
+    >(`${API_VERSION}/breeder-management/reviews/${reviewId}/reply`, data)
     .then(unwrap)
 
 /** 후기 답글 수정 */
 export const updateReviewReply = (reviewId: string, data: ReviewReplyRequest) =>
   apiClient
-    .patch<{
-      success: boolean
-      data: ReviewReplyResponseDto
-      message?: string
-    }>(`${API_VERSION}/breeder-management/reviews/${reviewId}/reply`, data)
+    .patch<
+      ApiResponseFull<ReviewReplyResponseDto>
+    >(`${API_VERSION}/breeder-management/reviews/${reviewId}/reply`, data)
     .then(unwrap)
 
 /** 후기 답글 삭제 */
 export const deleteReviewReply = (reviewId: string) =>
   apiClient
-    .delete<{
-      success: boolean
-      data: ReviewReplyDeleteResponseDto
-      message?: string
-    }>(`${API_VERSION}/breeder-management/reviews/${reviewId}/reply`)
+    .delete<
+      ApiResponseFull<ReviewReplyDeleteResponseDto>
+    >(`${API_VERSION}/breeder-management/reviews/${reviewId}/reply`)
     .then(unwrap)
 
 // ==================== 인증 (verification) ====================
@@ -169,21 +140,17 @@ export const deleteReviewReply = (reviewId: string) =>
 /** 브리더 인증 신청 */
 export const submitVerification = (data: VerificationSubmitRequest) =>
   apiClient
-    .post<{
-      success: boolean
-      data: VerificationSubmitResponse
-      message?: string
-    }>(`${API_VERSION}/breeder-management/verification`, data)
+    .post<
+      ApiResponseFull<VerificationSubmitResponse>
+    >(`${API_VERSION}/breeder-management/verification`, data)
     .then(unwrap)
 
 /** 브리더 인증 서류 제출 (간소화) */
 export const submitVerificationDocuments = (data: SubmitDocumentsRequest) =>
   apiClient
-    .post<{
-      success: boolean
-      data: VerificationSubmitResponse
-      message?: string
-    }>(`${API_VERSION}/breeder-management/verification/submit`, data)
+    .post<
+      ApiResponseFull<VerificationSubmitResponse>
+    >(`${API_VERSION}/breeder-management/verification/submit`, data)
     .then(unwrap)
 
 /** 브리더 인증 서류 업로드 (multipart) */
@@ -197,11 +164,9 @@ export const uploadVerificationDocuments = (
   formData.append('level', level)
 
   return apiClient
-    .post<{
-      success: boolean
-      data: UploadDocumentsResponseDto
-      message?: string
-    }>(`${API_VERSION}/breeder-management/verification/upload`, formData)
+    .post<
+      ApiResponseFull<UploadDocumentsResponseDto>
+    >(`${API_VERSION}/breeder-management/verification/upload`, formData)
     .then(unwrap)
 }
 
@@ -210,11 +175,9 @@ export const uploadVerificationDocuments = (
 /** 입양 신청 폼 수정 (간소화) */
 export const updateSimpleApplicationForm = (data: SimpleApplicationFormUpdateRequest) =>
   apiClient
-    .patch<{
-      success: boolean
-      data: SimpleApplicationFormUpdateResponse
-      message?: string
-    }>(`${API_VERSION}/breeder-management/application-form/simple`, data)
+    .patch<
+      ApiResponseFull<SimpleApplicationFormUpdateResponse>
+    >(`${API_VERSION}/breeder-management/application-form/simple`, data)
     .then(unwrap)
 
 // ==================== 회원 탈퇴 ====================
@@ -222,9 +185,7 @@ export const updateSimpleApplicationForm = (data: SimpleApplicationFormUpdateReq
 /** 브리더 계정 탈퇴 */
 export const deleteBreederAccount = (data: BreederAccountDeleteRequest) =>
   apiClient
-    .delete<{
-      success: boolean
-      data: BreederAccountDeleteResponse
-      message?: string
-    }>(`${API_VERSION}/breeder-management/account`, { data })
+    .delete<
+      ApiResponseFull<BreederAccountDeleteResponse>
+    >(`${API_VERSION}/breeder-management/account`, { data })
     .then(unwrap)


### PR DESCRIPTION
## 배경
PR #101 머지 시 기능 커밋만 반영되고 후속 리팩토링 커밋(fa7788c)이 누락되어, 이를 dev에 마저 반영한다.

## 작업 내용
- features/entities breeder.api의 `{ success, data, message? }` inline 응답 타입 33회 제거 → `ApiResponseFull<T>`
- CLAUDE.md 규칙(인라인 타입 금지, ApiResponseFull 사용) 준수
- 동작 변경 없음 (.then(unwrap) 동일)

## 검증
- type-check 통과, inline 패턴 잔여 0건, 린트 클린