### PR TITLE
feat(home): 둘러보기 카테고리 카드 픽셀 버튼 리디자인

### DIFF
--- a/public/images/category/btn-pixel-category.svg
+++ b/public/images/category/btn-pixel-category.svg
@@ -1,0 +1,6 @@
+<svg preserveAspectRatio="none" width="100%" height="100%" overflow="visible" style="display: block;" viewBox="0 0 191.854 61.3936" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="Group 74">
+<path id="Union" d="M184.181 15.3486H191.854V61.3936H15.3486V53.7197H7.6748V42.208H0V15.3486H7.6748V7.6748H184.181V15.3486ZM168.832 7.67383H23.0225V0H168.832V7.67383Z" fill="#6B6B6B"/>
+<path id="Union_2" d="M23.0225 42.208H7.6748V15.3486H23.0225V7.6748H168.832V15.3486H184.181V42.208H168.832V49.8818H23.0225V42.208Z" fill="white"/>
+</g>
+</svg>

--- a/public/images/category/search.svg
+++ b/public/images/category/search.svg
@@ -1,0 +1,12 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M17.8176 5.99988H10.5449V8.72715H17.8176V5.99988Z" fill="#6B6B6B" style="fill:#6B6B6B;fill:color(display-p3 0.4196 0.4196 0.4196);fill-opacity:1;"/>
+<path d="M10.5456 8.72726H7.81836V11.4545H10.5456V8.72726Z" fill="#6B6B6B" style="fill:#6B6B6B;fill:color(display-p3 0.4196 0.4196 0.4196);fill-opacity:1;"/>
+<path d="M20.5456 8.72726H17.8184V11.4545H20.5456V8.72726Z" fill="#6B6B6B" style="fill:#6B6B6B;fill:color(display-p3 0.4196 0.4196 0.4196);fill-opacity:1;"/>
+<path d="M8.72727 11.4547H6V16.9092H8.72727V11.4547Z" fill="#6B6B6B" style="fill:#6B6B6B;fill:color(display-p3 0.4196 0.4196 0.4196);fill-opacity:1;"/>
+<path d="M22.364 11.4547H19.6367V16.9092H22.364V11.4547Z" fill="#6B6B6B" style="fill:#6B6B6B;fill:color(display-p3 0.4196 0.4196 0.4196);fill-opacity:1;"/>
+<path d="M10.5456 16.9094H7.81836V19.6367H10.5456V16.9094Z" fill="#6B6B6B" style="fill:#6B6B6B;fill:color(display-p3 0.4196 0.4196 0.4196);fill-opacity:1;"/>
+<path d="M20.5455 16.9094H16.9092V20.5458H20.5455V16.9094Z" fill="#6B6B6B" style="fill:#6B6B6B;fill:color(display-p3 0.4196 0.4196 0.4196);fill-opacity:1;"/>
+<path d="M17.8176 19.6363H10.5449V22.3635H17.8176V19.6363Z" fill="#6B6B6B" style="fill:#6B6B6B;fill:color(display-p3 0.4196 0.4196 0.4196);fill-opacity:1;"/>
+<path d="M23.2731 19.6363H19.6367V23.2726H23.2731V19.6363Z" fill="#6B6B6B" style="fill:#6B6B6B;fill:color(display-p3 0.4196 0.4196 0.4196);fill-opacity:1;"/>
+<path d="M25.9996 22.3636H22.3633V26H25.9996V22.3636Z" fill="#6B6B6B" style="fill:#6B6B6B;fill:color(display-p3 0.4196 0.4196 0.4196);fill-opacity:1;"/>
+</svg>

--- a/src/features/category-browse/ui/CategoryBrowse.tsx
+++ b/src/features/category-browse/ui/CategoryBrowse.tsx
@@ -1,26 +1,61 @@
+import Image from 'next/image'
 import Link from 'next/link'
 import { SectionHeader } from '@/shared/ui'
+import { cafe24Proup } from '@/shared/lib/fonts'
+import { cn } from '@/shared/lib/cn'
+
+// [refactored] 에셋 경로 상수화
+const ASSETS = {
+  buttonBg: '/images/category/btn-pixel-category.svg',
+  searchIcon: '/images/category/search.svg',
+}
 
 const CATEGORIES = [
-  { label: '강아지', href: '/explore?category=dog' },
-  { label: '고양이', href: '/explore?category=cat' },
-  { label: '도마뱀', href: '/explore?category=lizard' },
-  { label: '브리더 탐색', href: '/explore?type=breeder' },
+  { label: '강아지', href: '/explore?category=dog', icon: false },
+  { label: '고양이', href: '/explore?category=cat', icon: false },
+  { label: '도마뱀', href: '/explore?category=lizard', icon: false },
+  { label: '브리더 탐색', href: '/explore?type=breeder', icon: true },
 ]
+
+// [refactored] 카드 마크업을 별도 컴포넌트로 분리 (SRP)
+interface CategoryCardProps {
+  label: string
+  href: string
+  icon: boolean
+}
+
+const CategoryCard = ({ label, href, icon }: CategoryCardProps) => {
+  return (
+    <Link
+      href={href}
+      className="relative flex h-[2.125rem] w-[6.640625rem] items-center justify-center gap-[0.125rem] p-[0.5rem] transition-transform hover:scale-105 pc:h-[3.8371rem] pc:w-[11.990875rem]"
+    >
+      <Image src={ASSETS.buttonBg} alt="" fill className="object-fill" />
+      <span
+        className={cn(
+          cafe24Proup.className,
+          'relative z-10 font-cafe24 text-[0.625rem] leading-[1.5] font-normal whitespace-nowrap text-[#6b6b6b] pc:text-[1rem]',
+        )}
+      >
+        {label}
+      </span>
+      {icon && (
+        <span className="relative z-10 size-[1.25rem] shrink-0 pc:size-[2rem]">
+          <Image src={ASSETS.searchIcon} alt="" fill className="object-contain" />
+        </span>
+      )}
+    </Link>
+  )
+}
 
 const CategoryBrowse = () => {
   return (
     <div className="flex flex-col gap-[0.75rem]">
       <SectionHeader title="둘러보기" />
-      <div className="grid grid-cols-2 gap-[0.625rem] tab:grid-cols-4 tab:gap-[1.25rem]">
+      <div className="mx-auto grid w-fit grid-cols-2 gap-x-[1.25rem] gap-y-[0.5rem] tab:grid-cols-4 tab:gap-y-0 pc:gap-x-[2rem]">
+        {/* [refactored] 카드 렌더링을 CategoryCard로 위임 */}
         {CATEGORIES.map((category) => (
-          <Link
-            key={category.label}
-            href={category.href}
-            className="flex h-[4.875rem] items-center justify-center rounded-[0.375rem] bg-[#c6c6c6] tab:rounded-[1.0625rem]"
-          >
-            <span className="text-[0.875rem] font-semibold text-[#5d5d5d]">{category.label}</span>
-          </Link>
+          <CategoryCard key={category.label} {...category} />
         ))}
       </div>
     </div>


### PR DESCRIPTION
## 작업 내용
홈 `둘러보기` 섹션 카테고리 카드 4개(강아지/고양이/도마뱀/브리더 탐색)를 Figma 리디자인(픽셀 아트 버튼)으로 교체.

## 변경 사항
- 픽셀 테두리 버튼 SVG 에셋 추가 (`public/images/category/btn-pixel-category.svg`, `search.svg`)
- `cafe24Proup` 픽셀 폰트, 텍스트 색 `#6b6b6b`
- 반응형 레이아웃: 모바일 **2x2** / 탭·데스크탑 **1x4** (`grid w-fit mx-auto`)
- 버튼 고정 비율 3.125:1 (모바일 106.25x34, pc 191.85x61.4)
- `브리더 탐색` 검색 아이콘(`search.svg`): 모바일·탭 20x20, pc 32x32
- 리팩토링: `CategoryCard` 컴포넌트 분리 + 에셋 경로 상수화

## 참고
- Figma 시안: 모바일 1054-32504 / 데스크탑 940-29471 / 탭 940-38920

Closes #103