### PR TITLE
feat(search): 검색/카테고리 섹션 레이아웃 Figma 적용 (SearchSection 공통화)

### DIFF
--- a/src/app/(main)/explore/_ui/BreederExploreContent.tsx
+++ b/src/app/(main)/explore/_ui/BreederExploreContent.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import { useState } from 'react'
-import { SectionHeader, SearchBar } from '@/shared/ui'
-import { PopularKeywords } from '@/features/search'
+import { SectionHeader } from '@/shared/ui'
+import { SearchSection } from '@/features/search'
 import { SEARCH_PLACEHOLDERS } from '../_lib/constants'
 import { BreederCard } from '@/app/(main)/home/_ui/BreederCard'
 import { BreederCardHorizontal } from './BreederCardHorizontal'
@@ -15,10 +15,11 @@ const BreederExploreContent = () => {
   return (
     <>
       {/* 검색바 + 인기 검색어 */}
-      <div className="w-full tab:mx-auto tab:mt-[2.188rem] tab:max-w-[42.5rem]">
-        <SearchBar placeholder={SEARCH_PLACEHOLDERS.breeder} />
-        <PopularKeywords />
-      </div>
+      <SearchSection
+        placeholder={SEARCH_PLACEHOLDERS.breeder}
+        withPadding={false}
+        className="tab:mt-[2.188rem]"
+      />
 
       {/* 주목할 브리더 */}
       <section className="mt-[2.063rem] flex flex-col gap-[0.75rem] tab:mt-[4rem] tab:gap-[1.25rem]">

--- a/src/app/(main)/explore/_ui/ExploreContent.tsx
+++ b/src/app/(main)/explore/_ui/ExploreContent.tsx
@@ -2,8 +2,8 @@
 
 import { useState, useCallback } from 'react'
 import { useSearchParams, useRouter, usePathname } from 'next/navigation'
-import { SectionHeader, Tabs, TabsList, TabsTrigger, SearchBar } from '@/shared/ui'
-import { PopularKeywords } from '@/features/search'
+import { SectionHeader, Tabs, TabsList, TabsTrigger } from '@/shared/ui'
+import { SearchSection } from '@/features/search'
 import { CategoryFilter } from '@/features/category-filter'
 import { AdoptionCard, AdoptionCardHorizontal } from '@/entities/adoption'
 import { createMockListings } from '@/shared/mocks/adoption'
@@ -83,7 +83,7 @@ const ExploreContent = () => {
       </Tabs>
 
       {/* ══════ 카테고리 영역 (Figma: mo py24/px16/gap8, tab py32/px48/gap12, pc py48/px80/gap12) ══════ */}
-      <div className="flex flex-col items-center justify-center gap-2 px-4 py-6 tab:gap-3 tab:px-12 tab:py-8 pc:px-20 pc:py-12">
+      <div className="flex flex-col items-center justify-center gap-2 py-6 tab:gap-3 tab:py-8 pc:py-12">
         <CategoryFilter selected={selectedCategory} onChange={handleCategoryChange} />
       </div>
 
@@ -92,10 +92,11 @@ const ExploreContent = () => {
       ) : (
         <>
           {/* 검색바 + 인기 검색어 */}
-          <div className="w-full tab:mx-auto tab:mt-[2.188rem] tab:max-w-[42.5rem]">
-            <SearchBar placeholder={SEARCH_PLACEHOLDERS.adoption} />
-            <PopularKeywords />
-          </div>
+          <SearchSection
+            placeholder={SEARCH_PLACEHOLDERS.adoption}
+            withPadding={false}
+            className="tab:mt-[2.188rem]"
+          />
 
           {/* ─── 인기 있는 동물들 (mo: top475→검색바 후 ~gap33, pc: top584→gap ~64px) ─── */}
           <section className="mt-[2.063rem] flex flex-col gap-[0.75rem] tab:mt-[4rem] tab:gap-[1.25rem]">

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -1,9 +1,8 @@
-import { Container, SearchBar } from '@/shared/ui'
 import { Banner } from '@/widgets/banner'
 import { HallOfFame } from '@/widgets/hall-of-fame'
 import { CommunityShowcase } from '@/widgets/community-showcase'
 import { FaqSection } from '@/widgets/faq'
-import { PopularKeywords } from '@/features/search'
+import { SearchSection } from '@/features/search'
 import { CategoryBrowse } from '@/features/category-browse'
 import type { HomeUserType } from '@/shared/types'
 
@@ -15,16 +14,9 @@ const HomePage = () => {
     <div>
       <Banner />
 
-      <Container className="mt-[3rem]">
-        <div className="mx-auto max-w-[42.5rem]">
-          <SearchBar />
-          <PopularKeywords />
-        </div>
-      </Container>
+      <SearchSection />
 
-      <Container className="mt-[3rem]">
-        <CategoryBrowse />
-      </Container>
+      <CategoryBrowse />
 
       <HallOfFame />
       <CommunityShowcase />

--- a/src/features/search/index.ts
+++ b/src/features/search/index.ts
@@ -1,1 +1,2 @@
 export { PopularKeywords } from './ui/PopularKeywords'
+export { SearchSection } from './ui/SearchSection'

--- a/src/features/search/ui/PopularKeywords.tsx
+++ b/src/features/search/ui/PopularKeywords.tsx
@@ -13,7 +13,7 @@ const PopularKeywords = () => {
 
   // 라벨은 항상 노출, 키워드는 데이터 있을 때만 렌더
   return (
-    <div className="mt-[1.125rem] flex items-center gap-[1.0625rem]">
+    <div className="flex items-center gap-5">
       <span className="shrink-0 text-center text-base leading-[1.5] font-medium text-[#3e3e3e]">
         인기 검색어
       </span>

--- a/src/features/search/ui/SearchSection.tsx
+++ b/src/features/search/ui/SearchSection.tsx
@@ -1,0 +1,32 @@
+import { SearchBar } from '@/shared/ui'
+import { cn } from '@/shared/lib/cn'
+import { PopularKeywords } from './PopularKeywords'
+
+interface SearchSectionProps {
+  placeholder?: {
+    mobile: string
+    desktop: string
+  }
+  className?: string
+  /** 독립 섹션이면 페이지 좌우 마진(px) 포함(홈), 이미 컨테이너 내부면 false(explore) */
+  withPadding?: boolean
+}
+
+const SearchSection = ({ placeholder, className, withPadding = true }: SearchSectionProps) => {
+  return (
+    <section
+      className={cn(
+        'flex flex-col items-center py-3 tab:py-5',
+        withPadding && 'px-4 tab:px-12 pc:px-20',
+        className,
+      )}
+    >
+      <div className="flex w-full flex-col gap-[0.4375rem] tab:max-w-[30.125rem] pc:max-w-[52.875rem]">
+        <SearchBar placeholder={placeholder} />
+        <PopularKeywords />
+      </div>
+    </section>
+  )
+}
+
+export { SearchSection }


### PR DESCRIPTION
## 작업 내용
검색바+인기검색어, 카테고리 영역을 Figma search/home-layout에 맞춰 독립 섹션으로 정리.

### SearchSection 공통 컴포넌트 (features/search)
- SearchBar + PopularKeywords를 묶음, Figma 레이아웃 적용
  - 중앙 정렬, 입력↔키워드 gap 7px, 내부 max-w 탭 482 / pc 846
  - 섹션 패딩: px 16/48/80, py 12/20
- `withPadding` prop: 독립 섹션(홈) true(기본) / 컨테이너 내부(explore) false

### PopularKeywords
- 상단 마진 제거(부모 gap이 간격 담당), 라벨↔키워드 gap 17→20px

### 레이아웃 정리 (max-w-90rem Container 의존 제거)
- 홈: 검색/카테고리를 `<Container className="mt-[3rem]">`에서 빼내 자체 섹션으로 (불필요한 Container import 제거)
- explore: 카테고리 wrapper px 제거 — 페이지 Container가 이미 px 제공(중복 패딩 해소), SearchSection은 withPadding={false}

## 검증
- type-check / lint 통과
- 실제 렌더 확인(홈 1440): 검색바 846 중앙 / 카테고리 픽셀 중앙, Container 벗어남 확인

## 참고
- Figma: search layout 1555:88216·88227·88238, home-layout 1555:88217·88239

Closes #113