### PR TITLE
refactor(adoption): 입양 카드 모바일 레이아웃(Figma 1023-40492) + CardImage/CardStats 추출

### DIFF
--- a/src/entities/adoption/ui/AdoptionCard.tsx
+++ b/src/entities/adoption/ui/AdoptionCard.tsx
@@ -27,58 +27,85 @@ interface AdoptionCardProps {
   className?: string
 }
 
+// [refactored] 세로형 카드 이미지(이미지 + 분양완료 오버레이) — 모바일/태블릿 공통, rounded만 className으로 차이
+const CardImage = ({
+  listing,
+  isCompleted,
+  className,
+}: {
+  listing: AdoptionListingCard
+  isCompleted: boolean
+  className?: string
+}) => (
+  <div className={cn('relative aspect-[348/284] w-full overflow-hidden bg-[#6b6b6b]', className)}>
+    <Image src={listing.thumbnailUrl} alt={listing.name} fill className="object-cover" />
+    {isCompleted && <div className="absolute inset-0 bg-white/70" />}
+  </div>
+)
+
+// [refactored] listing의 문의/관심/조회 카운트를 넘기는 ListingStats 래퍼 (3곳 prop 반복 제거)
+const CardStats = ({
+  listing,
+  size,
+  className,
+}: {
+  listing: AdoptionListingCard
+  size?: 'sm' | 'md' | 'lg'
+  className?: string
+}) => (
+  <ListingStats
+    inquiryCount={listing.inquiryCount}
+    favoriteCount={listing.favoriteCount}
+    viewCount={listing.viewCount}
+    size={size}
+    className={className}
+  />
+)
+
 /* ═══════════════════════════════════════════════
    세로형 카드 (Figma)
-   - 모바일: medium (796-81670) — rounded-4, 하트 이미지 오버레이, 제목=품종명, stats 12px
-   - 태블릿+: large (796-81669) — rounded-8, 제목=품종ǀ성별 나이, 하트+관심있어요 텍스트
+   - 모바일: medium (1023-40492) — rounded-4, 상/하 2행(제목·배지 / stats·하트), 제목=품종명, stats 12px
+   - 태블릿+: large (796-81669) — rounded-8, 좌/우 2단(제목·stats / 배지·관심있어요), 제목=품종ǀ성별 나이
    ═══════════════════════════════════════════════ */
 const AdoptionCard = ({ listing, className }: AdoptionCardProps) => {
   const isCompleted = listing.status === 'completed'
 
   return (
     <Link href={`/adoption/${listing.listingId}`} className={cn('block', className)}>
-      {/* ══════ 모바일 카드 (Figma 796-81670, medium) ══════ */}
+      {/* ══════ 모바일 카드 (Figma 1023-40492, medium) ══════ */}
       <div className="flex flex-col tab:hidden">
-        {/* 이미지: aspect 348/284, rounded-4, bg #6b6b6b, 하트 오버레이(우하단, 회색 #a6a6a6) */}
-        <div className="relative aspect-[348/284] w-full overflow-hidden rounded-[0.25rem] bg-[#6b6b6b]">
-          <Image src={listing.thumbnailUrl} alt={listing.name} fill className="object-cover" />
-          {isCompleted && <div className="absolute inset-0 bg-white/70" />}
-          <button type="button" className="absolute right-[0.5rem] bottom-[0.5rem]">
-            <FavoriteIcon className="size-9 text-[#a6a6a6]" />
-          </button>
-        </div>
+        {/* [refactored] 이미지 공통 컴포넌트 — rounded-4 */}
+        <CardImage listing={listing} isCompleted={isCompleted} className="rounded-[0.25rem]" />
 
-        {/* 정보: p-8, 좌(제목/stats) · 우(상태배지) */}
-        <div className="flex min-h-[5rem] justify-between gap-[0.5rem] p-[0.5rem]">
-          <div className="flex min-w-0 flex-1 flex-col justify-between">
-            <p className="line-clamp-2 text-[0.875rem] leading-[1.5] font-semibold text-[#3e3e3e]">
+        {/* 정보: p-8, 상단(제목/배지) · 하단(stats/하트) 2행 (Figma 796-81620) */}
+        <div className="flex min-h-[5rem] flex-col justify-between gap-[0.5rem] p-[0.5rem]">
+          {/* 상단: 제목 + 입양가능 배지 */}
+          <div className="flex items-start justify-between gap-[0.5rem]">
+            <p className="line-clamp-2 min-w-0 flex-1 text-[0.875rem] leading-[1.5] font-semibold text-[#3e3e3e]">
               {listing.name}
             </p>
-            <ListingStats
-              inquiryCount={listing.inquiryCount}
-              favoriteCount={listing.favoriteCount}
-              viewCount={listing.viewCount}
-              className="gap-[0.25rem] text-[0.75rem] leading-[1.5] text-[#6b6b6b]"
-            />
+            <Badge variant={STATUS_BADGE_VARIANT[listing.status]} size="md" className="shrink-0">
+              {ADOPTION_STATUS_LABEL[listing.status]}
+            </Badge>
           </div>
-          <Badge
-            variant={STATUS_BADGE_VARIANT[listing.status]}
-            size="md"
-            className="shrink-0 self-start"
-          >
-            {ADOPTION_STATUS_LABEL[listing.status]}
-          </Badge>
+          {/* 하단: 문의/관심/조회 + 하트 */}
+          <div className="flex items-end justify-between gap-[0.5rem]">
+            <CardStats
+              listing={listing}
+              className="gap-[0.25rem] text-[0.75rem] leading-[1.5] whitespace-nowrap text-[#6b6b6b]"
+            />
+            <button type="button" className="shrink-0">
+              <FavoriteIcon className="size-6 text-[#a6a6a6]" />
+            </button>
+          </div>
         </div>
       </div>
 
       {/* ══════ 태블릿+ 카드 (Figma 796-81669, large) ══════ */}
       {/* 카드 배경 없음 — 이미지만 rounded-8, 정보는 2단(제목/stats · 상태배지/관심있어요) */}
       <div className="hidden h-full flex-col tab:flex">
-        {/* 이미지: aspect 348/284, rounded-8, bg #6b6b6b */}
-        <div className="relative aspect-[348/284] w-full overflow-hidden rounded-[0.5rem] bg-[#6b6b6b]">
-          <Image src={listing.thumbnailUrl} alt={listing.name} fill className="object-cover" />
-          {isCompleted && <div className="absolute inset-0 bg-white/70" />}
-        </div>
+        {/* [refactored] 이미지 공통 컴포넌트 — rounded-8 */}
+        <CardImage listing={listing} isCompleted={isCompleted} className="rounded-[0.5rem]" />
 
         {/* 정보: flex-1, p-12, 좌(제목/stats) · 우(상태배지/관심있어요) */}
         <div className="flex min-h-[7.5rem] flex-1 justify-between gap-[0.5rem] p-[0.75rem]">
@@ -87,10 +114,8 @@ const AdoptionCard = ({ listing, className }: AdoptionCardProps) => {
             <p className="line-clamp-2 text-[1rem] leading-[1.5] font-semibold text-[#3e3e3e]">
               {`${listing.name} | ${GENDER_LABEL[listing.gender]} ${listing.ageText}`}
             </p>
-            <ListingStats
-              inquiryCount={listing.inquiryCount}
-              favoriteCount={listing.favoriteCount}
-              viewCount={listing.viewCount}
+            <CardStats
+              listing={listing}
               className="gap-[0.5rem] text-[0.875rem] leading-[1.5] text-[#6b6b6b]"
             />
           </div>
@@ -151,13 +176,7 @@ const AdoptionCardHorizontal = ({ listing, className }: AdoptionCardProps) => {
 
         {/* 문의/관심/조회 + 관심있어요 */}
         <div className="flex flex-col items-end">
-          <ListingStats
-            inquiryCount={listing.inquiryCount}
-            favoriteCount={listing.favoriteCount}
-            viewCount={listing.viewCount}
-            size="sm"
-            className="w-full justify-end"
-          />
+          <CardStats listing={listing} size="sm" className="w-full justify-end" />
           <FavoriteButton size="sm" />
         </div>
       </div>


### PR DESCRIPTION
## 변경 사항

### 모바일 카드 (Figma 1023-40492)
- 이미지의 하트 오버레이 제거
- 정보영역을 **상단(제목 / 입양가능 배지)** · **하단(문의·관심·조회 / 하트 아이콘)** 2행 구조로
- stats `whitespace-nowrap`로 좁은 폭에서 줄바꿈 방지

### 리팩토링
- 카드 이미지(이미지 + 분양완료 오버레이) → `CardImage` 서브 컴포넌트 (모바일/태블릿 2회 중복 제거)
- `ListingStats` 카운트 prop 반복 → `CardStats`(listing 전달) 래퍼 (3곳 중복 제거)

## 검증
모바일(375) / 태블릿·PC 확인, type-check 통과 / lint 클린

Closes #123