### PR TITLE
feat(adoption): 입양 상세 카드(건강/부모/사육환경) 피그마 레이아웃 정비

### DIFF
--- a/src/app/(main)/adoption/[id]/_ui/AdoptionDetailContent.tsx
+++ b/src/app/(main)/adoption/[id]/_ui/AdoptionDetailContent.tsx
@@ -6,6 +6,7 @@ import { Fragment, type ReactNode } from 'react'
 import { useRouter } from 'next/navigation'
 import {
   Badge,
+  Container,
   FavoriteButton,
   ListingStats,
   Separator,
@@ -58,9 +59,9 @@ const AdoptionDetailContent = ({ detail }: AdoptionDetailContentProps) => {
       </div>
 
       {/* ═══ 히어로 섹션 (브레드크럼 + 이미지 + 프로필 | 정보) ═══ */}
-      {/* 피그마: padding 20/80, 가로 2섹션 gap-20, 최대 1280 중앙 정렬 */}
-      <div className="tab:flex tab:justify-center tab:px-[3rem] tab:py-[1.25rem] pc:px-[5rem]">
-        <div className="tab:flex tab:w-full tab:max-w-[80rem] tab:items-start tab:gap-[1.25rem]">
+      {/* [refactored] 공용 Container 사용 (모바일은 풀블리드 이미지 위해 px-0) */}
+      <Container className="px-0 tab:px-[3rem] tab:py-[1.25rem]">
+        <div className="tab:flex tab:items-start tab:gap-[1.25rem]">
           {/* ── 좌측 섹션: 브레드크럼 + 이미지 + 브리더 프로필 ── 피그마: w-500, gap-12 */}
           <div className="relative tab:flex tab:w-[31.25rem] tab:shrink-0 tab:flex-col tab:gap-[0.75rem]">
             {/* 브레드크럼 (데스크탑 전용) — 피그마: 라벨(body/md/bold 14px #6b6b6b) + chevron */}
@@ -218,33 +219,34 @@ const AdoptionDetailContent = ({ detail }: AdoptionDetailContentProps) => {
             </div>
           </div>
         </div>
-      </div>
+      </Container>
 
-      {/* ═══ 건강 정보 + 부모 정보 섹션 ═══ */}
-      <div className="mt-[1.25rem] px-[1.25rem] tab:mt-[2rem] tab:flex tab:gap-[1.25rem] tab:px-[3rem] pc:px-[5rem]">
-        {/* 건강 정보 카드 */}
-        <HealthInfoCard detail={detail} />
-        {/* 부모 정보 카드 */}
-        <ParentInfoCard detail={detail} onImageClick={openImageModal} />
-      </div>
-
-      {/* ═══ 사육 환경 섹션 ═══ */}
-      <div className="mt-[1.25rem] px-[1.25rem] tab:mt-[2rem] tab:px-[3rem] pc:px-[5rem]">
-        <BreedingEnvironmentCard detail={detail} onImageClick={openImageModal} />
-      </div>
-
-      {/* ═══ 브리더의 다른 분양 동물 ═══ */}
-      <div className="mt-[1.5rem] px-[1.25rem] tab:mt-[2rem] tab:px-[3rem] pc:px-[5rem]">
-        <Separator className="mb-[1rem] bg-[#d4d4d4]" />
-        <p className="text-[0.75rem] leading-[1.375rem] font-medium text-[#5d5d5d] tab:text-[1.25rem] tab:font-semibold">
-          브리더의 다른 분양 동물 {detail.otherListings.length}
-        </p>
-        <div className="mt-[0.75rem] flex flex-col gap-[0.75rem] tab:mt-[1.3125rem] tab:gap-[1.3125rem]">
-          {detail.otherListings.map((listing) => (
-            <OtherListingCard key={listing.listingId} listing={listing} />
-          ))}
+      {/* ═══ 하단 콘텐츠 — [refactored] 히어로와 동일 공용 Container 사용 ═══ */}
+      <Container className="tab:py-[1.25rem]">
+        {/* 건강 정보 + 부모 정보 섹션 */}
+        <div className="mt-[1.25rem] tab:mt-0 tab:flex tab:gap-[1.25rem]">
+          <HealthInfoCard detail={detail} />
+          <ParentInfoCard detail={detail} onImageClick={openImageModal} />
         </div>
-      </div>
+
+        {/* 사육 환경 섹션 */}
+        <div className="mt-[1.25rem] tab:mt-[2rem]">
+          <BreedingEnvironmentCard detail={detail} onImageClick={openImageModal} />
+        </div>
+
+        {/* 브리더의 다른 분양 동물 */}
+        <div className="mt-[1.5rem] tab:mt-[2rem]">
+          <Separator className="mb-[1rem] bg-[#d4d4d4]" />
+          <p className="text-[0.75rem] leading-[1.375rem] font-medium text-[#5d5d5d] tab:text-[1.25rem] tab:font-semibold">
+            브리더의 다른 분양 동물 {detail.otherListings.length}
+          </p>
+          <div className="mt-[0.75rem] flex flex-col gap-[0.75rem] tab:mt-[1.3125rem] tab:gap-[1.3125rem]">
+            {detail.otherListings.map((listing) => (
+              <OtherListingCard key={listing.listingId} listing={listing} />
+            ))}
+          </div>
+        </div>
+      </Container>
 
       {/* ═══ CTA 하단 고정 바 ═══ */}
       <div className="fixed right-0 bottom-0 left-0 z-10 bg-white p-[1.25rem] tab:flex tab:items-center tab:justify-center tab:py-[1.4375rem]">

--- a/src/app/(main)/adoption/[id]/_ui/BaseInfoCard.tsx
+++ b/src/app/(main)/adoption/[id]/_ui/BaseInfoCard.tsx
@@ -10,14 +10,14 @@ interface BaseInfoCardProps {
 const BaseInfoCard = ({ title, className, children }: BaseInfoCardProps) => (
   <div
     className={cn(
-      'overflow-hidden rounded-[1rem] bg-[#f5f5f5] p-[0.875rem] tab:p-[1.75rem]',
+      'overflow-hidden rounded-[1rem] bg-[#f5f5f5] p-[0.875rem] tab:p-[1.25rem]',
       className,
     )}
   >
     <p className="text-[0.75rem] leading-[1.375rem] font-medium text-[#5d5d5d] tab:text-[1.25rem] tab:font-semibold">
       {title}
     </p>
-    <div className="mt-[1rem] tab:mt-[1.5rem]">{children}</div>
+    <div className="mt-[1rem] tab:mt-[1.25rem]">{children}</div>
   </div>
 )
 

--- a/src/app/(main)/adoption/[id]/_ui/BreedingEnvironmentCard.tsx
+++ b/src/app/(main)/adoption/[id]/_ui/BreedingEnvironmentCard.tsx
@@ -1,10 +1,7 @@
 'use client'
 
 import Image from 'next/image'
-import { Swiper, SwiperSlide } from 'swiper/react'
-import { Pagination } from 'swiper/modules'
-import 'swiper/css'
-import 'swiper/css/pagination'
+import { cn } from '@/shared/lib/cn'
 import type { AdoptionDetailDto } from '@/shared/types'
 
 interface BreedingEnvironmentCardProps {
@@ -12,11 +9,32 @@ interface BreedingEnvironmentCardProps {
   onImageClick?: (images: string[], index?: number) => void
 }
 
+// [refactored] 사육 환경 이미지 버튼 — 모바일/데스크탑 중복 제거 (크기만 className)
+const EnvImageButton = ({
+  src,
+  index,
+  className,
+  onClick,
+}: {
+  src: string
+  index: number
+  className: string
+  onClick?: () => void
+}) => (
+  <button
+    type="button"
+    onClick={onClick}
+    className={cn('relative shrink-0 overflow-hidden rounded-[0.5rem] bg-[#c6c6c6]', className)}
+  >
+    <Image src={src} alt={`사육 환경 ${index + 1}`} fill className="object-cover" />
+  </button>
+)
+
 const BreedingEnvironmentCard = ({ detail, onImageClick }: BreedingEnvironmentCardProps) => {
   const { description, imageUrls } = detail.breedingEnvironment
 
   return (
-    <div className="overflow-hidden rounded-[1rem] bg-[#f5f5f5] p-[0.875rem] tab:p-[1.75rem]">
+    <div className="overflow-hidden rounded-[1rem] bg-[#f5f5f5] p-[0.875rem] tab:p-[1.25rem]">
       {/* 모바일: 세로 레이아웃 */}
       <div className="tab:hidden">
         <p className="text-[0.75rem] leading-[1.375rem] font-medium text-[#5d5d5d]">사육 환경</p>
@@ -24,48 +42,35 @@ const BreedingEnvironmentCard = ({ detail, onImageClick }: BreedingEnvironmentCa
           {description}
         </p>
         <div className="mt-[0.75rem] flex gap-[0.6875rem] overflow-x-auto">
+          {/* [refactored] EnvImageButton 사용 */}
           {imageUrls.map((url, i) => (
-            <button
-              type="button"
+            <EnvImageButton
               key={`env-mo-${i}`}
+              src={url}
+              index={i}
               onClick={() => onImageClick?.(imageUrls, i)}
-              className="relative h-[8.125rem] w-[11.9375rem] shrink-0 overflow-hidden rounded-[0.5rem] bg-[#c6c6c6]"
-            >
-              <Image src={url} alt={`사육 환경 ${i + 1}`} fill className="object-cover" />
-            </button>
+              className="h-[8.125rem] w-[11.9375rem]"
+            />
           ))}
         </div>
       </div>
 
-      {/* 데스크탑: 좌측 Swiper 이미지 + 우측 텍스트 */}
-      <div className="hidden tab:flex tab:gap-[2rem]">
-        <div className="h-[24.5rem] w-[35.9375rem] shrink-0 overflow-hidden rounded-[0.5rem]">
-          <Swiper
-            modules={[Pagination]}
-            pagination={{ clickable: true }}
-            className="size-full [&_.swiper-pagination-bullet]:bg-white/70 [&_.swiper-pagination-bullet-active]:bg-[#2f2f2f]"
-          >
-            {imageUrls.map((url, i) => (
-              <SwiperSlide key={`env-pc-${i}`}>
-                <button
-                  type="button"
-                  onClick={() => onImageClick?.(imageUrls, i)}
-                  className="relative size-full"
-                >
-                  <Image src={url} alt={`사육 환경 ${i + 1}`} fill className="object-cover" />
-                </button>
-              </SwiperSlide>
-            ))}
-          </Swiper>
+      {/* 데스크탑: 세로 — 제목 → 이미지 스트립(320×240) → 설명 (피그마 1226-46244 environment) */}
+      <div className="hidden tab:flex tab:flex-col tab:gap-[1.25rem]">
+        <p className="text-[1.25rem] leading-[1.5] font-semibold text-[#3e3e3e]">사육 환경</p>
+        <div className="flex gap-[0.75rem] overflow-x-auto">
+          {/* [refactored] EnvImageButton 사용 */}
+          {imageUrls.map((url, i) => (
+            <EnvImageButton
+              key={`env-pc-${i}`}
+              src={url}
+              index={i}
+              onClick={() => onImageClick?.(imageUrls, i)}
+              className="h-[15rem] w-[20rem]"
+            />
+          ))}
         </div>
-        <div className="flex flex-col justify-center">
-          <p className="text-[1.25rem] leading-[1.375rem] font-semibold text-[#5d5d5d]">
-            사육 환경
-          </p>
-          <p className="mt-[2rem] text-[1rem] leading-[1.375rem] font-semibold text-[#5d5d5d]">
-            {description}
-          </p>
-        </div>
+        <p className="text-[1rem] leading-[1.5] font-semibold text-[#5d5d5d]">{description}</p>
       </div>
     </div>
   )

--- a/src/app/(main)/adoption/[id]/_ui/HealthInfoCard.tsx
+++ b/src/app/(main)/adoption/[id]/_ui/HealthInfoCard.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react'
 import { cn } from '@/shared/lib/cn'
 import { Badge } from '@/shared/ui'
 import { CheckIcon } from '@/shared/assets/icons'
@@ -17,74 +18,82 @@ const CompletionBadge = ({ completed }: { completed: boolean }) => (
   </Badge>
 )
 
+// [refactored] 섹션 헤더(제목 + 검사완료 배지) — 2회 반복 제거
+const SectionHeader = ({ title, completed }: { title: string; completed: boolean }) => (
+  <div className="flex items-center justify-between">
+    <p className="text-[0.875rem] leading-[1.375rem] font-semibold text-[#5d5d5d]">{title}</p>
+    <CompletionBadge completed={completed} />
+  </div>
+)
+
+// [refactored] 피그마 TableLayout 컨테이너 — 반복 className 제거
+const Table = ({ children }: { children: ReactNode }) => (
+  <div className="flex flex-col text-[0.875rem] leading-[1.375rem] font-semibold tab:text-[1rem] tab:leading-[1.5]">
+    {children}
+  </div>
+)
+
+// [refactored] 테이블 행(border #cacaca, gap-8, 기본 py-8) — 7회 반복 제거 (헤더는 className으로 py-4)
+const TableRow = ({ className, children }: { className?: string; children: ReactNode }) => (
+  <div
+    className={cn('flex items-center gap-[0.5rem] border-b border-[#cacaca] py-[0.5rem]', className)}
+  >
+    {children}
+  </div>
+)
+
 const HealthInfoCard = ({ detail }: { detail: AdoptionDetailDto }) => (
-  <BaseInfoCard title="건강 정보" className="tab:flex-1">
-    <div className="flex flex-col gap-[2.1875rem] tab:gap-[2rem]">
+  <BaseInfoCard title="건강 정보" className="tab:flex-1 pc:w-[55.75rem] pc:flex-none">
+    <div className="flex flex-col gap-[2.1875rem] tab:gap-[1.25rem]">
       {/* 예방 접종 현황 */}
       <div className="flex flex-col gap-[0.6875rem]">
-        <div className="flex items-center justify-between">
-          <p className="text-[0.875rem] leading-[1.375rem] font-semibold text-[#5d5d5d]">
-            예방 접종 현황
-          </p>
-          <CompletionBadge completed={detail.health.vaccinationCompleted} />
-        </div>
+        {/* [refactored] SectionHeader 사용 */}
+        <SectionHeader title="예방 접종 현황" completed={detail.health.vaccinationCompleted} />
 
-        <div className="flex flex-col gap-[0.75rem] text-[0.875rem] leading-[1.375rem] text-[#5d5d5d]">
-          <div className="flex items-center border-b border-[#d4d4d4] pb-px font-medium">
-            <span className="min-w-0 flex-1">접종명</span>
-            <div className="flex w-[10.5rem] items-center justify-end tab:w-[13.75rem]">
-              <span className="min-w-0 flex-1">접종일</span>
-              <span className="w-[2.85rem] text-right">차수</span>
-            </div>
-          </div>
+        {/* [refactored] Table/TableRow 사용 (3컬럼: 접종명/접종일/차수) */}
+        <Table>
+          <TableRow className="py-[0.25rem] font-medium text-[#6b6b6b]">
+            <span className="min-w-px flex-1">접종명</span>
+            <span className="min-w-px flex-1">접종일</span>
+            <span className="shrink-0 whitespace-nowrap">차수</span>
+          </TableRow>
           {detail.health.vaccinations.map((v, i) => (
-            <div
-              key={`${v.name}-${v.dose}-${i}`}
-              className="flex items-center border-b border-[#d4d4d4] pb-px font-semibold"
-            >
-              <span className="min-w-0 flex-1">{v.name}</span>
-              <div className="flex w-[10.5rem] items-center justify-end tab:w-[13.75rem]">
-                <span className="min-w-0 flex-1">{v.date}</span>
-                <span className="w-[2.85rem] text-right">{v.dose}</span>
-              </div>
-            </div>
+            <TableRow key={`${v.name}-${v.dose}-${i}`} className="text-[#3e3e3e]">
+              <span className="min-w-px flex-1">{v.name}</span>
+              <span className="min-w-px flex-1">{v.date}</span>
+              <span className="shrink-0 whitespace-nowrap">{v.dose}</span>
+            </TableRow>
           ))}
-        </div>
+        </Table>
       </div>
 
       {/* 유전병 검사 */}
       <div className="flex flex-col gap-[0.75rem]">
-        <div className="flex items-center justify-between">
-          <p className="text-[0.875rem] leading-[1.375rem] font-semibold text-[#5d5d5d]">
-            유전병 검사
-          </p>
-          <CompletionBadge completed={detail.health.geneticTestCompleted} />
-        </div>
+        {/* [refactored] SectionHeader 사용 */}
+        <SectionHeader title="유전병 검사" completed={detail.health.geneticTestCompleted} />
 
-        <div className="flex flex-col gap-[0.75rem] text-[0.875rem] leading-[1.375rem] font-medium text-[#5d5d5d]">
-          <div className="flex items-center border-b border-[#d4d4d4] pb-px">
-            <span className="min-w-0 flex-1">검진일</span>
-            <span className="min-w-0 flex-1 text-right">{detail.health.geneticTest.date}</span>
-          </div>
-          <div className="flex items-center border-b border-[#d4d4d4] pb-px">
-            <span className="min-w-0 flex-1">검사기관</span>
-            <span className="min-w-0 flex-1 text-right">
+        {/* [refactored] Table/TableRow 사용 (접종일 컬럼 없음) */}
+        <Table>
+          <TableRow>
+            <span className="min-w-px flex-1 text-[#6b6b6b]">검진일</span>
+            <span className="shrink-0 whitespace-nowrap text-[#3e3e3e]">
+              {detail.health.geneticTest.date}
+            </span>
+          </TableRow>
+          <TableRow>
+            <span className="min-w-px flex-1 text-[#6b6b6b]">검사기관</span>
+            <span className="shrink-0 whitespace-nowrap text-[#3e3e3e]">
               {detail.health.geneticTest.institution}
             </span>
-          </div>
+          </TableRow>
           {detail.health.geneticTest.results.map((r, i) => (
-            <div
-              key={`${r.disease}-${i}`}
-              className="flex items-center border-b border-[#d4d4d4] pb-px"
-            >
-              <span className="min-w-0 flex-1">{i === 0 ? '결과' : ''}</span>
-              <div className="flex min-w-0 flex-1 items-center text-right">
-                <span className="min-w-0 flex-1">{r.disease}</span>
-                <span className="min-w-0 flex-1">{r.result}</span>
-              </div>
-            </div>
+            <TableRow key={`${r.disease}-${i}`}>
+              <span className="min-w-px flex-1 text-[#6b6b6b]">{i === 0 ? '결과' : ''}</span>
+              <span className="min-w-px flex-1 text-[#3e3e3e]">{r.disease}</span>
+              <span className="shrink-0 whitespace-nowrap text-[#3e3e3e]">{r.result}</span>
+            </TableRow>
           ))}
-        </div>
+        </Table>
       </div>
     </div>
   </BaseInfoCard>

--- a/src/app/(main)/adoption/[id]/_ui/ParentInfoCard.tsx
+++ b/src/app/(main)/adoption/[id]/_ui/ParentInfoCard.tsx
@@ -7,41 +7,44 @@ interface ParentInfoCardProps {
   onImageClick?: (images: string[], index?: number) => void
 }
 
-const ParentInfoCard = ({ detail, onImageClick }: ParentInfoCardProps) => (
-  <BaseInfoCard title="부모 정보" className="mt-[0.75rem] tab:mt-0 tab:w-[26.25rem] tab:shrink-0">
-    <div className="flex flex-col gap-[1rem] tab:gap-[2.5rem]">
-      {detail.parents.map((parent, i) => (
-        <div key={parent.role} className="flex flex-col gap-[0.8125rem]">
-          <div className="flex items-center gap-[0.5625rem] tab:flex-col tab:items-start tab:gap-[0.8125rem]">
-            <button
-              type="button"
-              onClick={() =>
-                onImageClick?.(
-                  detail.parents.map((p) => p.imageUrl),
-                  i,
-                )
-              }
-              className="relative size-[6.25rem] shrink-0 overflow-hidden rounded-[0.5rem] bg-[#c6c6c6] tab:aspect-[368/204] tab:h-auto tab:w-full tab:rounded-[0.6875rem]"
-            >
-              <Image
-                src={parent.imageUrl}
-                alt={`${parent.role} 사진`}
-                fill
-                className="object-cover"
-              />
-            </button>
-            <div className="flex gap-[0.4375rem] text-[0.875rem] leading-[1.5] font-semibold text-[#5d5d5d] tab:gap-[1.375rem]">
-              <span className="font-bold">{parent.role}</span>
-              <div className="flex flex-col gap-[0.25rem]">
-                <span>{parent.name}</span>
-                <span>{parent.birthDate}</span>
+const ParentInfoCard = ({ detail, onImageClick }: ParentInfoCardProps) => {
+  // [refactored] onClick마다 재계산하던 부모 이미지 배열을 한 번만 계산
+  const parentImages = detail.parents.map((p) => p.imageUrl)
+
+  return (
+    <BaseInfoCard
+      title="부모 정보"
+      className="mt-[0.75rem] tab:mt-0 tab:w-[26.25rem] tab:shrink-0 pc:w-auto pc:flex-1"
+    >
+      <div className="flex flex-col gap-[1rem] tab:gap-[1.25rem]">
+        {detail.parents.map((parent, i) => (
+          <div key={parent.role} className="flex flex-col gap-[0.8125rem]">
+            <div className="flex items-center gap-[0.5625rem] tab:flex-col tab:items-start tab:gap-[0.8125rem]">
+              <button
+                type="button"
+                onClick={() => onImageClick?.(parentImages, i)}
+                className="relative size-[6.25rem] shrink-0 overflow-hidden rounded-[0.5rem] bg-[#c6c6c6] tab:aspect-[368/204] tab:h-auto tab:w-full tab:rounded-[0.6875rem]"
+              >
+                <Image
+                  src={parent.imageUrl}
+                  alt={`${parent.role} 사진`}
+                  fill
+                  className="object-cover"
+                />
+              </button>
+              <div className="flex gap-[0.4375rem] text-[0.875rem] leading-[1.5] font-semibold text-[#5d5d5d] tab:gap-[1.375rem]">
+                <span className="font-bold">{parent.role}</span>
+                <div className="flex flex-col gap-[0.25rem]">
+                  <span>{parent.name}</span>
+                  <span>{parent.birthDate}</span>
+                </div>
               </div>
             </div>
           </div>
-        </div>
-      ))}
-    </div>
-  </BaseInfoCard>
-)
+        ))}
+      </div>
+    </BaseInfoCard>
+  )
+}
 
 export { ParentInfoCard }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -28,6 +28,17 @@
   font-family: var(--font-pretendard), sans-serif;
 }
 
+/* 전역: 스크롤은 유지하되 스크롤바만 숨김 (스크롤 중에도 안 보이게) */
+* {
+  -ms-overflow-style: none; /* IE/구 Edge */
+  scrollbar-width: none; /* Firefox */
+}
+*::-webkit-scrollbar {
+  display: none; /* Chrome/Safari/Edge */
+  width: 0;
+  height: 0;
+}
+
 /* 배너 캐러셀 페이지네이션 (Figma: active 노란 알약, inactive 갈색 점) */
 .banner-swiper {
   --swiper-pagination-color: #fffa94;


### PR DESCRIPTION
## 작업 내용

입양 상세 하단 카드들을 피그마(node 1226-46244)에 맞춰 정비했습니다.

### 레이아웃 / 간격
- 카드 패딩 20px, 타이틀↔내용 20px (BaseInfoCard 공통)
- 건강 카드 width 892px(pc), 섹션 간 gap 20px
- 부모 카드: 카드 사이 gap 20px, pc에서 남는 폭 채움(flex-1)
- 사육 환경: 세로 레이아웃(제목 → 이미지 스트립 320×240 → 설명), gap 20px

### 테이블 (피그마 TableLayout)
- 예방접종: 3컬럼(접종명/접종일/차수), 헤더 py-4 #6b6b6b medium, 데이터 py-8 #3e3e3e semibold, border #cacaca
- 유전병: 검진일/검사기관(라벨+값 우측), 결과(라벨+질병+결과)

### 기타
- 전역 스크롤바 숨김(스크롤 기능 유지) — globals.css
- 히어로/하단 콘텐츠 프레임을 공용 `Container`로 교체(중복 제거)

### 리팩터링
- HealthInfoCard: SectionHeader / Table / TableRow 추출
- BreedingEnvironmentCard: EnvImageButton 추출 (Swiper 제거)
- ParentInfoCard: 부모 이미지 배열 호이스팅

Closes #135