### PR TITLE
fix(search): 인기 검색어 라벨 항상 노출 및 스타일 Figma 적용

### DIFF
--- a/src/features/search/ui/PopularKeywords.tsx
+++ b/src/features/search/ui/PopularKeywords.tsx
@@ -11,27 +11,30 @@ const PopularKeywords = () => {
   const { data } = useQuery(popularKeywordQueries.list())
   const keywords = [...(data ?? [])].sort((a, b) => a.rank - b.rank)
 
-  if (keywords.length === 0) return null
-
+  // 라벨은 항상 노출, 키워드는 데이터 있을 때만 렌더
   return (
     <div className="mt-[1.125rem] flex items-center gap-[1.0625rem]">
-      <span className="shrink-0 text-[0.875rem] font-semibold text-[#a8a8a8]">인기 검색어</span>
-      <Swiper
-        style={{ overflow: 'clip', minWidth: 0 }}
-        modules={[FreeMode]}
-        freeMode
-        slidesPerView="auto"
-        spaceBetween={10}
-        className="w-full !overflow-x-clip !overflow-y-visible"
-      >
-        {keywords.map((item) => (
-          <SwiperSlide key={item.keywordId} className="!w-auto">
-            <span className="shrink-0 rounded-full border border-[#a8a8a8] px-[0.625rem] py-[0.25rem] text-[0.875rem] font-semibold text-[#a8a8a8]">
-              {item.keyword}
-            </span>
-          </SwiperSlide>
-        ))}
-      </Swiper>
+      <span className="shrink-0 text-center text-base leading-[1.5] font-medium text-[#3e3e3e]">
+        인기 검색어
+      </span>
+      {keywords.length > 0 && (
+        <Swiper
+          style={{ overflow: 'clip', minWidth: 0 }}
+          modules={[FreeMode]}
+          freeMode
+          slidesPerView="auto"
+          spaceBetween={10}
+          className="w-full !overflow-x-clip !overflow-y-visible"
+        >
+          {keywords.map((item) => (
+            <SwiperSlide key={item.keywordId} className="!w-auto">
+              <span className="shrink-0 rounded-full border border-[#a8a8a8] px-[0.625rem] py-[0.25rem] text-[0.875rem] font-semibold text-[#a8a8a8]">
+                {item.keyword}
+              </span>
+            </SwiperSlide>
+          ))}
+        </Swiper>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## 작업 내용
- 데이터 없을 때 `return null` 제거 → **"인기 검색어" 라벨 항상 노출**, 키워드 칩(Swiper)은 데이터 있을 때만 렌더
- 라벨 스타일 Figma 적용
  - color #3E3E3E, font-size 16px, font-weight 500(medium), line-height 1.5, Pretendard, text-center

## 배경
인기 검색어 API가 데이터를 안 줄 때 컴포넌트 전체가 숨겨져 라벨까지 안 보이던 문제.

## 검증
- type-check / lint 통과

Closes #109