### PR TITLE
feat(ui): 공통 Tabs 언더라인 variant 추가 및 explore 탭 적용

### DIFF
--- a/src/app/(main)/explore/_ui/ExploreContent.tsx
+++ b/src/app/(main)/explore/_ui/ExploreContent.tsx
@@ -4,7 +4,7 @@ import { useState, useCallback } from 'react'
 import { useSearchParams, useRouter, usePathname } from 'next/navigation'
 import { cn } from '@/shared/lib/cn'
 import { cafe24Proup } from '@/shared/lib/fonts'
-import { SectionHeader } from '@/shared/ui'
+import { SectionHeader, Tabs, TabsList, TabsTrigger } from '@/shared/ui'
 import { SearchBar, PopularKeywords } from '@/features/search'
 import { CategoryFilter } from '@/features/category-filter'
 import { AdoptionCard, AdoptionCardHorizontal } from '@/entities/adoption'
@@ -63,25 +63,26 @@ const ExploreContent = () => {
 
   return (
     <div className="mx-auto flex w-full max-w-[67.5rem] flex-col">
-      {/* 모바일 탭 — 입양 탐색 / 브리더 탐색 */}
-      <div className="flex items-center tab:hidden">
-        {EXPLORE_TABS.map((tab) => (
-          <button
-            key={tab.type}
-            type="button"
-            onClick={() => handleTypeChange(tab.type)}
-            className={cn(
-              cafe24Proup.className,
-              'flex flex-1 items-center justify-center border-b-2 p-[0.625rem] font-cafe24 leading-[1.375rem]',
-              selectedType === tab.type
-                ? 'border-[#5d5d5d] text-[0.875rem] text-[#5d5d5d]'
-                : 'border-transparent text-[0.75rem] text-[#a7a7a7]',
-            )}
-          >
-            {tab.label}
-          </button>
-        ))}
-      </div>
+      {/* 탐색 탭 — 입양 탐색 / 브리더 탐색 (Figma 언더라인 탭: 모바일 md / 태블릿+ lg) */}
+      <Tabs
+        value={selectedType}
+        onValueChange={(value) => handleTypeChange(value as ExploreType)}
+        className="pt-3 tab:pt-4"
+      >
+        <TabsList variant="underline">
+          {EXPLORE_TABS.map((tab) => (
+            <TabsTrigger
+              key={tab.type}
+              value={tab.type}
+              variant="underline"
+              size="md"
+              className="tab:h-[3.8125rem] tab:pt-2 tab:text-base tab:after:h-[0.5625rem]"
+            >
+              {tab.label}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+      </Tabs>
 
       {/* ══════ 모바일: 타이틀 + 카테고리 ══════ */}
       <div className="flex flex-col gap-[0.75rem] py-5 tab:hidden">

--- a/src/shared/ui/Tabs.tsx
+++ b/src/shared/ui/Tabs.tsx
@@ -2,32 +2,68 @@
 
 import * as React from 'react'
 import * as TabsPrimitive from '@radix-ui/react-tabs'
+import { tv, type VariantProps } from 'tailwind-variants'
 import { cn } from '@/shared/lib/cn'
+import { cafe24Proup } from '@/shared/lib/fonts'
 
 export const Tabs = TabsPrimitive.Root
 
+const tabsListVariants = tv({
+  base: 'inline-flex items-center',
+  variants: {
+    variant: {
+      default: 'justify-center',
+      // Figma: 하단 보더 + 전폭 (탭 균등 분할)
+      underline: 'w-full border-b border-[#cacaca]',
+    },
+  },
+  defaultVariants: { variant: 'default' },
+})
+
 export const TabsList = React.forwardRef<
   React.ComponentRef<typeof TabsPrimitive.List>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
->(({ className, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List> & VariantProps<typeof tabsListVariants>
+>(({ className, variant, ...props }, ref) => (
   <TabsPrimitive.List
     ref={ref}
-    className={cn('inline-flex items-center justify-center', className)}
+    className={cn(tabsListVariants({ variant }), className)}
     {...props}
   />
 ))
 TabsList.displayName = TabsPrimitive.List.displayName
 
+const tabsTriggerVariants = tv({
+  base: 'inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50',
+  variants: {
+    variant: {
+      default: '',
+      // Figma: 라벨 상단 + 하단 갈색 바, 고정 높이(텍스트-바 간격). 활성 갈색/비활성 회색.
+      // cafe24 폰트 — 변수 단독으론 미적용이라 className 병행
+      underline: cn(
+        cafe24Proup.className,
+        'relative flex-1 items-start font-cafe24 text-[#a6a6a6] data-[state=active]:text-[#a9835a]',
+        'after:absolute after:bottom-0 after:left-0 after:w-full after:bg-[#a9835a]',
+        'after:opacity-0 data-[state=active]:after:opacity-100',
+      ),
+    },
+    size: { lg: '', md: '' },
+  },
+  compoundVariants: [
+    // 탭 높이: large 61px / medium 37px (컨테이너 pt 포함 시 77/49)
+    { variant: 'underline', size: 'lg', class: 'h-[3.8125rem] pt-2 text-base after:h-[0.5625rem]' },
+    { variant: 'underline', size: 'md', class: 'h-[2.3125rem] pt-1 text-xs after:h-[0.3125rem]' },
+  ],
+  defaultVariants: { variant: 'default', size: 'lg' },
+})
+
 export const TabsTrigger = React.forwardRef<
   React.ComponentRef<typeof TabsPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
->(({ className, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger> &
+    VariantProps<typeof tabsTriggerVariants>
+>(({ className, variant, size, ...props }, ref) => (
   <TabsPrimitive.Trigger
     ref={ref}
-    className={cn(
-      'inline-flex items-center justify-center whitespace-nowrap transition-all disabled:pointer-events-none disabled:opacity-50',
-      className,
-    )}
+    className={cn(tabsTriggerVariants({ variant, size }), className)}
     {...props}
   />
 ))


### PR DESCRIPTION
## 작업 내용
Figma 탭바(언더라인) 디자인을 공통 shared/ui Tabs에 variant로 추가하고, explore 탐색 탭을 교체.

### shared/ui Tabs (Tabs.tsx)
- `underline` variant 추가 (TabsList/TabsTrigger), size `lg`/`md`
- 활성 갈색 `#a9835a` + 하단 바, 비활성 회색 `#a6a6a6`, 하단 보더 `#cacaca`
- cafe24 폰트 (변수 단독 미적용 이슈 → `cafe24Proup.className` 병행)
- 탭 높이/여백 Figma 일치: lg 61px(바 9px) / md 37px(바 5px), 라벨 상단 정렬 + 텍스트-바 간격
- 기존 `default` variant 하위 호환 (HomeTabs/Bookmarks 영향 없음)

### explore (ExploreContent.tsx)
- 직접 구현한 탭(회색) → 공통 `Tabs/TabsList/TabsTrigger`로 교체
- 반응형: 모바일 md → 태블릿+ lg
- 기존 모바일 전용(`tab:hidden`) → 전 브레이크포인트 노출 (Figma 768/PC에도 탭)
- URL 상태(selectedType/handleTypeChange)에 value/onValueChange 연결

## 검증
- type-check / lint 통과
- 실제 렌더 확인 (데스크탑/모바일 스크린샷) — 폰트·색상·여백 Figma 일치

## 참고
- Figma: tab bar-layout 976:32388 / 단일 탭 976:25144 / explore 768·PC 인스턴스

Closes #105