### PR TITLE
feat(adoption): 입양 상세 하단 CTA 바 반응형 피그마 반영 (모바일/탭/pc)

### DIFF
--- a/src/app/(main)/adoption/[id]/_ui/AdoptionCtaBar.tsx
+++ b/src/app/(main)/adoption/[id]/_ui/AdoptionCtaBar.tsx
@@ -25,7 +25,7 @@ const AdoptionCtaBar = ({ listingId }: AdoptionCtaBarProps) => (
 
       <Link
         href={`/adoption/${listingId}/apply`}
-        className="flex  max-w-[18.5625rem] flex-1 items-center justify-center rounded-full bg-[#fffa94] p-[0.5rem] text-[1rem] font-semibold text-[#3e3e3e] tab:h-[2rem] tab:max-w-[16.125rem] tab:text-[0.875rem]"
+        className="flex h-[3rem] max-w-[18.5625rem] flex-1 items-center justify-center rounded-full bg-[#fffa94] px-[0.5rem] text-[1rem] font-semibold text-[#3e3e3e] tab:h-[2rem] tab:max-w-[16.125rem] tab:text-[0.875rem]"
       >
         입양 신청하기
       </Link>

--- a/src/app/(main)/adoption/[id]/_ui/AdoptionCtaBar.tsx
+++ b/src/app/(main)/adoption/[id]/_ui/AdoptionCtaBar.tsx
@@ -1,19 +1,33 @@
 import Link from 'next/link'
+import { FavoriteIcon } from '@/shared/assets/icons'
 
 interface AdoptionCtaBarProps {
   listingId: string
-  chatCount?: number
 }
 
-/* ── 하단 고정 CTA 바 (채팅 진입) ── */
-const AdoptionCtaBar = ({ listingId, chatCount }: AdoptionCtaBarProps) => (
-  <div className="fixed right-0 bottom-0 left-0 z-10 bg-white p-[1.25rem] pc:flex pc:items-center pc:justify-center pc:py-[1.4375rem]">
-    <div className="flex items-center gap-[0.625rem] pc:w-auto">
+/* ── 하단 고정 CTA 바 (입양 신청) ──
+   피그마 btn layout — 모바일(1654:148608) / 탭(1654:148637) / pc(1654:148643)
+   - 모바일: px-16 py-16, 가운데 정렬 · 하트(48) + 노란 버튼(h-48, 가득 max-297)
+   - 탭:    px-48 py-12, 우측 정렬 · 하트(48) + 노란 버튼(h-32, max-258)
+   - pc:    px-80 py-12, 우측 정렬 · 노란 버튼만 (하트 숨김)
+   세 상태를 한 트리에서 반응형 클래스로만 분기 (중복 최소화) */
+const AdoptionCtaBar = ({ listingId }: AdoptionCtaBarProps) => (
+  <div className="fixed right-0 bottom-0 left-0 z-10 flex items-center justify-center gap-[0.625rem] bg-white px-[1rem] py-[1rem] tab:justify-end tab:gap-[1.25rem] tab:px-[3rem] tab:py-[0.75rem] pc:px-[5rem]">
+    {/* 탭·pc 우측 정렬용 좌측 스페이서 (피그마 flex-1 h-45) */}
+    <div className="hidden tab:block tab:h-[2.8125rem] tab:flex-1" />
+
+    {/* 하트 + 버튼 그룹 — 모바일: 가득 / 탭·pc: w-360 우측 고정 */}
+    <div className="flex w-full items-center justify-center gap-[0.625rem] tab:w-[22.5rem] tab:max-w-[33.5rem] tab:min-w-[22.5rem] tab:justify-end tab:gap-[1.25rem]">
+      {/* 관심(하트) — pc에서는 숨김 */}
+      <button type="button" aria-label="관심있어요" className="shrink-0 pc:hidden">
+        <FavoriteIcon className="size-[3rem] text-[#5d5d5d]" />
+      </button>
+
       <Link
         href={`/adoption/${listingId}/apply`}
-        className="flex h-12 flex-1 items-center justify-center rounded-full bg-[#d4d4d4] text-[1rem] font-semibold text-[#5d5d5d] pc:w-[29.75rem] pc:flex-initial"
+        className="flex  max-w-[18.5625rem] flex-1 items-center justify-center rounded-full bg-[#fffa94] p-[0.5rem] text-[1rem] font-semibold text-[#3e3e3e] tab:h-[2rem] tab:max-w-[16.125rem] tab:text-[0.875rem]"
       >
-        대화중인 채팅 {chatCount}
+        입양 신청하기
       </Link>
     </div>
   </div>

--- a/src/app/(main)/adoption/[id]/_ui/AdoptionDetailContent.tsx
+++ b/src/app/(main)/adoption/[id]/_ui/AdoptionDetailContent.tsx
@@ -76,7 +76,7 @@ const AdoptionDetailContent = ({ detail }: AdoptionDetailContentProps) => {
       </Section>
 
       {/* ═══ CTA 하단 고정 바 ═══ */}
-      <AdoptionCtaBar listingId={detail.listingId} chatCount={detail.chatCount} />
+      <AdoptionCtaBar listingId={detail.listingId} />
 
       {/* ═══ 이미지 모달 ═══ */}
       <ImageModal


### PR DESCRIPTION
Closes #142

## Changes
- 입양 상세 하단 고정 CTA 바(`AdoptionCtaBar`)를 피그마 btn layout 세 상태에 맞춰 반응형으로 재구성
  - 모바일(1654:148608): px-16 py-16, 가운데 정렬, 하트(48) + 노란 버튼(h-48, 가득 max-297)
  - 탭(1654:148637): px-48 py-12, 우측 정렬, 하트(48) + 노란 버튼(h-32, max-258)
  - pc(1654:148643): px-80 py-12, 우측 정렬, 노란 버튼만(하트 pc:hidden)
- 세 상태를 단일 트리에서 반응형 클래스로만 분기 (중복 최소화), fixed 하단 고정 유지
- 버튼 라벨을 `입양 신청하기`(/apply 링크)로 정렬하고 미사용 `chatCount` prop 제거 (`AdoptionDetailContent` 호출부 포함)

## How to test
1. `/adoption/{id}` 진입
2. 뷰포트를 모바일(<768)/탭(768~1439)/pc(≥1440)로 바꿔가며 하단 CTA 바 확인
   - 모바일: 하트 + 가득 찬 노란 버튼, 가운데 정렬
   - 탭: 우측 정렬, 하트 + 작은 버튼
   - pc: 우측 정렬, 하트 없이 버튼만