### PR TITLE
feat(adoption): 입양 상세 히어로 이미지 swiper 전환 및 관심/공유 배치 정비

### DIFF
--- a/src/app/(main)/adoption/[id]/_ui/AdoptionDetailHero.tsx
+++ b/src/app/(main)/adoption/[id]/_ui/AdoptionDetailHero.tsx
@@ -78,7 +78,8 @@ const AdoptionDetailHero = ({ detail, onImageClick }: AdoptionDetailHeroProps) =
       </div>
 
       {/* ── 우측 섹션: 이름 ~ 관심/공유 ── 좌우 px는 바깥 Container가, 여기는 py만 (px 없음) */}
-      <div className="flex h-full w-full flex-col py-[0.75rem] pc:flex-1 pc:items-end pc:justify-between pc:self-stretch pc:py-0">
+      {/* pc: self-stretch가 동작하려면 height가 auto여야 함(h-full 제거) → justify-between + py-48로 하단 그룹을 이미지 바닥에 정렬 */}
+      <div className="flex w-full flex-col py-[0.75rem] pc:flex-1 pc:items-end pc:justify-between pc:self-stretch pc:py-[3rem]">
         {/* 브리더 프로필 (모바일만 여기서 표시) */}
         <div className="w-full pc:hidden">
           <div className="flex items-center gap-[0.375rem]">
@@ -146,14 +147,16 @@ const AdoptionDetailHero = ({ detail, onImageClick }: AdoptionDetailHeroProps) =
           </div>
         </div>
 
-        {/* 문의/관심/조회 (모바일) */}
-        <ListingStats
-          inquiryCount={detail.inquiryCount}
-          favoriteCount={detail.favoriteCount}
-          viewCount={detail.viewCount}
-          size="sm"
-          className="mt-[0.5rem] justify-end pc:hidden"
-        />
+        {/* 문의/관심/조회 + 공유 (모바일·탭) — 피그마 1943:128143: 좌측 통계(flex-1) + 우측 공유 */}
+        <div className="mt-[0.5rem] flex w-full items-center justify-between pc:hidden">
+          <ListingStats
+            inquiryCount={detail.inquiryCount}
+            favoriteCount={detail.favoriteCount}
+            viewCount={detail.viewCount}
+            size="sm"
+          />
+          <FavoriteShareActions showFavorite={false} />
+        </div>
 
         {/* ── 하단 그룹: 문의/관심/조회 + 관심/공유 (데스크탑 전용) ── */}
         <div className="hidden flex-col items-end gap-[0.5rem] pc:flex">

--- a/src/app/(main)/adoption/[id]/_ui/FavoriteShareActions.tsx
+++ b/src/app/(main)/adoption/[id]/_ui/FavoriteShareActions.tsx
@@ -5,27 +5,40 @@ import { cn } from '@/shared/lib/cn'
 interface FavoriteShareActionsProps {
   isFavorite?: boolean
   onToggle?: () => void
+  // 피그마 Frame1707484443 like/share 토글 — pc는 둘 다, 모바일·탭 하단은 공유만(showFavorite=false)
+  showFavorite?: boolean
+  showShare?: boolean
   className?: string
 }
 
 // [refactored] 피그마 Frame1707484443 (관심있어요 + 공유) — 히어로/리스트 카드 공통 액션 행
 // 아이콘 32, 아이콘↔텍스트 gap-0, 텍스트 12px semibold #3e3e3e, 행 gap-16
-const FavoriteShareActions = ({ isFavorite, onToggle, className }: FavoriteShareActionsProps) => (
+const FavoriteShareActions = ({
+  isFavorite,
+  onToggle,
+  showFavorite = true,
+  showShare = true,
+  className,
+}: FavoriteShareActionsProps) => (
   <div className={cn('flex items-center gap-[1rem]', className)}>
-    <FavoriteButton
-      size="lg"
-      className="gap-0 p-0 text-[0.75rem] font-semibold text-[#3e3e3e]"
-      iconClassName="size-[2rem]"
-      isFavorite={isFavorite}
-      onToggle={onToggle}
-    />
-    <button
-      type="button"
-      className="flex items-center gap-0 text-[0.75rem] font-semibold text-[#3e3e3e]"
-    >
-      <ShareIcon className="size-[2rem]" />
-      <span>공유</span>
-    </button>
+    {showFavorite && (
+      <FavoriteButton
+        size="lg"
+        className="gap-0 p-0 text-[0.75rem] font-semibold text-[#3e3e3e]"
+        iconClassName="size-[2rem]"
+        isFavorite={isFavorite}
+        onToggle={onToggle}
+      />
+    )}
+    {showShare && (
+      <button
+        type="button"
+        className="flex items-center gap-0 text-[0.75rem] font-semibold text-[#3e3e3e]"
+      >
+        <ShareIcon className="size-[2rem]" />
+        <span>공유</span>
+      </button>
+    )}
   </div>
 )
 

--- a/src/app/(main)/adoption/[id]/_ui/HeroImageCarousel.tsx
+++ b/src/app/(main)/adoption/[id]/_ui/HeroImageCarousel.tsx
@@ -1,10 +1,14 @@
 'use client'
 
 import Image from 'next/image'
-import { useImageCarousel } from '@/shared/lib/useImageCarousel'
-import { PixelArrowRightIcon, ShareIcon } from '@/shared/assets/icons'
+import { useState } from 'react'
+import { Swiper, SwiperSlide } from 'swiper/react'
+import type { Swiper as SwiperClass } from 'swiper'
+import { PixelArrowRightIcon } from '@/shared/assets/icons'
+import 'swiper/css'
 
-// [refactored] 히어로 이미지 캐러셀 (이미지 + 모바일 공유 + 좌우 네비 + 인디케이터)
+// [refactored] 히어로 이미지 캐러셀 — Swiper 기반(모바일/탭 스와이프) + 커스텀 화살표·인디케이터
+// 공유 버튼은 정보 영역 하단으로 이동(피그마 1240-45672) — 이미지에서는 제거
 const HeroImageCarousel = ({
   images,
   alt,
@@ -14,43 +18,55 @@ const HeroImageCarousel = ({
   alt: string
   onImageClick: (index: number) => void
 }) => {
-  const { currentIndex, handlePrev, handleNext } = useImageCarousel(images)
-  const hasMultiple = images.length > 1
+  const [swiper, setSwiper] = useState<SwiperClass | null>(null)
+  const [activeIndex, setActiveIndex] = useState(0)
 
   return (
-    <div className="relative aspect-[375/279] w-full overflow-hidden pc:flex pc:aspect-square pc:h-[31.25rem] pc:w-[31.25rem] pc:items-center pc:justify-center pc:self-stretch pc:rounded-[0.5rem]">
-      <button
-        type="button"
-        onClick={() => onImageClick(currentIndex)}
-        className="relative block size-full"
+    <div className="relative aspect-[375/279] w-full overflow-hidden pc:aspect-square pc:h-[31.25rem] pc:w-[31.25rem] pc:rounded-[0.5rem]">
+      <Swiper
+        onSwiper={setSwiper}
+        onSlideChange={(s) => setActiveIndex(s.activeIndex)}
+        className="size-full"
       >
-        <Image src={images[currentIndex]} alt={alt} fill className="object-cover" />
-      </button>
-
-      {/* 공유 버튼 (모바일) */}
-      <button type="button" className="absolute top-[0.75rem] right-[0.75rem] pc:hidden">
-        <ShareIcon className="size-[2rem] text-white" />
-      </button>
+        {images.map((url, index) => (
+          // 같은 이미지 URL이 중복될 수 있어 index를 포함해 고유 key 생성
+          <SwiperSlide key={`${url}-${index}`}>
+            <button
+              type="button"
+              onClick={() => onImageClick(index)}
+              className="relative block size-full"
+            >
+              {/* draggable=false: 네이티브 이미지 드래그가 Swiper 스와이프를 가로채는 것 방지 */}
+              <Image src={url} alt={alt} fill draggable={false} className="object-cover" />
+            </button>
+          </SwiperSlide>
+        ))}
+      </Swiper>
 
       {/* 좌우 슬라이드 네비게이션 — 첫 사진(대표사진)에서는 이전(왼쪽) 화살표 숨김 */}
-      {currentIndex > 0 && (
+      {activeIndex > 0 && (
         <SlideNavButton
           label="이전 사진"
-          onClick={handlePrev}
+          onClick={() => swiper?.slidePrev()}
           className="left-[1.25rem] rotate-180"
         />
       )}
-      {hasMultiple && (
-        <SlideNavButton label="다음 사진" onClick={handleNext} className="right-[1.25rem]" />
+      {/* 마지막 사진에서는 다음(오른쪽) 화살표 숨김 */}
+      {activeIndex < images.length - 1 && (
+        <SlideNavButton
+          label="다음 사진"
+          onClick={() => swiper?.slideNext()}
+          className="right-[1.25rem]"
+        />
       )}
 
       {/* 인디케이터 — 활성 pill(20x8 #fffa94), 비활성 dot(8 #a9835a) */}
-      <div className="absolute bottom-[1rem] left-1/2 flex -translate-x-1/2 items-center gap-[0.25rem] pc:bottom-[1.5rem]">
+      <div className="pointer-events-none absolute bottom-[1rem] left-1/2 z-10 flex -translate-x-1/2 items-center gap-[0.25rem] pc:bottom-[1.5rem]">
         {images.map((url, index) => (
           <span
-            key={url}
+            key={`${url}-${index}`}
             className={
-              index === currentIndex
+              index === activeIndex
                 ? 'h-[0.5rem] w-[1.25rem] rounded-[0.5rem] bg-[#fffa94]'
                 : 'size-[0.5rem] rounded-[0.5rem] bg-[#a9835a]'
             }
@@ -75,7 +91,7 @@ const SlideNavButton = ({
     type="button"
     onClick={onClick}
     aria-label={label}
-    className={`absolute top-1/2 -translate-y-1/2 ${className}`}
+    className={`absolute top-1/2 z-10 hidden -translate-y-1/2 pc:block ${className}`}
   >
     <PixelArrowRightIcon className="size-[3rem] text-[#f6f6f6]" />
   </button>


### PR DESCRIPTION
Closes #144

## Changes
- 히어로 이미지 캐러셀을 Swiper로 전환 → 모바일/탭 스와이프 동작 (이미지 `draggable=false`로 네이티브 드래그가 스와이프 가로채는 것 방지)
- 좌우 화살표는 PC에서만 노출(`hidden pc:block`), 첫 슬라이드는 이전·마지막 슬라이드는 다음 화살표 숨김
- 이미지 위에 있던 공유 버튼 제거 → 정보 영역 하단으로 이동
- 모바일/탭 하단: `[문의/관심/조회] ↔ [공유]` 한 줄 space-between (피그마 1240-45672)
- PC 우측 컬럼: `h-full` 제거로 `self-stretch` 동작 + `pc:py-[3rem]` → 관심있어요/공유가 이미지 바닥에 정렬 (피그마 1226-55701)
- `FavoriteShareActions`: `showFavorite`/`showShare` prop 추가 (피그마 Frame1707484443 like/share)

## How to test
1. `/adoption/{id}` 진입
2. 모바일/탭 폭: 이미지 스와이프 동작, 화살표 미노출, 하단 통계 좌측 + 공유 우측
3. PC 폭: 좌우 화살표 노출(첫/마지막에서 해당 화살표 숨김), 우측 하단 관심/공유가 이미지 바닥 정렬