### PR TITLE
style(adoption): 입양 신청 버튼 hover/press 상태 스타일 추가

### DIFF
--- a/src/app/(main)/adoption/[id]/_ui/AdoptionCtaBar.tsx
+++ b/src/app/(main)/adoption/[id]/_ui/AdoptionCtaBar.tsx
@@ -25,7 +25,8 @@ const AdoptionCtaBar = ({ listingId }: AdoptionCtaBarProps) => (
 
       <Link
         href={`/adoption/${listingId}/apply`}
-        className="flex h-[3rem] max-w-[18.5625rem] flex-1 items-center justify-center rounded-full bg-[#fffa94] px-[0.5rem] text-[1rem] font-semibold text-[#3e3e3e] tab:h-[2rem] tab:max-w-[16.125rem] tab:text-[0.875rem]"
+        // hover: 글씨 #6b6b6b / press(active): 배경 #f3ec59 · 글씨 #3e3e3e (피그마 743-70327·743-70329)
+        className="flex h-[3rem] max-w-[18.5625rem] flex-1 items-center justify-center rounded-full bg-[#fffa94] px-[0.5rem] text-[1rem] font-semibold text-[#3e3e3e] tab:h-[2rem] tab:max-w-[16.125rem] tab:text-[0.875rem] hover:text-[#6b6b6b] active:bg-[#f3ec59] active:text-[#3e3e3e]"
       >
         입양 신청하기
       </Link>


### PR DESCRIPTION
Closes #146

## Changes
- 입양 상세 하단 CTA `입양 신청하기` 버튼에 상태 스타일 추가 (피그마 743-70327·743-70329)
  - hover: 배경 `#fffa94` 유지 + 글씨 `#6b6b6b`
  - press(active): 배경 `#f3ec59` + 글씨 `#3e3e3e`
- Tailwind 변수 순서상 `active:`가 `hover:` 뒤라 누를 때 글씨색이 `#3e3e3e`로 정상 적용

## How to test
1. `/adoption/{id}` 진입
2. 하단 입양 신청하기 버튼에 마우스 올리면 글씨 회색(#6b6b6b)
3. 클릭(누르고 있을 때) 배경 #f3ec59 + 글씨 #3e3e3e