### PR TITLE
feat(adoption): 입양 상세 반응형 레이아웃 정비 (탭/pc 브레이크포인트·부모정보 세로형·pc 그리드)

### DIFF
--- a/src/app/(main)/adoption/[id]/_ui/AdoptionDetailContent.tsx
+++ b/src/app/(main)/adoption/[id]/_ui/AdoptionDetailContent.tsx
@@ -48,34 +48,30 @@ const AdoptionDetailContent = ({ detail }: AdoptionDetailContentProps) => {
       <AdoptionDetailHero detail={detail} onImageClick={openImageModal} />
 
       {/* ═══ 하단 콘텐츠 ═══ 피그마 tab: 섹션별 컨테이너 px-48 py-12 */}
-      {/* [refactored] 반복되던 <Container className="tab:py-[0.75rem]"> 를 Section으로 추출 */}
-      {/* 건강 정보 + 부모 정보 */}
+      {/* [refactored] 반복되던 <Container className="tab:py-[0.75rem] pc:py-[1.25rem]"> 를 Section으로 추출 */}
+      {/* 건강 + 부모 + 사육 — pc: 좌(건강↑/사육↓) | 우(부모 전체 높이) grid / 모바일·탭: 세로 (Figma 1226-54550) */}
       <Section>
-        <div className="mt-[1.25rem] tab:mt-0 pc:flex pc:gap-[1.25rem]">
+        <div className="pc:grid pc:grid-cols-[55.75rem_minmax(0,1fr)] pc:gap-[1.75rem]">
           <HealthInfoCard detail={detail} />
           <ParentInfoCard detail={detail} onImageClick={openImageModal} />
-        </div>
-      </Section>
-
-      {/* 사육 환경 */}
-      <Section>
-        <div className="mt-[1.25rem] tab:mt-0">
-          <BreedingEnvironmentCard detail={detail} onImageClick={openImageModal} />
+          <BreedingEnvironmentCard
+            detail={detail}
+            onImageClick={openImageModal}
+            className="mt-[1.5rem] pc:col-start-1 pc:row-start-2 pc:mt-0"
+          />
         </div>
       </Section>
 
       {/* 브리더의 다른 분양건 — 피그마: 컬럼 920px 중앙(외곽서 260px), 제목 위 48px, gap 39px */}
       <Section>
-        <div className="mt-[1.5rem] tab:mt-0">
-          <Separator className="bg-[#d4d4d4]" />
-          <div className="mt-[1rem] flex flex-col gap-[0.75rem] pc:mx-auto pc:mt-[3rem] pc:max-w-[57.5rem] pc:gap-[2.4375rem]">
-            <p className="text-[0.75rem] leading-[1.375rem] font-medium text-[#5d5d5d] pc:text-[1.25rem] pc:font-semibold pc:text-[#3e3e3e]">
-              브리더의 다른 분양건 {detail.otherListings.length}
-            </p>
-            {detail.otherListings.map((listing) => (
-              <OtherListingCard key={listing.listingId} listing={listing} />
-            ))}
-          </div>
+        <Separator className="bg-[#d4d4d4]" />
+        <div className="mt-[1rem] flex flex-col gap-[0.75rem] pc:mx-auto pc:mt-[3rem] pc:max-w-[57.5rem] pc:gap-[2.4375rem]">
+          <p className="text-[0.75rem] leading-[1.375rem] font-medium text-[#5d5d5d] pc:text-[1.25rem] pc:font-semibold pc:text-[#3e3e3e]">
+            브리더의 다른 분양건 {detail.otherListings.length}
+          </p>
+          {detail.otherListings.map((listing) => (
+            <OtherListingCard key={listing.listingId} listing={listing} />
+          ))}
         </div>
       </Section>
 
@@ -93,9 +89,9 @@ const AdoptionDetailContent = ({ detail }: AdoptionDetailContentProps) => {
   )
 }
 
-// [refactored] 하단 섹션 공용 컨테이너 (피그마 tab: py-12) — 반복 className 제거
+// [refactored] 하단 섹션 공용 컨테이너 — 섹션 패딩: 모바일 12/16, 탭 12/48, pc 20/80 (px는 Container 기본)
 const Section = ({ children }: { children: ReactNode }) => (
-  <Container className="tab:py-[0.75rem]">{children}</Container>
+  <Container className="px-[1rem] py-[0.75rem] pc:py-[1.25rem]">{children}</Container>
 )
 
 export { AdoptionDetailContent }

--- a/src/app/(main)/adoption/[id]/_ui/AdoptionDetailHero.tsx
+++ b/src/app/(main)/adoption/[id]/_ui/AdoptionDetailHero.tsx
@@ -27,11 +27,11 @@ interface AdoptionDetailHeroProps {
 
 /* ── 입양 상세 히어로 (브레드크럼 + 이미지 + 브리더 프로필 | 정보) ── */
 const AdoptionDetailHero = ({ detail, onImageClick }: AdoptionDetailHeroProps) => (
-  // 좌우 패딩(모바일20/탭48)은 Container가 담당, 이미지만 음수마진으로 풀블리드
-  <Container className="pc:px-[3rem] pc:py-[0.75rem]">
+  // 좌우 패딩(모바일16/탭48/pc80)은 Container가 담당, 이미지만 음수마진으로 풀블리드. pc 섹션 py-20
+  <Container className="px-[1rem] pc:py-[1.25rem]">
     <div className="pc:flex pc:items-start pc:gap-[1.25rem]">
       {/* ── 좌측 섹션: 브레드크럼 + 이미지 + 브리더 프로필 ── 피그마: w-500, gap-12 */}
-      <div className="relative -mx-[1.25rem] tab:-mx-[3rem] pc:mx-0 pc:flex pc:w-[31.25rem] pc:shrink-0 pc:flex-col pc:gap-[0.75rem]">
+      <div className="relative -mx-[1rem] tab:-mx-[3rem] pc:mx-0 pc:flex pc:w-[31.25rem] pc:shrink-0 pc:flex-col pc:gap-[0.75rem]">
         {/* 브레드크럼 (데스크탑 전용) — 피그마: 라벨(body/md/bold 14px #6b6b6b) + chevron */}
         <div className="hidden items-end py-[0.625rem] pc:flex">
           {['홈', '입양', '도마뱀'].map((label, index) => (
@@ -78,7 +78,7 @@ const AdoptionDetailHero = ({ detail, onImageClick }: AdoptionDetailHeroProps) =
       </div>
 
       {/* ── 우측 섹션: 이름 ~ 관심/공유 ── 좌우 px는 바깥 Container가, 여기는 py만 (px 없음) */}
-      <div className="flex h-full w-full flex-col py-[0.75rem] pc:flex-1 pc:items-end pc:justify-between pc:self-stretch pc:py-[3rem]">
+      <div className="flex h-full w-full flex-col py-[0.75rem] pc:flex-1 pc:items-end pc:justify-between pc:self-stretch pc:py-0">
         {/* 브리더 프로필 (모바일만 여기서 표시) */}
         <div className="w-full pc:hidden">
           <div className="flex items-center gap-[0.375rem]">
@@ -171,7 +171,15 @@ const AdoptionDetailHero = ({ detail, onImageClick }: AdoptionDetailHeroProps) =
 )
 
 // [refactored] 브리더 아바타 (원형 이미지 + fallback 배경) — 데스크탑/모바일 중복 제거 (크기만 className)
-const BreederAvatar = ({ src, alt, className }: { src: string; alt: string; className: string }) => (
+const BreederAvatar = ({
+  src,
+  alt,
+  className,
+}: {
+  src: string
+  alt: string
+  className: string
+}) => (
   <div className={cn('relative shrink-0 overflow-hidden rounded-full bg-[#d4d4d4]', className)}>
     <Image src={src} alt={alt} fill className="object-cover" />
   </div>

--- a/src/app/(main)/adoption/[id]/_ui/BaseInfoCard.tsx
+++ b/src/app/(main)/adoption/[id]/_ui/BaseInfoCard.tsx
@@ -10,14 +10,14 @@ interface BaseInfoCardProps {
 const BaseInfoCard = ({ title, className, children }: BaseInfoCardProps) => (
   <div
     className={cn(
-      'overflow-hidden rounded-[1rem] bg-[#f5f5f5] p-[0.875rem] pc:p-[1.25rem]',
+      'overflow-hidden rounded-[1rem] bg-[#f5f5f5] p-[0.75rem] pc:p-[1.25rem]',
       className,
     )}
   >
     <p className="text-[0.75rem] leading-[1.375rem] font-medium text-[#5d5d5d] pc:text-[1.25rem] pc:font-semibold">
       {title}
     </p>
-    <div className="mt-[1rem] pc:mt-[1.25rem]">{children}</div>
+    <div className="mt-[0.75rem] pc:mt-[1.25rem]">{children}</div>
   </div>
 )
 

--- a/src/app/(main)/adoption/[id]/_ui/BreedingEnvironmentCard.tsx
+++ b/src/app/(main)/adoption/[id]/_ui/BreedingEnvironmentCard.tsx
@@ -7,6 +7,7 @@ import type { AdoptionDetailDto } from '@/shared/types'
 interface BreedingEnvironmentCardProps {
   detail: AdoptionDetailDto
   onImageClick?: (images: string[], index?: number) => void
+  className?: string
 }
 
 // [refactored] 사육 환경 이미지 버튼 — 모바일/데스크탑 중복 제거 (크기만 className)
@@ -30,47 +31,42 @@ const EnvImageButton = ({
   </button>
 )
 
-const BreedingEnvironmentCard = ({ detail, onImageClick }: BreedingEnvironmentCardProps) => {
+const BreedingEnvironmentCard = ({
+  detail,
+  onImageClick,
+  className,
+}: BreedingEnvironmentCardProps) => {
   const { description, imageUrls } = detail.breedingEnvironment
 
   return (
-    <div className="overflow-hidden rounded-[1rem] bg-[#f5f5f5] p-[0.875rem] pc:p-[1.25rem]">
-      {/* 모바일: 세로 레이아웃 */}
-      <div className="pc:hidden">
-        <p className="text-[0.75rem] leading-[1.375rem] font-medium text-[#5d5d5d]">사육 환경</p>
-        <p className="mt-[0.5rem] text-[0.875rem] leading-[1.5] font-semibold text-[#5d5d5d]">
+    <div
+      className={cn(
+        'overflow-hidden rounded-[1rem] bg-[#f5f5f5] p-[0.75rem] pc:p-[1.25rem]',
+        className,
+      )}
+    >
+      {/* [refactored] 모바일/pc 단일 레이아웃 — 제목·설명·이미지맵 1벌, 순서만 flex order로 분기 */}
+      {/* 제목 (모바일 12px #5d5d5d / pc 20px #3e3e3e) */}
+      <p className="text-[0.75rem] leading-[1.375rem] font-medium text-[#5d5d5d] pc:text-[1.25rem] pc:leading-[1.5] pc:font-semibold pc:text-[#3e3e3e]">
+        사육 환경
+      </p>
+
+      {/* 모바일: 설명 → 이미지 / pc: 이미지 → 설명 (order로 순서만 전환) */}
+      <div className="mt-[0.5rem] flex flex-col gap-[0.75rem] pc:mt-[1.25rem] pc:gap-[1.25rem]">
+        <p className="order-1 text-[0.875rem] leading-[1.5] font-semibold text-[#5d5d5d] pc:order-2 pc:text-[1rem]">
           {description}
         </p>
-        <div className="mt-[0.75rem] flex gap-[0.6875rem] overflow-x-auto">
-          {/* [refactored] EnvImageButton 사용 */}
+        <div className="order-2 flex gap-[0.75rem] overflow-x-auto pc:order-1">
           {imageUrls.map((url, i) => (
             <EnvImageButton
-              key={`env-mo-${i}`}
+              key={`env-${i}`}
               src={url}
               index={i}
               onClick={() => onImageClick?.(imageUrls, i)}
-              className="h-[8.125rem] w-[11.9375rem]"
+              className="h-[8.125rem] w-[11.9375rem] pc:h-[15rem] pc:w-[20rem]"
             />
           ))}
         </div>
-      </div>
-
-      {/* 데스크탑: 세로 — 제목 → 이미지 스트립(320×240) → 설명 (피그마 1226-46244 environment) */}
-      <div className="hidden pc:flex pc:flex-col pc:gap-[1.25rem]">
-        <p className="text-[1.25rem] leading-[1.5] font-semibold text-[#3e3e3e]">사육 환경</p>
-        <div className="flex gap-[0.75rem] overflow-x-auto">
-          {/* [refactored] EnvImageButton 사용 */}
-          {imageUrls.map((url, i) => (
-            <EnvImageButton
-              key={`env-pc-${i}`}
-              src={url}
-              index={i}
-              onClick={() => onImageClick?.(imageUrls, i)}
-              className="h-[15rem] w-[20rem]"
-            />
-          ))}
-        </div>
-        <p className="text-[1rem] leading-[1.5] font-semibold text-[#5d5d5d]">{description}</p>
       </div>
     </div>
   )

--- a/src/app/(main)/adoption/[id]/_ui/HealthInfoCard.tsx
+++ b/src/app/(main)/adoption/[id]/_ui/HealthInfoCard.tsx
@@ -43,7 +43,7 @@ const TableRow = ({ className, children }: { className?: string; children: React
 )
 
 const HealthInfoCard = ({ detail }: { detail: AdoptionDetailDto }) => (
-  <BaseInfoCard title="건강 정보" className="pc:w-[55.75rem] pc:flex-none">
+  <BaseInfoCard title="건강 정보" className="pc:col-start-1 pc:row-start-1">
     <div className="flex flex-col gap-[2.1875rem] pc:gap-[1.25rem]">
       {/* 예방 접종 현황 */}
       <div className="flex flex-col gap-[0.6875rem]">

--- a/src/app/(main)/adoption/[id]/_ui/OtherListingCard.tsx
+++ b/src/app/(main)/adoption/[id]/_ui/OtherListingCard.tsx
@@ -17,12 +17,13 @@ const OtherListingCard = ({ listing }: { listing: AdoptionListingCard }) => {
 
   return (
     <>
-      {/* 모바일: 가로형 카드 */}
+      {/* 모바일·탭: 가로형 카드 — 다른 분양건 카드 패딩 8px (Figma card-2) */}
       <div className="pc:hidden">
         <AdoptionCardHorizontal
           listing={listing}
           isFavorite={isFavorite}
           onToggle={toggleFavorite}
+          className="p-[0.5rem]"
         />
       </div>
       {/* 데스크탑: 가로형 큰 카드 */}

--- a/src/app/(main)/adoption/[id]/_ui/ParentInfoCard.tsx
+++ b/src/app/(main)/adoption/[id]/_ui/ParentInfoCard.tsx
@@ -1,4 +1,6 @@
 import Image from 'next/image'
+import { Badge } from '@/shared/ui'
+import { GenderIcon } from '@/shared/assets/icons'
 import type { AdoptionDetailDto } from '@/shared/types'
 import { BaseInfoCard } from './BaseInfoCard'
 
@@ -14,30 +16,38 @@ const ParentInfoCard = ({ detail, onImageClick }: ParentInfoCardProps) => {
   return (
     <BaseInfoCard
       title="부모 정보"
-      className="mt-[0.75rem] pc:mt-0 pc:w-auto pc:flex-1"
+      className="mt-[0.75rem] pc:col-start-2 pc:row-span-2 pc:row-start-1 pc:mt-0"
     >
-      <div className="flex flex-col gap-[1rem] pc:gap-[1.25rem]">
+      {/* 세로 배치: 4:3 이미지 → 배지(role + 성별 아이콘) + 이름/생일 — Figma 1240-45069 */}
+      <div className="flex flex-col gap-[0.75rem]">
         {detail.parents.map((parent, i) => (
-          <div key={parent.role} className="flex flex-col gap-[0.8125rem]">
-            <div className="flex items-center gap-[0.5625rem] pc:flex-col pc:items-start pc:gap-[0.8125rem]">
-              <button
-                type="button"
-                onClick={() => onImageClick?.(parentImages, i)}
-                className="relative size-[6.25rem] shrink-0 overflow-hidden rounded-[0.5rem] bg-[#c6c6c6] pc:aspect-[368/204] pc:h-auto pc:w-full pc:rounded-[0.6875rem]"
-              >
-                <Image
-                  src={parent.imageUrl}
-                  alt={`${parent.role} 사진`}
-                  fill
-                  className="object-cover"
+          <div key={parent.role} className="flex flex-col items-start gap-[0.75rem]">
+            {/* 이미지: 4:3 풀폭 (rounded-8) */}
+            <button
+              type="button"
+              onClick={() => onImageClick?.(parentImages, i)}
+              className="relative aspect-[4/3] w-full overflow-hidden rounded-[0.5rem] bg-[#c6c6c6]"
+            >
+              <Image
+                src={parent.imageUrl}
+                alt={`${parent.role} 사진`}
+                fill
+                className="object-cover"
+              />
+            </button>
+
+            {/* 배지(role + 성별 아이콘) + 이름/생일 */}
+            <div className="flex items-start gap-[0.5rem] text-[1rem] leading-[1.5] font-semibold text-[#3e3e3e]">
+              <Badge variant="active" size="md" className="shrink-0">
+                {parent.role}
+                <GenderIcon
+                  gender={parent.role === '엄마' ? 'female' : 'male'}
+                  className="size-[1.5rem]"
                 />
-              </button>
-              <div className="flex gap-[0.4375rem] text-[0.875rem] leading-[1.5] font-semibold text-[#5d5d5d] pc:gap-[1.375rem]">
-                <span className="font-bold">{parent.role}</span>
-                <div className="flex flex-col gap-[0.25rem]">
-                  <span>{parent.name}</span>
-                  <span>{parent.birthDate}</span>
-                </div>
+              </Badge>
+              <div className="flex flex-col gap-[0.125rem]">
+                <span>{parent.name}</span>
+                <span>{parent.birthDate}</span>
               </div>
             </div>
           </div>

--- a/src/entities/adoption/ui/AdoptionCard.tsx
+++ b/src/entities/adoption/ui/AdoptionCard.tsx
@@ -165,7 +165,7 @@ const AdoptionCardHorizontal = ({
     <Link
       href={`/adoption/${listing.listingId}`}
       className={cn(
-        'relative flex items-center gap-[0.5625rem] rounded-[0.375rem] bg-[#f0f0f0] px-[0.5rem] py-[0.4375rem]',
+        'relative flex items-center gap-[0.5625rem] rounded-[0.375rem] bg-[#f0f0f0] px-[0.5rem] py-[0.4375rem] tab:gap-[1rem]',
         className,
       )}
     >


### PR DESCRIPTION
## Changes
- 섹션 패딩 반응형 통일 (모바일 12/16, 탭 12/48, pc 20/80)
- 데스크탑 레이아웃 분기를 tab→pc로 이동 (탭은 모바일형 단일 컬럼)
- 부모정보 세로형 카드 (배지 + 성별 아이콘)
- pc 그리드 배치: 좌측 건강+사육 / 우측 부모정보 전체 높이 (Figma 1226-54550)
- 사육환경 모바일/pc 레이아웃 단일 통합
- 카드 패딩 정비 (건강/부모/사육 12px, 다른분양건 8px)

## How to test
1. /adoption/{id} 진입
2. 모바일 / 탭(768) / pc(1440) 폭에서 레이아웃 확인