### PR TITLE
fix(explore): 탐색 탭 바 Figma tab bar-layout 적용

### DIFF
--- a/src/app/(main)/explore/_ui/ExploreContent.tsx
+++ b/src/app/(main)/explore/_ui/ExploreContent.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useCallback } from 'react'
 import { useSearchParams, useRouter, usePathname } from 'next/navigation'
-import { SectionHeader, Tabs, TabsList, TabsTrigger } from '@/shared/ui'
+import { Container, SectionHeader, Tabs, TabsList, TabsTrigger } from '@/shared/ui'
 import { SearchSection } from '@/features/search'
 import { CategoryFilter } from '@/features/category-filter'
 import { AdoptionCard, AdoptionCardHorizontal } from '@/entities/adoption'
@@ -60,96 +60,107 @@ const ExploreContent = () => {
   const [allCollapsed, setAllCollapsed] = useState(false)
 
   return (
-    <div className="mx-auto flex w-full max-w-[67.5rem] flex-col">
-      {/* 탐색 탭 — 입양 탐색 / 브리더 탐색 (Figma 언더라인 탭: 모바일 md / 태블릿+ lg) */}
-      <Tabs
-        value={selectedType}
-        onValueChange={(value) => handleTypeChange(value as ExploreType)}
-        className="pt-3 tab:pt-4"
-      >
-        <TabsList variant="underline">
-          {EXPLORE_TABS.map((tab) => (
-            <TabsTrigger
-              key={tab.type}
-              value={tab.type}
-              variant="underline"
-              size="md"
-              className="tab:h-[3.8125rem] tab:pt-2 tab:text-base tab:after:h-[0.5625rem]"
-            >
-              {tab.label}
-            </TabsTrigger>
-          ))}
-        </TabsList>
-      </Tabs>
-
-      {/* ══════ 카테고리 영역 (Figma: mo py24/px16/gap8, tab py32/px48/gap12, pc py48/px80/gap12) ══════ */}
-      <div className="flex flex-col items-center justify-center gap-2 py-6 tab:gap-3 tab:py-8 pc:py-12">
-        <CategoryFilter selected={selectedCategory} onChange={handleCategoryChange} />
+    <>
+      {/* ══════ 탐색 탭 바 (Figma 'tab bar-layout') ══════
+          - GNB 헤더와 동일하게 max-width 캡 없는 full-width + margin/pc(20/48/80) inset.
+            (1440 초과 화면에서 헤더는 끝까지 가는데 탭만 멈춰 여백이 생기는 것 방지)
+          - 하단 회색선(border-b)은 이 래퍼에 두어 px(margin)을 무시하고 전폭(edge-to-edge)으로 항상 노출.
+          - spacing/16 상단 패딩(pt-4). */}
+      <div className="w-full border-b border-[#cacaca] px-[1.25rem] pt-3 tab:px-[3rem] tab:pt-4 pc:px-[5rem]">
+        <Tabs
+          value={selectedType}
+          onValueChange={(value) => handleTypeChange(value as ExploreType)}
+          className="w-full"
+        >
+          <TabsList variant="underline">
+            {EXPLORE_TABS.map((tab) => (
+              <TabsTrigger
+                key={tab.type}
+                value={tab.type}
+                variant="underline"
+                size="md"
+                className="tab:h-[3.8125rem] tab:pt-2 tab:text-base tab:after:h-[0.5625rem]"
+              >
+                {tab.label}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </Tabs>
       </div>
 
-      {selectedType === 'breeder' ? (
-        <BreederExploreContent />
-      ) : (
-        <>
-          {/* 검색바 + 인기 검색어 */}
-          <SearchSection
-            placeholder={SEARCH_PLACEHOLDERS.adoption}
-            withPadding={false}
-            className="tab:mt-[2.188rem]"
-          />
+      {/* ══════ 콘텐츠 영역 — 1080 중앙 정렬 ══════ */}
+      <Container>
+        <div className="mx-auto flex w-full max-w-[67.5rem] flex-col">
+          {/* 카테고리 영역 (Figma: mo py24/px16/gap8, tab py32/px48/gap12, pc py48/px80/gap12) */}
+          <div className="flex flex-col items-center justify-center gap-2 py-6 tab:gap-3 tab:py-8 pc:py-12">
+            <CategoryFilter selected={selectedCategory} onChange={handleCategoryChange} />
+          </div>
 
-          {/* ─── 인기 있는 동물들 (mo: top475→검색바 후 ~gap33, pc: top584→gap ~64px) ─── */}
-          <section className="mt-[2.063rem] flex flex-col gap-[0.75rem] tab:mt-[4rem] tab:gap-[1.25rem]">
-            <SectionHeader
-              title={`인기있는 동물들 ${popularListings.length}`}
-              collapsible
-              collapsed={popularCollapsed}
-              onToggle={() => setPopularCollapsed((prev) => !prev)}
-            />
-            {/* 모바일: 가로형 카드 리스트 (gap 12px) */}
-            {!popularCollapsed && (
-              <div className="flex flex-col gap-[0.75rem] tab:hidden">
-                {popularListings.map((listing) => (
-                  <AdoptionCardHorizontal key={listing.listingId} listing={listing} />
-                ))}
-              </div>
-            )}
-            {/* 데스크탑: 3열 세로형 카드 (gap 18.493px) */}
-            <div className="hidden tab:grid tab:grid-cols-3 tab:gap-[1.156rem]">
-              {popularListings.map((listing) => (
-                <AdoptionCard key={listing.listingId} listing={listing} />
-              ))}
-            </div>
-          </section>
+          {selectedType === 'breeder' ? (
+            <BreederExploreContent />
+          ) : (
+            <>
+              {/* 검색바 + 인기 검색어 */}
+              <SearchSection
+                placeholder={SEARCH_PLACEHOLDERS.adoption}
+                withPadding={false}
+                className="tab:mt-[2.188rem]"
+              />
 
-          {/* ─── 전체 입양 소식 (mo: gap20, pc: gap64→4rem) ─── */}
-          <section className="mt-[1.25rem] flex flex-col gap-[0.75rem] tab:mt-[4rem] tab:gap-[1.25rem]">
-            <SectionHeader
-              title={`전체 입양 소식 ${mockListings.length}`}
-              collapsible
-              collapsed={allCollapsed}
-              onToggle={() => setAllCollapsed((prev) => !prev)}
-            />
-            {/* 모바일 2열 / 데스크탑 3열, gap 피그마: mo 15.5px, pc 18.493px */}
-            {!allCollapsed && (
-              <div className="grid grid-cols-2 gap-[0.97rem] tab:hidden">
-                {mockListings.map((listing) => (
-                  <AdoptionCard key={listing.listingId} listing={listing} />
-                ))}
-              </div>
-            )}
-            <div className="hidden tab:grid tab:grid-cols-3 tab:gap-[1.156rem]">
-              {mockListings.map((listing) => (
-                <AdoptionCard key={listing.listingId} listing={listing} />
-              ))}
-            </div>
-          </section>
+              {/* ─── 인기 있는 동물들 (mo: top475→검색바 후 ~gap33, pc: top584→gap ~64px) ─── */}
+              <section className="mt-[2.063rem] flex flex-col gap-[0.75rem] tab:mt-[4rem] tab:gap-[1.25rem]">
+                <SectionHeader
+                  title={`인기있는 동물들 ${popularListings.length}`}
+                  collapsible
+                  collapsed={popularCollapsed}
+                  onToggle={() => setPopularCollapsed((prev) => !prev)}
+                />
+                {/* 모바일: 가로형 카드 리스트 (gap 12px) */}
+                {!popularCollapsed && (
+                  <div className="flex flex-col gap-[0.75rem] tab:hidden">
+                    {popularListings.map((listing) => (
+                      <AdoptionCardHorizontal key={listing.listingId} listing={listing} />
+                    ))}
+                  </div>
+                )}
+                {/* 데스크탑: 3열 세로형 카드 (gap 18.493px) */}
+                <div className="hidden tab:grid tab:grid-cols-3 tab:gap-[1.156rem]">
+                  {popularListings.map((listing) => (
+                    <AdoptionCard key={listing.listingId} listing={listing} />
+                  ))}
+                </div>
+              </section>
 
-          {/* 하단 여백 */}
-          <div className="h-[4rem]" />
-        </>
-      )}
-    </div>
+              {/* ─── 전체 입양 소식 (mo: gap20, pc: gap64→4rem) ─── */}
+              <section className="mt-[1.25rem] flex flex-col gap-[0.75rem] tab:mt-[4rem] tab:gap-[1.25rem]">
+                <SectionHeader
+                  title={`전체 입양 소식 ${mockListings.length}`}
+                  collapsible
+                  collapsed={allCollapsed}
+                  onToggle={() => setAllCollapsed((prev) => !prev)}
+                />
+                {/* 모바일 2열 / 데스크탑 3열, gap 피그마: mo 15.5px, pc 18.493px */}
+                {!allCollapsed && (
+                  <div className="grid grid-cols-2 gap-[0.97rem] tab:hidden">
+                    {mockListings.map((listing) => (
+                      <AdoptionCard key={listing.listingId} listing={listing} />
+                    ))}
+                  </div>
+                )}
+                <div className="hidden tab:grid tab:grid-cols-3 tab:gap-[1.156rem]">
+                  {mockListings.map((listing) => (
+                    <AdoptionCard key={listing.listingId} listing={listing} />
+                  ))}
+                </div>
+              </section>
+
+              {/* 하단 여백 */}
+              <div className="h-[4rem]" />
+            </>
+          )}
+        </div>
+      </Container>
+    </>
   )
 }
 

--- a/src/app/(main)/explore/page.tsx
+++ b/src/app/(main)/explore/page.tsx
@@ -1,16 +1,15 @@
 import { Suspense } from 'react'
-import { Container } from '@/shared/ui'
 import { ExploreContent } from './_ui/ExploreContent'
 
 // ExploreContent 내부에서 useSearchParams 를 사용하므로 Next.js 의 prerender 단계에서
 // Suspense 경계를 요구한다. 없으면 빌드가 CSR bailout 에러로 실패한다.
+// 탭 바(tab bar-layout)는 margin/pc inset + 전폭 회색선을 위해 Container 밖에서 자체 레이아웃을 가지므로
+// 여기서는 Container 로 감싸지 않고 ExploreContent 가 직접 레이아웃을 구성한다.
 const ExplorePage = () => {
   return (
-    <Container>
-      <Suspense fallback={null}>
-        <ExploreContent />
-      </Suspense>
-    </Container>
+    <Suspense fallback={null}>
+      <ExploreContent />
+    </Suspense>
   )
 }
 

--- a/src/shared/ui/Tabs.tsx
+++ b/src/shared/ui/Tabs.tsx
@@ -13,8 +13,10 @@ const tabsListVariants = tv({
   variants: {
     variant: {
       default: 'justify-center',
-      // Figma: 하단 보더 + 전폭 (탭 균등 분할)
-      underline: 'w-full border-b border-[#cacaca]',
+      // flex(block-level)로 두어 inline-flex line-box strut 여백을 없앤다
+      // (바깥 래퍼 border-b 회색선과 갈색 바가 틈 없이 붙도록).
+      // 탭은 flex-1 균등 분할이라 고정 gap은 두지 않는다(좁은 화면 라벨 잘림 방지).
+      underline: 'flex w-full justify-center',
     },
   },
   defaultVariants: { variant: 'default' },


### PR DESCRIPTION
## 변경 사항

explore 탐색 탭 바를 Figma `tab bar-layout`에 맞춤.

- **레이아웃 분리**: 탭 바를 Container(1080 콘텐츠 레이아웃) 밖으로 빼서 GNB 헤더와 동일하게 max-width 캡 없는 full-width + margin/pc inset 블록으로 구성
- **전폭 회색선**: 하단 회색 baseline(`border-b`)을 바깥 래퍼에 두어 px(margin)을 무시하고 edge-to-edge 전폭으로 항상 노출
- **틈 제거**: `TabsList` underline variant를 `flex`(block-level)로 변경해 inline-flex line-box strut 여백 제거 → 활성 갈색 바와 회색선이 틈 없이 붙음
- **라벨 잘림 방지**: 좁은 화면에서 고정 gap이 탭 라벨을 밀어내는 문제로 고정 gap 제거 (flex-1 균등 분할)

## 검증

| 브레이크포인트 | 결과 |
|---|---|
| 모바일 (375) | 정상 |
| 태블릿 (768) | 정상 |
| PC (1440) | 정상 |
| 1440 초과 (1664) | 회색선이 헤더처럼 끝까지 이어짐, 여백 없음 |

type-check 통과 / 변경 파일 lint 클린

Closes #115