### PR TITLE
feat(bookmarks): 저장피드 개별 피드 카드 및 ProfileHeader 공통 컴포넌트 추가

### DIFF
--- a/src/app/(main)/bookmarks/_ui/SavedFeedsTab.tsx
+++ b/src/app/(main)/bookmarks/_ui/SavedFeedsTab.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Container, SectionHeader } from '@/shared/ui'
+import { Container } from '@/shared/ui'
 import { PostCard } from '@/entities/community'
 import { toPostCardProps, type MyHomePost } from '@/shared/mocks/myHome'
 
@@ -9,27 +9,14 @@ interface SavedFeedsTabProps {
 }
 
 const SavedFeedsTab = ({ feeds }: SavedFeedsTabProps) => (
-  <Container>
-    <div className="pt-5 tab:pt-8">
-      <SectionHeader
-        title={`저장한 피드 ${feeds.length}`}
-        linkText="커뮤니티 가기"
-        linkHref="/community"
-      />
-    </div>
-
-    {/* 모바일: 카드 stack */}
-    <div className="flex flex-col gap-5 pb-15 tab:hidden">
+  // 저장피드 전용 패딩 — 모바일 py48·px16 / tab 48 전방향 (tab px는 Container 기본 48)
+  <Container className="px-4 py-12">
+    {/* 각 피드가 개별 보더 카드 (Figma 2091-148897) — 카드 간 gap 모바일 20 / tab 28, tab max-w 59.25rem 가운데 */}
+    <div className="flex flex-col gap-5 tab:mx-auto tab:max-w-[59.25rem] pc:gap-7">
       {feeds.map((post) => (
-        <PostCard key={post.id} {...toPostCardProps(post)} />
-      ))}
-    </div>
-
-    {/* PC: 개별 보더 카드 */}
-    <div className="hidden tab:mt-6 tab:flex tab:flex-col tab:gap-3 tab:pb-10">
-      {feeds.map((post) => (
-        <div key={post.id} className="overflow-hidden rounded-2xl border border-[#cacaca]">
-          <PostCard {...toPostCardProps(post)} />
+        <div key={post.id} className="rounded-lg border border-[#cacaca] bg-white">
+          {/* 저장피드: ProfileHeader sm 헤더 + 모바일 좌우 패딩 보완(px-3) */}
+          <PostCard profileType="sm" className="px-3" {...toPostCardProps(post)} />
         </div>
       ))}
     </div>

--- a/src/entities/community/ui/PostCard.tsx
+++ b/src/entities/community/ui/PostCard.tsx
@@ -1,9 +1,9 @@
 'use client'
 
-import type { ComponentType, SVGProps } from 'react'
+import { useState, type ComponentType, type SVGProps } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
-import { ProfileAvatar } from '@/shared/ui'
+import { ProfileAvatar, ProfileHeader } from '@/shared/ui'
 import { cn } from '@/shared/lib/cn'
 import {
   FavoriteIcon,
@@ -29,6 +29,8 @@ interface PostCardProps {
   commentCount: number
   /** 게시글 상세 링크 (있으면 본문 영역이 링크) */
   detailHref?: string
+  /** 지정 시 헤더를 공통 ProfileHeader(아바타 32/40·미리보기 1줄)로 렌더 + 이미지 tab 상단패딩 제거 (저장피드용) */
+  profileType?: 'sm' | 'md'
   className?: string
 }
 
@@ -60,9 +62,11 @@ const PostCard = ({
   likeCount,
   commentCount,
   detailHref,
+  profileType,
   className,
 }: PostCardProps) => {
   const hasImages = images.length > 0
+  const [isBookmarked, setIsBookmarked] = useState(false)
 
   const profileCluster = (
     <div className="flex min-w-0 flex-1 items-start gap-2">
@@ -95,23 +99,35 @@ const PostCard = ({
 
   return (
     <article className={cn('flex flex-col py-3 tab:p-3', className)}>
-      {/* 헤더: 프로필 + 더보기 */}
-      <div className="flex items-start justify-between gap-4 py-2 tab:py-3">
-        {detailHref ? (
-          <Link href={detailHref} className="flex min-w-0 flex-1">
-            {profileCluster}
-          </Link>
-        ) : (
-          profileCluster
-        )}
-        <button type="button" aria-label="더보기" className="shrink-0">
-          <MoreVertIcon className="size-6 text-[#3e3e3e]" />
-        </button>
-      </div>
+      {/* 헤더: profileType 지정 시 공통 ProfileHeader, 아니면 기본 인라인 헤더 */}
+      {profileType ? (
+        <ProfileHeader
+          type={profileType}
+          nickname={author.nickname}
+          createdAt={createdAt}
+          preview={text}
+          profileImageUrl={author.profileImageUrl}
+          detailHref={detailHref}
+          className="py-2 tab:py-3"
+        />
+      ) : (
+        <div className="flex items-start justify-between gap-4 py-2 tab:py-3">
+          {detailHref ? (
+            <Link href={detailHref} className="flex min-w-0 flex-1">
+              {profileCluster}
+            </Link>
+          ) : (
+            profileCluster
+          )}
+          <button type="button" aria-label="더보기" className="shrink-0">
+            <MoreVertIcon className="size-6 text-[#3e3e3e]" />
+          </button>
+        </div>
+      )}
 
-      {/* 이미지 (가로 스크롤) */}
+      {/* 이미지 (가로 스크롤) — 저장피드(profileType)는 상단패딩 제거 */}
       {hasImages && (
-        <div className="flex gap-3 overflow-x-auto pt-3">
+        <div className={cn('flex gap-3 overflow-x-auto pt-3', profileType && 'pt-0')}>
           {images.map((src, index) => (
             <div
               key={index}
@@ -129,8 +145,17 @@ const PostCard = ({
       <div className="flex items-center gap-2">
         <Stat icon={FavoriteIcon} count={likeCount} />
         <Stat icon={PixelMessageIcon} count={commentCount} />
-        <button type="button" aria-label="북마크" className="shrink-0">
-          <PixelBookmarkIcon className="size-8 text-[#a6a6a6]" />
+        <button
+          type="button"
+          aria-label="북마크"
+          aria-pressed={isBookmarked}
+          onClick={() => setIsBookmarked((prev) => !prev)}
+          className="shrink-0"
+        >
+          {/* 활성(저장) 시 브랜드 브라운 #a9835a */}
+          <PixelBookmarkIcon
+            className={cn('size-8', isBookmarked ? 'text-[#a9835a]' : 'text-[#a6a6a6]')}
+          />
         </button>
       </div>
     </article>

--- a/src/shared/ui/LabelTextButton.tsx
+++ b/src/shared/ui/LabelTextButton.tsx
@@ -29,33 +29,21 @@ const ACTION_SIZE = {
 
 type LabelTextButtonVariants = VariantProps<typeof labelTextButtonVariants>
 
-interface LabelTextButtonBase extends LabelTextButtonVariants {
+interface LabelTextButtonProps extends LabelTextButtonVariants {
   label: string
-  /** 우측 버튼 라벨 (없으면 버튼 미노출) */
-  actionLabel?: string
   className?: string
   /** 라벨 텍스트 스타일 오버라이드 (반응형 사이즈 등) */
   labelClassName?: string
+  /** 우측 텍스트버튼 라벨 — href와 함께 있을 때만 노출 (없으면 라벨 전용) */
+  actionLabel?: string
+  href?: string
 }
-
-interface LabelTextButtonAsLink extends LabelTextButtonBase {
-  href: string
-  onAction?: never
-}
-
-interface LabelTextButtonAsButton extends LabelTextButtonBase {
-  href?: never
-  onAction: (e: React.MouseEvent<HTMLButtonElement>) => void
-}
-
-type LabelTextButtonProps = LabelTextButtonAsLink | LabelTextButtonAsButton
 
 const LabelTextButton = ({
   size = 'large',
   label,
   actionLabel,
   href,
-  onAction,
   className,
   labelClassName,
 }: LabelTextButtonProps) => {
@@ -65,12 +53,9 @@ const LabelTextButton = ({
   return (
     <div className={cn(root(), className)}>
       <p className={cn(labelClass(), labelClassName)}>{label}</p>
-      {actionLabel &&
-        (href ? (
-          <DetailLink href={href} label={actionLabel} size={actionSize} />
-        ) : (
-          <DetailLink variant="button" onClick={onAction} label={actionLabel} size={actionSize} />
-        ))}
+      {actionLabel && href && (
+        <DetailLink href={href} label={actionLabel} size={actionSize} />
+      )}
     </div>
   )
 }

--- a/src/shared/ui/ProfileHeader.tsx
+++ b/src/shared/ui/ProfileHeader.tsx
@@ -1,0 +1,84 @@
+'use client'
+
+import Link from 'next/link'
+import { ProfileAvatar } from './ProfileAvatar'
+import { MoreVertIcon } from '@/shared/assets/icons'
+import { cn } from '@/shared/lib/cn'
+
+// Figma chat-profile (1867-182359) — 아바타 + 이름·시각 + 미리보기 1줄 + (옵션)빨간 배지 + 더보기
+// 채팅 리스트·저장피드 카드 헤더 공용. type: sm(아바타 32·이름 14) / md(아바타 40·이름 16).
+const NAME_SIZE = { sm: 'text-sm', md: 'text-base' } as const
+const AVATAR_SIZE = { sm: 'small', md: 'medium' } as const
+
+interface ProfileHeaderProps {
+  nickname: string
+  createdAt: string
+  /** 미리보기 본문 (1줄 말줄임) */
+  preview: string
+  profileImageUrl?: string
+  type?: 'sm' | 'md'
+  /** 빨간 알림 배지 카운트 (채팅용) — 없으면 미노출 */
+  badgeCount?: number
+  /** 프로필·본문 클릭 시 이동 링크 */
+  detailHref?: string
+  onMore?: () => void
+  className?: string
+}
+
+const ProfileHeader = ({
+  nickname,
+  createdAt,
+  preview,
+  profileImageUrl,
+  type = 'md',
+  badgeCount,
+  detailHref,
+  onMore,
+  className,
+}: ProfileHeaderProps) => {
+  const profile = (
+    <div className="flex min-w-0 flex-1 items-start gap-2">
+      <ProfileAvatar
+        size={AVATAR_SIZE[type]}
+        src={profileImageUrl}
+        alt={nickname}
+        className="shrink-0"
+      />
+      <div className="flex min-w-0 flex-1 flex-col justify-center">
+        <div className="flex items-center gap-2 p-0.5">
+          <span className={cn('truncate font-semibold text-[#3e3e3e]', NAME_SIZE[type])}>
+            {nickname}
+          </span>
+          <span className="shrink-0 text-xs leading-[1.5] font-medium text-[#6b6b6b]">
+            {createdAt}
+          </span>
+        </div>
+        <p className="truncate text-sm leading-[1.5] font-semibold text-[#3e3e3e]">{preview}</p>
+      </div>
+    </div>
+  )
+
+  return (
+    <div className={cn('flex items-start justify-between gap-4', className)}>
+      <div className="flex min-w-0 flex-1 items-center gap-4">
+        {detailHref ? (
+          <Link href={detailHref} className="flex min-w-0 flex-1">
+            {profile}
+          </Link>
+        ) : (
+          profile
+        )}
+        {badgeCount !== undefined && (
+          <span className="flex h-5 shrink-0 items-center justify-center rounded-full bg-[#d63d4a] px-2 text-sm leading-[1.5] text-white">
+            {badgeCount}
+          </span>
+        )}
+      </div>
+      <button type="button" aria-label="더보기" onClick={onMore} className="shrink-0">
+        <MoreVertIcon className="size-6 text-[#3e3e3e]" />
+      </button>
+    </div>
+  )
+}
+
+export { ProfileHeader }

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -1,5 +1,6 @@
 export * from './AlertMessage'
 export * from './AuthorInfo'
+export * from './ProfileHeader'
 export * from './Avatar'
 export * from './Breadcrumb'
 export * from './AvatarGroup'


### PR DESCRIPTION
Closes #164

## Changes
### 저장피드(저장목록)
- 각 피드를 개별 보더 카드로 구분 (Figma 2091-148897) — border #cacaca, rounded-8, 카드 간 gap 모바일 20 / pc 28
- Container 패딩 정리 (모바일 py48·px16 / tab 48 전방향)

### ProfileHeader 공통 컴포넌트 (Figma 1867-182359)
- shared/ui 신설 — type sm/md, 빨간 알림 배지(badgeCount) 옵션 → 채팅 재사용 대비
- PostCard `profileType` prop: 저장피드에서만 ProfileHeader 헤더 렌더 + 이미지 상단패딩 제거

### PostCard 북마크 토글
- 북마크 클릭 시 활성 색(브랜드 브라운 #a9835a) 토글, aria-pressed 반영

### 정리
- LabelTextButton action prop optional로 단순화 (미사용 버튼 분기 제거)

## How to test
1. \`/bookmarks\` → 저장 피드 탭
2. 각 피드가 개별 보더 카드로 구분되는지 (모바일 단일 이미지 / tab 가로 스크롤)
3. 헤더가 ProfileHeader sm(아바타 32·이름 14·미리보기 1줄)인지, 이미지 위 상단패딩 없는지
4. 북마크 아이콘 클릭 시 브라운(#a9835a)으로 토글되는지