### PR TITLE
refactor(adoption): 입양 상세 pc 브레이크포인트 전환 및 공용 컴포넌트 추출

### DIFF
--- a/src/app/(main)/adoption/[id]/_ui/AdoptionCtaBar.tsx
+++ b/src/app/(main)/adoption/[id]/_ui/AdoptionCtaBar.tsx
@@ -7,11 +7,11 @@ interface AdoptionCtaBarProps {
 
 /* ── 하단 고정 CTA 바 (채팅 진입) ── */
 const AdoptionCtaBar = ({ listingId, chatCount }: AdoptionCtaBarProps) => (
-  <div className="fixed right-0 bottom-0 left-0 z-10 bg-white p-[1.25rem] tab:flex tab:items-center tab:justify-center tab:py-[1.4375rem]">
-    <div className="flex items-center gap-[0.625rem] tab:w-auto">
+  <div className="fixed right-0 bottom-0 left-0 z-10 bg-white p-[1.25rem] pc:flex pc:items-center pc:justify-center pc:py-[1.4375rem]">
+    <div className="flex items-center gap-[0.625rem] pc:w-auto">
       <Link
         href={`/adoption/${listingId}/apply`}
-        className="flex h-12 flex-1 items-center justify-center rounded-full bg-[#d4d4d4] text-[1rem] font-semibold text-[#5d5d5d] tab:w-[29.75rem] tab:flex-initial"
+        className="flex h-12 flex-1 items-center justify-center rounded-full bg-[#d4d4d4] text-[1rem] font-semibold text-[#5d5d5d] pc:w-[29.75rem] pc:flex-initial"
       >
         대화중인 채팅 {chatCount}
       </Link>

--- a/src/app/(main)/adoption/[id]/_ui/AdoptionDetailContent.tsx
+++ b/src/app/(main)/adoption/[id]/_ui/AdoptionDetailContent.tsx
@@ -1,8 +1,9 @@
 'use client'
 
 import { useRouter } from 'next/navigation'
+import type { ReactNode } from 'react'
 import { Container, Separator, ImageModal } from '@/shared/ui'
-import { ArrowBackIcon } from '@/shared/assets/icons'
+import { ArrowBackIcon, MoreVertIcon } from '@/shared/assets/icons'
 import { useImageModal } from '@/shared/lib/useImageModal'
 import type { AdoptionDetailDto } from '@/shared/types'
 import { HealthInfoCard } from './HealthInfoCard'
@@ -28,35 +29,47 @@ const AdoptionDetailContent = ({ detail }: AdoptionDetailContentProps) => {
 
   return (
     <div className="pb-[6rem] tab:pb-[6rem]">
-      {/* ── 모바일 서브헤더 ── */}
-      <div className="flex items-center gap-[0.625rem] px-[1.25rem] py-[0.75rem] tab:hidden">
+      {/* ── 네비게이션 바 ── 피그마 976:25819: 뒤로가기 + 가운데 정렬 제목 + 더보기(케밥) px-16 py-4 */}
+      <div className="flex items-center px-[1rem] py-[0.25rem] pc:hidden">
         <button type="button" onClick={() => router.back()}>
-          <ArrowBackIcon className="size-[1.25rem] text-[#5d5d5d]" />
+          <ArrowBackIcon className="size-[1.5rem] text-[#3e3e3e]" />
         </button>
-        <p className="text-[0.875rem] leading-[1.5] font-semibold text-[#5d5d5d]">{detail.name}</p>
+        <div className="flex min-w-px flex-1 items-center justify-center p-[0.125rem]">
+          <p className="text-[0.875rem] leading-[1.5] font-semibold whitespace-nowrap text-[#3e3e3e]">
+            {detail.name}
+          </p>
+        </div>
+        <button type="button">
+          <MoreVertIcon className="size-[1.5rem] text-[#3e3e3e]" />
+        </button>
       </div>
 
       {/* ═══ 히어로 섹션 ═══ */}
       <AdoptionDetailHero detail={detail} onImageClick={openImageModal} />
 
-      {/* ═══ 하단 콘텐츠 (히어로와 동일 공용 Container) ═══ */}
-      <Container className="tab:py-[1.25rem]">
-        {/* 건강 정보 + 부모 정보 */}
-        <div className="mt-[1.25rem] tab:mt-0 tab:flex tab:gap-[1.25rem]">
+      {/* ═══ 하단 콘텐츠 ═══ 피그마 tab: 섹션별 컨테이너 px-48 py-12 */}
+      {/* [refactored] 반복되던 <Container className="tab:py-[0.75rem]"> 를 Section으로 추출 */}
+      {/* 건강 정보 + 부모 정보 */}
+      <Section>
+        <div className="mt-[1.25rem] tab:mt-0 pc:flex pc:gap-[1.25rem]">
           <HealthInfoCard detail={detail} />
           <ParentInfoCard detail={detail} onImageClick={openImageModal} />
         </div>
+      </Section>
 
-        {/* 사육 환경 */}
-        <div className="mt-[1.25rem] tab:mt-[2rem]">
+      {/* 사육 환경 */}
+      <Section>
+        <div className="mt-[1.25rem] tab:mt-0">
           <BreedingEnvironmentCard detail={detail} onImageClick={openImageModal} />
         </div>
+      </Section>
 
-        {/* 브리더의 다른 분양건 — 피그마: 컬럼 920px 중앙(외곽서 260px), 제목 위 48px, gap 39px */}
-        <div className="mt-[1.5rem] tab:mt-[2rem]">
+      {/* 브리더의 다른 분양건 — 피그마: 컬럼 920px 중앙(외곽서 260px), 제목 위 48px, gap 39px */}
+      <Section>
+        <div className="mt-[1.5rem] tab:mt-0">
           <Separator className="bg-[#d4d4d4]" />
-          <div className="mt-[1rem] flex flex-col gap-[0.75rem] tab:mx-auto tab:mt-[3rem] tab:max-w-[57.5rem] tab:gap-[2.4375rem]">
-            <p className="text-[0.75rem] leading-[1.375rem] font-medium text-[#5d5d5d] tab:text-[1.25rem] tab:font-semibold tab:text-[#3e3e3e]">
+          <div className="mt-[1rem] flex flex-col gap-[0.75rem] pc:mx-auto pc:mt-[3rem] pc:max-w-[57.5rem] pc:gap-[2.4375rem]">
+            <p className="text-[0.75rem] leading-[1.375rem] font-medium text-[#5d5d5d] pc:text-[1.25rem] pc:font-semibold pc:text-[#3e3e3e]">
               브리더의 다른 분양건 {detail.otherListings.length}
             </p>
             {detail.otherListings.map((listing) => (
@@ -64,7 +77,7 @@ const AdoptionDetailContent = ({ detail }: AdoptionDetailContentProps) => {
             ))}
           </div>
         </div>
-      </Container>
+      </Section>
 
       {/* ═══ CTA 하단 고정 바 ═══ */}
       <AdoptionCtaBar listingId={detail.listingId} chatCount={detail.chatCount} />
@@ -79,5 +92,10 @@ const AdoptionDetailContent = ({ detail }: AdoptionDetailContentProps) => {
     </div>
   )
 }
+
+// [refactored] 하단 섹션 공용 컨테이너 (피그마 tab: py-12) — 반복 className 제거
+const Section = ({ children }: { children: ReactNode }) => (
+  <Container className="tab:py-[0.75rem]">{children}</Container>
+)
 
 export { AdoptionDetailContent }

--- a/src/app/(main)/adoption/[id]/_ui/AdoptionDetailHero.tsx
+++ b/src/app/(main)/adoption/[id]/_ui/AdoptionDetailHero.tsx
@@ -13,6 +13,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
 } from '@/shared/ui'
+import { cn } from '@/shared/lib/cn'
 import { ArrowRightIcon, CheckIcon, GenderIcon } from '@/shared/assets/icons'
 import { ADOPTION_STATUS_LABEL, GENDER_LABEL } from '@/shared/types'
 import type { AdoptionDetailDto, AdoptionStatus } from '@/shared/types'
@@ -26,13 +27,13 @@ interface AdoptionDetailHeroProps {
 
 /* ── 입양 상세 히어로 (브레드크럼 + 이미지 + 브리더 프로필 | 정보) ── */
 const AdoptionDetailHero = ({ detail, onImageClick }: AdoptionDetailHeroProps) => (
-  // 공용 Container 사용 (모바일은 풀블리드 이미지 위해 px-0)
-  <Container className="px-0 tab:px-[3rem] tab:py-[1.25rem]">
-    <div className="tab:flex tab:items-start tab:gap-[1.25rem]">
+  // 좌우 패딩(모바일20/탭48)은 Container가 담당, 이미지만 음수마진으로 풀블리드
+  <Container className="pc:px-[3rem] pc:py-[0.75rem]">
+    <div className="pc:flex pc:items-start pc:gap-[1.25rem]">
       {/* ── 좌측 섹션: 브레드크럼 + 이미지 + 브리더 프로필 ── 피그마: w-500, gap-12 */}
-      <div className="relative tab:flex tab:w-[31.25rem] tab:shrink-0 tab:flex-col tab:gap-[0.75rem]">
+      <div className="relative -mx-[1.25rem] tab:-mx-[3rem] pc:mx-0 pc:flex pc:w-[31.25rem] pc:shrink-0 pc:flex-col pc:gap-[0.75rem]">
         {/* 브레드크럼 (데스크탑 전용) — 피그마: 라벨(body/md/bold 14px #6b6b6b) + chevron */}
-        <div className="hidden items-end py-[0.625rem] tab:flex">
+        <div className="hidden items-end py-[0.625rem] pc:flex">
           {['홈', '입양', '도마뱀'].map((label, index) => (
             <Fragment key={label}>
               {index > 0 && <ArrowRightIcon className="size-[1.5rem] text-[#6b6b6b]" />}
@@ -51,17 +52,15 @@ const AdoptionDetailHero = ({ detail, onImageClick }: AdoptionDetailHeroProps) =
         />
 
         {/* ── 브리더 프로필 (데스크탑 전용) ── 아바타 + 닉네임 + 애정도 배지 ··· 브리더홈 > */}
-        <div className="hidden items-center gap-[1.75rem] tab:flex">
+        <div className="hidden items-center gap-[1.75rem] pc:flex">
           <div className="flex flex-1 items-center gap-[1.25rem]">
             <div className="flex items-center gap-[0.5rem]">
-              <div className="relative size-[2.5rem] shrink-0 overflow-hidden rounded-full bg-[#d4d4d4]">
-                <Image
-                  src={detail.breeder.profileImageUrl}
-                  alt={detail.breeder.nickname}
-                  fill
-                  className="object-cover"
-                />
-              </div>
+              {/* [refactored] BreederAvatar 사용 */}
+              <BreederAvatar
+                src={detail.breeder.profileImageUrl}
+                alt={detail.breeder.nickname}
+                className="size-[2.5rem]"
+              />
               <p className="text-[1rem] leading-[1.5] font-semibold text-[#3e3e3e]">
                 {detail.breeder.nickname}
               </p>
@@ -78,19 +77,17 @@ const AdoptionDetailHero = ({ detail, onImageClick }: AdoptionDetailHeroProps) =
         </div>
       </div>
 
-      {/* ── 우측 섹션: 이름 ~ 관심/공유 ── 피그마: flex-1, py-48, items-end, justify-between */}
-      <div className="flex flex-col px-[1.25rem] pt-[0.75rem] tab:flex-1 tab:items-end tab:justify-between tab:self-stretch tab:px-0 tab:py-[3rem]">
+      {/* ── 우측 섹션: 이름 ~ 관심/공유 ── 좌우 px는 바깥 Container가, 여기는 py만 (px 없음) */}
+      <div className="flex h-full w-full flex-col py-[0.75rem] pc:flex-1 pc:items-end pc:justify-between pc:self-stretch pc:py-[3rem]">
         {/* 브리더 프로필 (모바일만 여기서 표시) */}
-        <div className="w-full tab:hidden">
+        <div className="w-full pc:hidden">
           <div className="flex items-center gap-[0.375rem]">
-            <div className="relative size-[2.75rem] shrink-0 overflow-hidden rounded-full bg-[#d4d4d4]">
-              <Image
-                src={detail.breeder.profileImageUrl}
-                alt={detail.breeder.nickname}
-                fill
-                className="object-cover"
-              />
-            </div>
+            {/* [refactored] BreederAvatar 사용 */}
+            <BreederAvatar
+              src={detail.breeder.profileImageUrl}
+              alt={detail.breeder.nickname}
+              className="size-[2.75rem]"
+            />
             <div className="flex flex-1 flex-col">
               <p className="text-[0.875rem] leading-[1.5] font-bold text-[#5d5d5d]">
                 {detail.breeder.nickname}
@@ -112,8 +109,8 @@ const AdoptionDetailHero = ({ detail, onImageClick }: AdoptionDetailHeroProps) =
         {/* ── 상단 그룹: 이름 ~ 소개 (한 줄씩 gap-20px) ── */}
         <div className="flex w-full flex-col gap-[1.25rem]">
           {/* 이름 + 상태 배지(드롭다운) + 인기 배지 (피그마: body/2xl/bolder 24px) */}
-          <div className="flex flex-wrap items-center gap-[0.4375rem] tab:gap-[0.5rem]">
-            <p className="text-[0.875rem] leading-[1.5] font-bold text-[#5d5d5d] tab:text-[1.5rem] tab:text-[#3e3e3e]">
+          <div className="flex flex-wrap items-center gap-[0.4375rem] pc:gap-[0.5rem]">
+            <p className="text-[0.875rem] leading-[1.5] font-bold text-[#5d5d5d] pc:text-[1.5rem] pc:text-[#3e3e3e]">
               {detail.name}
             </p>
             <StatusDropdown currentStatus={detail.status} />
@@ -133,15 +130,17 @@ const AdoptionDetailHero = ({ detail, onImageClick }: AdoptionDetailHeroProps) =
           <InfoItem
             label="성별"
             value={GENDER_LABEL[detail.gender]}
-            trailing={<GenderIcon gender={detail.gender} className="size-[1.5rem] text-[#6b6b6b]" />}
+            trailing={
+              <GenderIcon gender={detail.gender} className="size-[1.5rem] text-[#6b6b6b]" />
+            }
           />
 
           {/* 소개 (라벨 ↔ 내용 gap-4px, 내용 body/lg/bold 16px) */}
           <div className="flex flex-col gap-[0.25rem] text-[#5d5d5d]">
-            <p className="text-[0.75rem] leading-[1.5] font-medium tab:text-[1.25rem] tab:text-[#6b6b6b]">
+            <p className="text-[0.75rem] leading-[1.5] font-medium pc:text-[1.25rem] pc:text-[#6b6b6b]">
               소개
             </p>
-            <p className="text-[0.875rem] leading-[1.5] font-semibold whitespace-pre-wrap tab:text-[1rem] tab:text-[#3e3e3e]">
+            <p className="text-[0.875rem] leading-[1.5] font-semibold whitespace-pre-wrap pc:text-[1rem] pc:text-[#3e3e3e]">
               {detail.description}
             </p>
           </div>
@@ -153,11 +152,11 @@ const AdoptionDetailHero = ({ detail, onImageClick }: AdoptionDetailHeroProps) =
           favoriteCount={detail.favoriteCount}
           viewCount={detail.viewCount}
           size="sm"
-          className="mt-[0.5rem] justify-end tab:hidden"
+          className="mt-[0.5rem] justify-end pc:hidden"
         />
 
         {/* ── 하단 그룹: 문의/관심/조회 + 관심/공유 (데스크탑 전용) ── */}
-        <div className="hidden flex-col items-end gap-[0.5rem] tab:flex">
+        <div className="hidden flex-col items-end gap-[0.5rem] pc:flex">
           <ListingStats
             inquiryCount={detail.inquiryCount}
             favoriteCount={detail.favoriteCount}
@@ -169,6 +168,13 @@ const AdoptionDetailHero = ({ detail, onImageClick }: AdoptionDetailHeroProps) =
       </div>
     </div>
   </Container>
+)
+
+// [refactored] 브리더 아바타 (원형 이미지 + fallback 배경) — 데스크탑/모바일 중복 제거 (크기만 className)
+const BreederAvatar = ({ src, alt, className }: { src: string; alt: string; className: string }) => (
+  <div className={cn('relative shrink-0 overflow-hidden rounded-full bg-[#d4d4d4]', className)}>
+    <Image src={src} alt={alt} fill className="object-cover" />
+  </div>
 )
 
 /* ── 정보 항목 (라벨 ↔ 내용: 가로 배치 gap-12px) ── */
@@ -183,11 +189,11 @@ const InfoItem = ({
   trailing?: ReactNode
 }) => (
   <div className="flex items-center gap-[0.75rem] text-[#5d5d5d]">
-    <p className="shrink-0 text-[0.75rem] leading-[1.5] font-medium tab:text-[1.25rem] tab:text-[#6b6b6b]">
+    <p className="shrink-0 text-[0.75rem] leading-[1.5] font-medium pc:text-[1.25rem] pc:text-[#6b6b6b]">
       {label}
     </p>
     <div className="flex items-center gap-[0.25rem]">
-      <p className="text-[0.875rem] leading-[1.5] font-semibold tab:text-[1.25rem] tab:text-[#3e3e3e]">
+      <p className="text-[0.875rem] leading-[1.5] font-semibold pc:text-[1.25rem] pc:text-[#3e3e3e]">
         {value}
       </p>
       {trailing}
@@ -203,7 +209,7 @@ const StatusDropdown = ({ currentStatus }: { currentStatus: AdoptionStatus }) =>
     <DropdownMenuTrigger asChild>
       <button
         type="button"
-        className="inline-flex items-center gap-[0.625rem] rounded-full bg-[#5d5d5d] px-[0.625rem] py-[0.25rem] text-[0.75rem] leading-[1.375rem] font-semibold text-white tab:text-[0.875rem]"
+        className="inline-flex items-center gap-[0.625rem] rounded-full bg-[#5d5d5d] px-[0.625rem] py-[0.25rem] text-[0.75rem] leading-[1.375rem] font-semibold text-white pc:text-[0.875rem]"
       >
         {ADOPTION_STATUS_LABEL[currentStatus]}
         <CheckIcon className="size-[1.25rem]" />

--- a/src/app/(main)/adoption/[id]/_ui/BaseInfoCard.tsx
+++ b/src/app/(main)/adoption/[id]/_ui/BaseInfoCard.tsx
@@ -10,14 +10,14 @@ interface BaseInfoCardProps {
 const BaseInfoCard = ({ title, className, children }: BaseInfoCardProps) => (
   <div
     className={cn(
-      'overflow-hidden rounded-[1rem] bg-[#f5f5f5] p-[0.875rem] tab:p-[1.25rem]',
+      'overflow-hidden rounded-[1rem] bg-[#f5f5f5] p-[0.875rem] pc:p-[1.25rem]',
       className,
     )}
   >
-    <p className="text-[0.75rem] leading-[1.375rem] font-medium text-[#5d5d5d] tab:text-[1.25rem] tab:font-semibold">
+    <p className="text-[0.75rem] leading-[1.375rem] font-medium text-[#5d5d5d] pc:text-[1.25rem] pc:font-semibold">
       {title}
     </p>
-    <div className="mt-[1rem] tab:mt-[1.25rem]">{children}</div>
+    <div className="mt-[1rem] pc:mt-[1.25rem]">{children}</div>
   </div>
 )
 

--- a/src/app/(main)/adoption/[id]/_ui/BreedingEnvironmentCard.tsx
+++ b/src/app/(main)/adoption/[id]/_ui/BreedingEnvironmentCard.tsx
@@ -34,9 +34,9 @@ const BreedingEnvironmentCard = ({ detail, onImageClick }: BreedingEnvironmentCa
   const { description, imageUrls } = detail.breedingEnvironment
 
   return (
-    <div className="overflow-hidden rounded-[1rem] bg-[#f5f5f5] p-[0.875rem] tab:p-[1.25rem]">
+    <div className="overflow-hidden rounded-[1rem] bg-[#f5f5f5] p-[0.875rem] pc:p-[1.25rem]">
       {/* 모바일: 세로 레이아웃 */}
-      <div className="tab:hidden">
+      <div className="pc:hidden">
         <p className="text-[0.75rem] leading-[1.375rem] font-medium text-[#5d5d5d]">사육 환경</p>
         <p className="mt-[0.5rem] text-[0.875rem] leading-[1.5] font-semibold text-[#5d5d5d]">
           {description}
@@ -56,7 +56,7 @@ const BreedingEnvironmentCard = ({ detail, onImageClick }: BreedingEnvironmentCa
       </div>
 
       {/* 데스크탑: 세로 — 제목 → 이미지 스트립(320×240) → 설명 (피그마 1226-46244 environment) */}
-      <div className="hidden tab:flex tab:flex-col tab:gap-[1.25rem]">
+      <div className="hidden pc:flex pc:flex-col pc:gap-[1.25rem]">
         <p className="text-[1.25rem] leading-[1.5] font-semibold text-[#3e3e3e]">사육 환경</p>
         <div className="flex gap-[0.75rem] overflow-x-auto">
           {/* [refactored] EnvImageButton 사용 */}

--- a/src/app/(main)/adoption/[id]/_ui/HealthInfoCard.tsx
+++ b/src/app/(main)/adoption/[id]/_ui/HealthInfoCard.tsx
@@ -9,11 +9,11 @@ const CompletionBadge = ({ completed }: { completed: boolean }) => (
   <Badge
     variant="status"
     className={cn(
-      'flex items-center justify-center px-[0.625rem] py-[0.25rem] text-[0.75rem] leading-[1.375rem] tab:text-[0.875rem]',
+      'flex items-center justify-center px-[0.625rem] py-[0.25rem] text-[0.75rem] leading-[1.375rem] pc:text-[0.875rem]',
       completed ? 'bg-[#5d5d5d]' : 'bg-[#a4a4a4]',
     )}
   >
-    <CheckIcon className="size-[1.25rem] tab:size-[1.5rem]" />
+    <CheckIcon className="size-[1.25rem] pc:size-[1.5rem]" />
     <span>{completed ? '검사 완료' : '미완료'}</span>
   </Badge>
 )
@@ -28,7 +28,7 @@ const SectionHeader = ({ title, completed }: { title: string; completed: boolean
 
 // [refactored] 피그마 TableLayout 컨테이너 — 반복 className 제거
 const Table = ({ children }: { children: ReactNode }) => (
-  <div className="flex flex-col text-[0.875rem] leading-[1.375rem] font-semibold tab:text-[1rem] tab:leading-[1.5]">
+  <div className="flex flex-col text-[0.875rem] leading-[1.375rem] font-semibold pc:text-[1rem] pc:leading-[1.5]">
     {children}
   </div>
 )
@@ -43,8 +43,8 @@ const TableRow = ({ className, children }: { className?: string; children: React
 )
 
 const HealthInfoCard = ({ detail }: { detail: AdoptionDetailDto }) => (
-  <BaseInfoCard title="건강 정보" className="tab:flex-1 pc:w-[55.75rem] pc:flex-none">
-    <div className="flex flex-col gap-[2.1875rem] tab:gap-[1.25rem]">
+  <BaseInfoCard title="건강 정보" className="pc:w-[55.75rem] pc:flex-none">
+    <div className="flex flex-col gap-[2.1875rem] pc:gap-[1.25rem]">
       {/* 예방 접종 현황 */}
       <div className="flex flex-col gap-[0.6875rem]">
         {/* [refactored] SectionHeader 사용 */}

--- a/src/app/(main)/adoption/[id]/_ui/HeroImageCarousel.tsx
+++ b/src/app/(main)/adoption/[id]/_ui/HeroImageCarousel.tsx
@@ -18,7 +18,7 @@ const HeroImageCarousel = ({
   const hasMultiple = images.length > 1
 
   return (
-    <div className="relative aspect-[375/279] w-full overflow-hidden tab:flex tab:aspect-square tab:h-[31.25rem] tab:w-[31.25rem] tab:items-center tab:justify-center tab:self-stretch tab:rounded-[0.5rem]">
+    <div className="relative aspect-[375/279] w-full overflow-hidden pc:flex pc:aspect-square pc:h-[31.25rem] pc:w-[31.25rem] pc:items-center pc:justify-center pc:self-stretch pc:rounded-[0.5rem]">
       <button
         type="button"
         onClick={() => onImageClick(currentIndex)}
@@ -28,7 +28,7 @@ const HeroImageCarousel = ({
       </button>
 
       {/* 공유 버튼 (모바일) */}
-      <button type="button" className="absolute top-[0.75rem] right-[0.75rem] tab:hidden">
+      <button type="button" className="absolute top-[0.75rem] right-[0.75rem] pc:hidden">
         <ShareIcon className="size-[2rem] text-white" />
       </button>
 
@@ -45,7 +45,7 @@ const HeroImageCarousel = ({
       )}
 
       {/* 인디케이터 — 활성 pill(20x8 #fffa94), 비활성 dot(8 #a9835a) */}
-      <div className="absolute bottom-[1rem] left-1/2 flex -translate-x-1/2 items-center gap-[0.25rem] tab:bottom-[1.5rem]">
+      <div className="absolute bottom-[1rem] left-1/2 flex -translate-x-1/2 items-center gap-[0.25rem] pc:bottom-[1.5rem]">
         {images.map((url, index) => (
           <span
             key={url}

--- a/src/app/(main)/adoption/[id]/_ui/OtherListingCard.tsx
+++ b/src/app/(main)/adoption/[id]/_ui/OtherListingCard.tsx
@@ -18,7 +18,7 @@ const OtherListingCard = ({ listing }: { listing: AdoptionListingCard }) => {
   return (
     <>
       {/* 모바일: 가로형 카드 */}
-      <div className="tab:hidden">
+      <div className="pc:hidden">
         <AdoptionCardHorizontal
           listing={listing}
           isFavorite={isFavorite}
@@ -26,7 +26,7 @@ const OtherListingCard = ({ listing }: { listing: AdoptionListingCard }) => {
         />
       </div>
       {/* 데스크탑: 가로형 큰 카드 */}
-      <div className="hidden tab:block">
+      <div className="hidden pc:block">
         <DesktopOtherListingCard
           listing={listing}
           isFavorite={isFavorite}

--- a/src/app/(main)/adoption/[id]/_ui/ParentInfoCard.tsx
+++ b/src/app/(main)/adoption/[id]/_ui/ParentInfoCard.tsx
@@ -14,16 +14,16 @@ const ParentInfoCard = ({ detail, onImageClick }: ParentInfoCardProps) => {
   return (
     <BaseInfoCard
       title="부모 정보"
-      className="mt-[0.75rem] tab:mt-0 tab:w-[26.25rem] tab:shrink-0 pc:w-auto pc:flex-1"
+      className="mt-[0.75rem] pc:mt-0 pc:w-auto pc:flex-1"
     >
-      <div className="flex flex-col gap-[1rem] tab:gap-[1.25rem]">
+      <div className="flex flex-col gap-[1rem] pc:gap-[1.25rem]">
         {detail.parents.map((parent, i) => (
           <div key={parent.role} className="flex flex-col gap-[0.8125rem]">
-            <div className="flex items-center gap-[0.5625rem] tab:flex-col tab:items-start tab:gap-[0.8125rem]">
+            <div className="flex items-center gap-[0.5625rem] pc:flex-col pc:items-start pc:gap-[0.8125rem]">
               <button
                 type="button"
                 onClick={() => onImageClick?.(parentImages, i)}
-                className="relative size-[6.25rem] shrink-0 overflow-hidden rounded-[0.5rem] bg-[#c6c6c6] tab:aspect-[368/204] tab:h-auto tab:w-full tab:rounded-[0.6875rem]"
+                className="relative size-[6.25rem] shrink-0 overflow-hidden rounded-[0.5rem] bg-[#c6c6c6] pc:aspect-[368/204] pc:h-auto pc:w-full pc:rounded-[0.6875rem]"
               >
                 <Image
                   src={parent.imageUrl}
@@ -32,7 +32,7 @@ const ParentInfoCard = ({ detail, onImageClick }: ParentInfoCardProps) => {
                   className="object-cover"
                 />
               </button>
-              <div className="flex gap-[0.4375rem] text-[0.875rem] leading-[1.5] font-semibold text-[#5d5d5d] tab:gap-[1.375rem]">
+              <div className="flex gap-[0.4375rem] text-[0.875rem] leading-[1.5] font-semibold text-[#5d5d5d] pc:gap-[1.375rem]">
                 <span className="font-bold">{parent.role}</span>
                 <div className="flex flex-col gap-[0.25rem]">
                   <span>{parent.name}</span>


### PR DESCRIPTION
Closes #139

## Changes
- `tab:` → `pc:` 브레이크포인트 전환 + 피그마 레이아웃 정비 (히어로/카드/CTA/캐러셀/다른 분양건)
- `AdoptionDetailContent`: 반복되던 `<Container className="tab:py-[0.75rem]">` 를 `Section` 래퍼로 추출 (SRP)
- `AdoptionDetailHero`: 데스크탑/모바일 중복 아바타 마크업을 `BreederAvatar` 컴포넌트로 추출

## Acceptance criteria
- [ ] pc 브레이크포인트 기준으로 반응형 동작
- [ ] type-check / lint 통과
- [ ] 동작 변경 없음(마크업 결과 동일)

## How to test
1. `/adoption/[id]` 진입
2. 뷰포트를 pc(1440px) 이상/이하로 조절하며 히어로·카드·CTA 레이아웃 전환 확인
3. 브리더 아바타(데스크탑/모바일), 하단 섹션 간격이 기존과 동일한지 확인