### PR TITLE
feat(adoption): 입양 카드 관심(좋아요) 토글 mutation 연결

### DIFF
--- a/src/app/(main)/adoption/[id]/_ui/OtherListingCard.tsx
+++ b/src/app/(main)/adoption/[id]/_ui/OtherListingCard.tsx
@@ -1,26 +1,51 @@
+'use client'
+
 import Image from 'next/image'
 import { Badge, FavoriteButton, ListingStats } from '@/shared/ui'
 import { ShareIcon } from '@/shared/assets/icons'
 import { ADOPTION_STATUS_LABEL, GENDER_LABEL } from '@/shared/types'
 import { AdoptionCardHorizontal } from '@/entities/adoption'
+import { useToggleAdoptionFavorite } from '@/features/adoption'
 import type { AdoptionListingCard } from '@/shared/types'
 
 const OtherListingCard = ({ listing }: { listing: AdoptionListingCard }) => {
+  // 모바일/데스크탑 변형이 같은 관심 상태를 공유하도록 부모에서 토글 훅 호출
+  const { isFavorite, toggleFavorite } = useToggleAdoptionFavorite(
+    listing.listingId,
+    listing.isFavorited,
+  )
+
   return (
     <>
       {/* 모바일: 가로형 카드 */}
       <div className="tab:hidden">
-        <AdoptionCardHorizontal listing={listing} />
+        <AdoptionCardHorizontal
+          listing={listing}
+          isFavorite={isFavorite}
+          onToggle={toggleFavorite}
+        />
       </div>
       {/* 데스크탑: 가로형 큰 카드 */}
       <div className="hidden tab:block">
-        <DesktopOtherListingCard listing={listing} />
+        <DesktopOtherListingCard
+          listing={listing}
+          isFavorite={isFavorite}
+          onToggle={toggleFavorite}
+        />
       </div>
     </>
   )
 }
 
-const DesktopOtherListingCard = ({ listing }: { listing: AdoptionListingCard }) => (
+const DesktopOtherListingCard = ({
+  listing,
+  isFavorite,
+  onToggle,
+}: {
+  listing: AdoptionListingCard
+  isFavorite: boolean
+  onToggle: () => void
+}) => (
   <div className="flex overflow-hidden rounded-[1rem] bg-[#e7e7e7]">
     <div className="relative h-[21.75rem] w-[20.1875rem] shrink-0 overflow-hidden rounded-[0.5rem] bg-[#c6c6c6]">
       <Image src={listing.thumbnailUrl} alt={listing.name} fill className="object-cover" />
@@ -55,7 +80,7 @@ const DesktopOtherListingCard = ({ listing }: { listing: AdoptionListingCard }) 
         className="mt-auto justify-end"
       />
       <div className="mt-[0.5rem] flex items-center justify-end gap-[0.625rem]">
-        <FavoriteButton size="lg" />
+        <FavoriteButton size="lg" isFavorite={isFavorite} onToggle={onToggle} />
         <button
           type="button"
           className="flex items-center gap-[0.625rem] rounded-full p-[0.625rem] text-[0.875rem] font-medium text-[#5d5d5d]"

--- a/src/app/(main)/adoption/my-listings/_ui/MyListingsContent.tsx
+++ b/src/app/(main)/adoption/my-listings/_ui/MyListingsContent.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link'
 import { Container, PageHeader, Separator } from '@/shared/ui'
-import { AdoptionCard } from '@/entities/adoption'
+import { FavoriteAdoptionCard } from '@/features/adoption'
 import { createMockListings } from '@/shared/mocks/adoption'
 import { useListingsFilter } from '../_lib/useListingsFilter'
 import { StatusFilterChips } from './StatusFilterChips'
@@ -65,7 +65,7 @@ const MyListingsContent = () => {
             {/* Desktop: 3열 그리드 */}
             <div className="hidden tab:mt-6 tab:grid tab:grid-cols-3 tab:gap-6 tab:pb-8">
               {filteredListings.map((listing) => (
-                <AdoptionCard key={listing.listingId} listing={listing} />
+                <FavoriteAdoptionCard key={listing.listingId} listing={listing} />
               ))}
             </div>
           </>

--- a/src/app/(main)/bookmarks/_ui/FavoritesTab.tsx
+++ b/src/app/(main)/bookmarks/_ui/FavoritesTab.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { Container, SectionHeader } from '@/shared/ui'
-import { AdoptionCard } from '@/entities/adoption'
+import { FavoriteAdoptionCard } from '@/features/adoption'
 import type { AdoptionListingCard } from '@/shared/types'
 
 interface FavoritesTabProps {
@@ -21,14 +21,14 @@ const FavoritesTab = ({ listings }: FavoritesTabProps) => (
     {/* 모바일: 2열 그리드 */}
     <div className="grid grid-cols-2 gap-4 pt-3 pb-15 tab:hidden">
       {listings.map((listing) => (
-        <AdoptionCard key={listing.listingId} listing={listing} />
+        <FavoriteAdoptionCard key={listing.listingId} listing={listing} />
       ))}
     </div>
 
     {/* PC: 3열 그리드 */}
     <div className="hidden tab:mt-6 tab:grid tab:grid-cols-3 tab:gap-[1.156rem] tab:pb-10">
       {listings.map((listing) => (
-        <AdoptionCard key={listing.listingId} listing={listing} />
+        <FavoriteAdoptionCard key={listing.listingId} listing={listing} />
       ))}
     </div>
   </Container>

--- a/src/app/(main)/explore/_ui/AdoptionListingSection.tsx
+++ b/src/app/(main)/explore/_ui/AdoptionListingSection.tsx
@@ -1,4 +1,4 @@
-import { AdoptionCard } from '@/entities/adoption'
+import { FavoriteAdoptionCard } from '@/features/adoption'
 import { cn } from '@/shared/lib/cn'
 import type { AdoptionListingCard } from '@/shared/types'
 import { CollapsibleSection } from './CollapsibleSection'
@@ -27,7 +27,7 @@ const AdoptionListingSection = ({ title, listings, className }: AdoptionListingS
     >
       <div className={CARD_GRID}>
         {listings.map((listing) => (
-          <AdoptionCard key={listing.listingId} listing={listing} />
+          <FavoriteAdoptionCard key={listing.listingId} listing={listing} />
         ))}
       </div>
     </CollapsibleSection>

--- a/src/app/(main)/home/[userId]/_ui/BreederHomeContent.tsx
+++ b/src/app/(main)/home/[userId]/_ui/BreederHomeContent.tsx
@@ -9,7 +9,7 @@ import { createMockListings } from '@/shared/mocks/adoption'
 import { breederQueries } from '@/entities/breeder'
 import { ProfileCard } from '../../_ui/ProfileCard'
 import { BreederListingCard } from '../../_ui/BreederListingCard'
-import { AdoptionCard } from '@/entities/adoption'
+import { FavoriteAdoptionCard } from '@/features/adoption'
 import { HomeTabs, TabsContent } from '../../_ui/HomeTabs'
 import { HomeTitle } from '../../_ui/HomeTitle'
 import { PostList } from '../../_ui/PostList'
@@ -56,7 +56,7 @@ const BreederHomeContent = ({ userId }: BreederHomeContentProps) => {
             {/* Desktop */}
             <div className="hidden tab:mt-[2.959rem] tab:grid tab:grid-cols-3 tab:gap-6">
               {listings.map((listing) => (
-                <AdoptionCard key={listing.listingId} listing={listing} />
+                <FavoriteAdoptionCard key={listing.listingId} listing={listing} />
               ))}
             </div>
           </Container>

--- a/src/app/(main)/home/_ui/MyHomeContent.tsx
+++ b/src/app/(main)/home/_ui/MyHomeContent.tsx
@@ -9,7 +9,7 @@ import { createMockListings } from '@/shared/mocks/adoption'
 import { adopterQueries } from '@/entities/adopter'
 import { breederQueries } from '@/entities/breeder'
 import type { AdopterPublicProfile, BreederPublicProfile } from '@/shared/types'
-import { AdoptionCard } from '@/entities/adoption'
+import { FavoriteAdoptionCard } from '@/features/adoption'
 import { ProfileCard } from './ProfileCard'
 import { HomeTabs, TabsContent } from './HomeTabs'
 import { HomeTitle } from './HomeTitle'
@@ -111,7 +111,7 @@ const MyHomeContent = () => {
               {/* Desktop */}
               <div className="hidden tab:mt-6 tab:grid tab:grid-cols-3 tab:gap-6">
                 {listings.map((listing) => (
-                  <AdoptionCard key={listing.listingId} listing={listing} />
+                  <FavoriteAdoptionCard key={listing.listingId} listing={listing} />
                 ))}
               </div>
             </Container>

--- a/src/entities/adoption/ui/AdoptionCard.tsx
+++ b/src/entities/adoption/ui/AdoptionCard.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { type MouseEvent } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
 import { cn } from '@/shared/lib/cn'
@@ -25,6 +26,9 @@ const STATUS_BADGE_VARIANT: Record<AdoptionListingCard['status'], 'active' | 'di
 interface AdoptionCardProps {
   listing: AdoptionListingCard
   className?: string
+  // 제어형 관심 상태 — mutation 연결은 features 레이어 래퍼(FavoriteAdoptionCard)에서 주입
+  isFavorite?: boolean
+  onToggle?: () => void
 }
 
 // [refactored] 세로형 카드 이미지(이미지 + 분양완료 오버레이) — 모바일/태블릿 공통, rounded만 className으로 차이
@@ -67,8 +71,15 @@ const CardStats = ({
    - 모바일: medium (1023-40492) — rounded-4, 상/하 2행(제목·배지 / stats·하트), 제목=품종명, stats 12px
    - 태블릿+: large (796-81669) — rounded-8, 좌/우 2단(제목·stats / 배지·관심있어요), 제목=품종ǀ성별 나이
    ═══════════════════════════════════════════════ */
-const AdoptionCard = ({ listing, className }: AdoptionCardProps) => {
+const AdoptionCard = ({ listing, className, isFavorite, onToggle }: AdoptionCardProps) => {
   const isCompleted = listing.status === 'completed'
+
+  // 카드 Link 내부의 하트 클릭 시 네비게이션 방지 + 관심 토글
+  const handleFavoriteClick = (e: MouseEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    onToggle?.()
+  }
 
   return (
     <Link href={`/adoption/${listing.listingId}`} className={cn('block', className)}>
@@ -94,8 +105,10 @@ const AdoptionCard = ({ listing, className }: AdoptionCardProps) => {
               listing={listing}
               className="gap-[0.25rem] text-[0.75rem] leading-[1.5] whitespace-nowrap text-[#6b6b6b]"
             />
-            <button type="button" className="shrink-0">
-              <FavoriteIcon className="size-6 text-[#a6a6a6]" />
+            <button type="button" onClick={handleFavoriteClick} className="shrink-0">
+              <FavoriteIcon
+                className={cn('size-6', isFavorite ? 'text-[#ff8181]' : 'text-[#a6a6a6]')}
+              />
             </button>
           </div>
         </div>
@@ -126,6 +139,8 @@ const AdoptionCard = ({ listing, className }: AdoptionCardProps) => {
             </Badge>
             <FavoriteButton
               size="md"
+              isFavorite={isFavorite}
+              onToggle={onToggle}
               className="gap-[0.25rem] p-0 text-[0.75rem] font-semibold text-[#3e3e3e]"
               iconClassName="size-6 text-[#a6a6a6]"
             />
@@ -140,7 +155,12 @@ const AdoptionCard = ({ listing, className }: AdoptionCardProps) => {
    가로형 카드 — 모바일 인기 동물 섹션 전용
    피그마: bg #f0f0f0, rounded 6, px8 py7, img 100x100
    ═══════════════════════════════════════════════ */
-const AdoptionCardHorizontal = ({ listing, className }: AdoptionCardProps) => {
+const AdoptionCardHorizontal = ({
+  listing,
+  className,
+  isFavorite,
+  onToggle,
+}: AdoptionCardProps) => {
   return (
     <Link
       href={`/adoption/${listing.listingId}`}
@@ -177,7 +197,7 @@ const AdoptionCardHorizontal = ({ listing, className }: AdoptionCardProps) => {
         {/* 문의/관심/조회 + 관심있어요 */}
         <div className="flex flex-col items-end">
           <CardStats listing={listing} size="sm" className="w-full justify-end" />
-          <FavoriteButton size="sm" />
+          <FavoriteButton size="sm" isFavorite={isFavorite} onToggle={onToggle} />
         </div>
       </div>
 

--- a/src/features/adoption/api/adoption.mutations.ts
+++ b/src/features/adoption/api/adoption.mutations.ts
@@ -1,5 +1,6 @@
 'use client'
 
+import { useState } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { adoptionQueries } from '@/entities/adoption'
 import type { CreateAdoptionApplicationRequest } from '@/shared/types'
@@ -27,6 +28,26 @@ export const useRemoveAdoptionFavorite = () => {
       void qc.invalidateQueries({ queryKey: adoptionQueries.all() })
     },
   })
+}
+
+/**
+ * 관심(좋아요) 토글 — 낙관적 UI 상태 + add/remove mutation 연결.
+ * 카드가 mock 데이터라 실제 API는 404일 수 있으므로 낙관적 상태를 유지(롤백 없음)한다.
+ * 백엔드 연동 후에는 onError 롤백을 추가한다.
+ */
+export const useToggleAdoptionFavorite = (petId: string, initialFavorite: boolean) => {
+  const [isFavorite, setIsFavorite] = useState(initialFavorite)
+  const addFavorite = useAddAdoptionFavorite()
+  const removeFavorite = useRemoveAdoptionFavorite()
+
+  const toggleFavorite = () => {
+    const next = !isFavorite
+    setIsFavorite(next)
+    if (next) addFavorite.mutate(petId)
+    else removeFavorite.mutate(petId)
+  }
+
+  return { isFavorite, toggleFavorite }
 }
 
 export const useCreateAdoptionApplication = () => {

--- a/src/features/adoption/index.ts
+++ b/src/features/adoption/index.ts
@@ -1,1 +1,2 @@
 export * from './api/adoption.mutations'
+export { FavoriteAdoptionCard, FavoriteAdoptionCardHorizontal } from './ui/FavoriteAdoptionCard'

--- a/src/features/adoption/ui/FavoriteAdoptionCard.tsx
+++ b/src/features/adoption/ui/FavoriteAdoptionCard.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import { AdoptionCard, AdoptionCardHorizontal } from '@/entities/adoption'
+import type { AdoptionListingCard } from '@/shared/types'
+import { useToggleAdoptionFavorite } from '../api/adoption.mutations'
+
+interface FavoriteAdoptionCardProps {
+  listing: AdoptionListingCard
+  className?: string
+}
+
+/**
+ * entities의 프레젠테이셔널 카드에 관심(좋아요) mutation을 연결한 features 레이어 래퍼.
+ * (entities → features 역방향 import 금지이므로 연결은 이 래퍼에서 수행)
+ */
+// [refactored] 세로형/가로형 래퍼가 렌더 카드만 다르고 훅·prop 주입이 동일 → 팩토리로 통합
+const createFavoriteCard = (
+  Card: typeof AdoptionCard | typeof AdoptionCardHorizontal,
+  displayName: string,
+) => {
+  const FavoriteCard = ({ listing, className }: FavoriteAdoptionCardProps) => {
+    const { isFavorite, toggleFavorite } = useToggleAdoptionFavorite(
+      listing.listingId,
+      listing.isFavorited,
+    )
+
+    return (
+      <Card
+        listing={listing}
+        className={className}
+        isFavorite={isFavorite}
+        onToggle={toggleFavorite}
+      />
+    )
+  }
+  FavoriteCard.displayName = displayName
+  return FavoriteCard
+}
+
+const FavoriteAdoptionCard = createFavoriteCard(AdoptionCard, 'FavoriteAdoptionCard')
+const FavoriteAdoptionCardHorizontal = createFavoriteCard(
+  AdoptionCardHorizontal,
+  'FavoriteAdoptionCardHorizontal',
+)
+
+export { FavoriteAdoptionCard, FavoriteAdoptionCardHorizontal }

--- a/src/shared/ui/FavoriteButton.tsx
+++ b/src/shared/ui/FavoriteButton.tsx
@@ -1,3 +1,6 @@
+'use client'
+
+import { type MouseEvent } from 'react'
 import { tv, type VariantProps } from 'tailwind-variants'
 import { cn } from '@/shared/lib/cn'
 import { FavoriteIcon } from '@/shared/assets/icons'
@@ -23,23 +26,38 @@ const favoriteIconSize = {
 interface FavoriteButtonProps extends VariantProps<typeof favoriteButtonVariants> {
   className?: string
   iconClassName?: string
-  onClick?: () => void
+  // 제어형: 관심 여부와 토글 콜백은 상위(카드)에서 mutation과 연결한다
+  isFavorite?: boolean
+  onToggle?: () => void
 }
 
 const FavoriteButton = ({
   size = 'lg',
   className,
   iconClassName,
-  onClick,
-}: FavoriteButtonProps) => (
-  <button
-    type="button"
-    className={cn(favoriteButtonVariants({ size }), className)}
-    onClick={onClick}
-  >
-    <FavoriteIcon className={cn(favoriteIconSize[size ?? 'lg'], iconClassName)} />
-    <span>관심있어요</span>
-  </button>
-)
+  isFavorite = false,
+  onToggle,
+}: FavoriteButtonProps) => {
+  // 카드 Link 내부에 있을 수 있으므로 클릭 시 네비게이션 방지 + 관심 토글
+  const handleClick = (e: MouseEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    onToggle?.()
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      // 관심 시 하트+텍스트 모두 #FF8181
+      className={cn(favoriteButtonVariants({ size }), className, isFavorite && 'text-[#ff8181]')}
+    >
+      <FavoriteIcon
+        className={cn(favoriteIconSize[size ?? 'lg'], iconClassName, isFavorite && 'text-[#ff8181]')}
+      />
+      <span>관심있어요</span>
+    </button>
+  )
+}
 
 export { FavoriteButton, favoriteButtonVariants }


### PR DESCRIPTION
## 개요
입양 카드의 관심(좋아요) 토글을 로컬 상태에서 TanStack Query mutation 연결로 전환했습니다.

## 변경 사항
- `useToggleAdoptionFavorite(petId, initialFavorite)` 훅 추가 — 낙관적 상태 + add/remove mutation 호출
- `FavoriteButton` 제어형 전환 (`isFavorite` + `onToggle` props, 내부 useState 제거)
- `AdoptionCard` / `AdoptionCardHorizontal` 제어형 props 수용 (모바일 하트 + 관심있어요 버튼)
- features 레이어 래퍼 `FavoriteAdoptionCard` / `FavoriteAdoptionCardHorizontal` 신설 (entities→features 역방향 import 회피, 팩토리로 중복 제거)
- 카드 렌더 6곳 교체: home, breeder-home, my-listings, explore, bookmarks, 입양 상세(OtherListingCard)

## 구조
FSD상 entities는 features를 import할 수 없으므로 카드는 제어형(presentational)으로 두고, mutation 연결은 features 래퍼에서 주입합니다.

## 비고
- 카드가 mock 데이터라 실제 POST/DELETE는 404 가능 — 낙관적 UI만 동작 (백엔드 연동 시 onError 롤백 추가 예정)
- 관심 시 하트+텍스트 #FF8181 적용

Closes #131