### PR TITLE
feat(ui): 공통 Badge 컴포넌트(Figma 743-68292) 추가 및 적용

### DIFF
--- a/src/app/(main)/explore/_ui/ExploreFilterBar.tsx
+++ b/src/app/(main)/explore/_ui/ExploreFilterBar.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 import Image from 'next/image'
-import { SearchIcon } from '@/shared/ui'
+import { SearchIcon, badgeVariants } from '@/shared/ui'
 import { cn } from '@/shared/lib/cn'
 import { ANIMAL_CATEGORIES, CATEGORY_LABEL } from '@/shared/types'
 import type { AnimalCategory } from '@/shared/types'
@@ -59,32 +59,26 @@ const ExploreFilterBar = ({ selected, onChange, className }: ExploreFilterBarPro
           </button>
 
           {/* 전체폭 검색바 */}
-          <div className={cn(PILL_BASE, 'min-w-0 flex-1 justify-between gap-2 border-[#a6a6a6] px-2')}>
+          <div
+            className={cn(PILL_BASE, 'min-w-0 flex-1 justify-between gap-2 border-[#a6a6a6] px-2')}
+          >
             {searchContent}
           </div>
         </>
       ) : (
         <>
-          {/* 카테고리 칩 (badge) */}
+          {/* 카테고리 칩 — 공통 Badge(default/active) */}
           <div className="flex flex-wrap items-center gap-2">
-            {ANIMAL_CATEGORIES.map((category) => {
-              const active = selected === category
-              return (
-                <button
-                  key={category}
-                  type="button"
-                  onClick={() => onChange(category)}
-                  className={cn(
-                    'flex items-center rounded-full px-2 py-1 text-base leading-[1.5] font-medium whitespace-nowrap',
-                    active
-                      ? 'bg-[#3e3e3e] text-[#f6f6f6]'
-                      : 'border border-[#cacaca] bg-white text-[#6b6b6b]',
-                  )}
-                >
-                  {CATEGORY_LABEL[category]}
-                </button>
-              )
-            })}
+            {ANIMAL_CATEGORIES.map((category) => (
+              <button
+                key={category}
+                type="button"
+                onClick={() => onChange(category)}
+                className={badgeVariants({ variant: selected === category ? 'active' : 'default' })}
+              >
+                {CATEGORY_LABEL[category]}
+              </button>
+            ))}
           </div>
 
           {/* 작은 "검색" 버튼 — 클릭 시 검색바 펼침 */}

--- a/src/entities/adoption/ui/AdoptionCard.tsx
+++ b/src/entities/adoption/ui/AdoptionCard.tsx
@@ -15,11 +15,11 @@ const STATUS_BG: Record<AdoptionListingCard['status'], string> = {
   completed: 'bg-[#a4a4a4]',
 }
 
-// Figma 세로형 카드(796-81669 large / 796-81670 medium) 상태 배지: 활성 다크(#3e3e3e), 완료는 그레이
-const STATUS_BG_DARK: Record<AdoptionListingCard['status'], string> = {
-  available: 'bg-[#3e3e3e]',
-  reserved: 'bg-[#3e3e3e]',
-  completed: 'bg-[#a4a4a4]',
+// Figma 세로형 카드 상태 배지 → 공통 Badge 변형: 분양중/예약중 active(다크), 분양완료 disabled(그레이)
+const STATUS_BADGE_VARIANT: Record<AdoptionListingCard['status'], 'active' | 'disabled'> = {
+  available: 'active',
+  reserved: 'active',
+  completed: 'disabled',
 }
 
 interface AdoptionCardProps {
@@ -62,11 +62,9 @@ const AdoptionCard = ({ listing, className }: AdoptionCardProps) => {
             />
           </div>
           <Badge
-            variant="status"
-            className={cn(
-              STATUS_BG_DARK[listing.status],
-              'shrink-0 self-start px-[0.5rem] py-[0.125rem] text-[0.875rem] leading-[1.5] font-medium text-[#f6f6f6]',
-            )}
+            variant={STATUS_BADGE_VARIANT[listing.status]}
+            size="md"
+            className="shrink-0 self-start"
           >
             {ADOPTION_STATUS_LABEL[listing.status]}
           </Badge>
@@ -98,13 +96,7 @@ const AdoptionCard = ({ listing, className }: AdoptionCardProps) => {
           </div>
           {/* 우측: 상태배지(상단, 다크) + 관심있어요(하단, 하트+텍스트) */}
           <div className="flex shrink-0 flex-col items-end justify-between">
-            <Badge
-              variant="status"
-              className={cn(
-                STATUS_BG_DARK[listing.status],
-                'px-[0.5rem] py-[0.25rem] text-[1rem] leading-[1.5] font-medium text-[#f6f6f6]',
-              )}
-            >
+            <Badge variant={STATUS_BADGE_VARIANT[listing.status]} className="shrink-0">
               {ADOPTION_STATUS_LABEL[listing.status]}
             </Badge>
             <FavoriteButton

--- a/src/shared/ui/Badge.tsx
+++ b/src/shared/ui/Badge.tsx
@@ -3,7 +3,7 @@ import { tv, type VariantProps } from 'tailwind-variants'
 import { cn } from '@/shared/lib/cn'
 
 const badgeVariants = tv({
-  base: 'inline-flex items-center justify-center rounded-[999px] whitespace-nowrap font-semibold',
+  base: 'inline-flex items-center justify-center gap-[0.125rem] rounded-[999px] whitespace-nowrap font-semibold',
   variants: {
     variant: {
       outline:
@@ -12,8 +12,21 @@ const badgeVariants = tv({
         'bg-[#e1e1e1] text-[#5d5d5d] px-[0.625rem] py-[0.25rem] text-[0.875rem] leading-[1.375rem]',
       status:
         'bg-[#5d5d5d] text-white px-[0.625rem] py-[0.25rem] text-[0.875rem] leading-[1.375rem]',
+      // Figma 디자인 시스템 뱃지 (743-68292) — large 기준, size="md"로 medium 전환
+      default:
+        'border border-[#cacaca] bg-white px-2 py-1 text-base leading-[1.5] font-medium text-[#6b6b6b]',
+      active: 'bg-[#3e3e3e] px-2 py-1 text-base leading-[1.5] font-medium text-[#f6f6f6]',
+      disabled: 'bg-[#e4e4e4] px-2 py-1 text-base leading-[1.5] font-medium text-[#b8b8b8]',
+    },
+    size: {
+      lg: '',
+      md: '',
     },
   },
+  compoundVariants: [
+    // medium: h-24 / py-2 / 14px (default·active·disabled 전용)
+    { variant: ['default', 'active', 'disabled'], size: 'md', class: 'h-6 px-2 py-0.5 text-sm' },
+  ],
   defaultVariants: {
     variant: 'outline',
   },
@@ -21,6 +34,8 @@ const badgeVariants = tv({
 
 type BadgeProps = React.HTMLAttributes<HTMLSpanElement> & VariantProps<typeof badgeVariants>
 
-export const Badge = ({ className, variant, ...props }: BadgeProps) => {
-  return <span className={cn(badgeVariants({ variant }), className)} {...props} />
+export const Badge = ({ className, variant, size, ...props }: BadgeProps) => {
+  return <span className={cn(badgeVariants({ variant, size }), className)} {...props} />
 }
+
+export { badgeVariants }


### PR DESCRIPTION
## 변경 사항

Figma 뱃지 컴포넌트(743-68292)를 공통 `Badge`에 추가하고 explore/입양 카드에 적용.

### Badge (shared/ui)
- 기존 `outline`/`filled`/`status` 유지하고 Figma 디자인 시스템 변형 추가
  - `variant`: **default**(흰색+`#cacaca`+`#6b6b6b`), **active**(`#3e3e3e`+`#f6f6f6`), **disabled**(`#e4e4e4`+`#b8b8b8`)
  - `size`: **lg**(16px) / **md**(14px, h-24)
  - `badgeVariants` export (버튼 등에서 직접 합성)

### 적용
- explore 필터 칩 → 공통 Badge(`default`/`active`)
- 입양 카드 상태 뱃지 → 공통 Badge(`active`/`disabled`), 모바일 `md` / 태블릿 `lg`

## 검증
type-check 통과 / lint 클린

Closes #121