### PR TITLE
feat(search): 검색바 input 전환 + 포커스 스타일(border #256EF4)

### DIFF
--- a/src/app/(main)/explore/_ui/ExploreFilterBar.tsx
+++ b/src/app/(main)/explore/_ui/ExploreFilterBar.tsx
@@ -58,11 +58,20 @@ const ExploreFilterBar = ({ selected, onChange, className }: ExploreFilterBarPro
             필터
           </button>
 
-          {/* 전체폭 검색바 */}
+          {/* 전체폭 검색바 (input) — 포커스 시 border #256EF4(1px) */}
           <div
-            className={cn(PILL_BASE, 'min-w-0 flex-1 justify-between gap-2 border-[#a6a6a6] px-2')}
+            className={cn(
+              PILL_BASE,
+              'min-w-0 flex-1 justify-between gap-2 border-[#a6a6a6] px-2 focus-within:border-[#256ef4]',
+            )}
           >
-            {searchContent}
+            <input
+              autoFocus
+              type="text"
+              placeholder="검색"
+              className="min-w-0 flex-1 bg-transparent text-[0.875rem] font-semibold text-[#3e3e3e] outline-none placeholder:text-[#6b6b6b]"
+            />
+            <SearchIcon className="size-5 shrink-0 text-[#6b6b6b]" />
           </div>
         </>
       ) : (

--- a/src/shared/ui/SearchBar.tsx
+++ b/src/shared/ui/SearchBar.tsx
@@ -1,4 +1,7 @@
+'use client'
+
 import { cn } from '@/shared/lib/cn'
+import { useBreakpoint } from '@/shared/lib/useBreakpoint'
 import { SearchIcon } from './SearchIcon'
 
 interface SearchBarProps {
@@ -14,19 +17,23 @@ const DEFAULT_PLACEHOLDER = {
   desktop: '검색해서 원하는 아이 찾기',
 }
 
-// Figma: h56 / rounded8 / border #a6a6a6 / p12, placeholder Pretendard medium 16px #a6a6a6, 우측 32px 검색 아이콘
+// Figma: h56 / rounded8 / border #a6a6a6(포커스 #256EF4 — 모바일·탭 1px / PC 2px) / p12,
+// 입력 텍스트 #3E3E3E, placeholder Pretendard medium 16px #a6a6a6, 우측 32px 검색 아이콘
 export const SearchBar = ({ placeholder = DEFAULT_PLACEHOLDER, className }: SearchBarProps) => {
+  const isTablet = useBreakpoint('tab')
+
   return (
     <div
       className={cn(
-        'flex h-14 w-full items-center justify-between gap-3 rounded-lg border border-[#a6a6a6] bg-white p-3',
+        'flex h-14 w-full items-center justify-between gap-3 rounded-lg border border-[#a6a6a6] bg-white p-3 focus-within:border-[#256ef4] pc:focus-within:border-2',
         className,
       )}
     >
-      <span className="min-w-0 flex-1 truncate text-base leading-[1.5] font-medium text-[#a6a6a6]">
-        <span className="tab:hidden">{placeholder.mobile}</span>
-        <span className="hidden tab:inline">{placeholder.desktop}</span>
-      </span>
+      <input
+        type="text"
+        placeholder={isTablet ? placeholder.desktop : placeholder.mobile}
+        className="min-w-0 flex-1 bg-transparent text-base leading-[1.5] font-medium text-[#3e3e3e] outline-none placeholder:text-[#a6a6a6]"
+      />
       <SearchIcon className="size-8 shrink-0 text-[#6b6b6b]" />
     </div>
   )


### PR DESCRIPTION
## 변경 사항

- 검색바를 `div` → **`input`** 으로 전환 (포커스/입력 가능)
  - 포커스 시 border **#256EF4** (SearchBar: 모바일·탭 1px / PC 2px, ExploreFilterBar 검색 pill: 1px)
  - 입력 텍스트 **#3E3E3E**, placeholder #a6a6a6(#6b6b6b)
  - 반응형 placeholder는 `useBreakpoint`로 유지
- `ExploreFilterBar` 펼친 검색바도 `<input>`(autofocus)로 전환

## 검증
headless(CDP)로 포커스/입력 + 파란 border 확인, type-check 통과 / lint 클린

Closes #129