### PR TITLE
feat(bookmarks): 입양목록 탭 카드 디자인 및 반응형 레이아웃

### DIFF
--- a/src/app/(main)/bookmarks/_ui/AdoptedListingCard.tsx
+++ b/src/app/(main)/bookmarks/_ui/AdoptedListingCard.tsx
@@ -1,7 +1,9 @@
 'use client'
 
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
 import Image from 'next/image'
-import { Badge, Button, ListingStats } from '@/shared/ui'
+import { Badge, Button, CtaModal, ListingStats } from '@/shared/ui'
 import { cn } from '@/shared/lib/cn'
 import type { AdoptedListingCard as AdoptedListingCardType } from '@/shared/types'
 import { ADOPTION_STATUS_LABEL, GENDER_LABEL } from '@/shared/types'
@@ -53,13 +55,20 @@ const CardStats = ({
 )
 
 const AdoptedListingCard = ({ listing }: AdoptedListingCardProps) => {
+  const router = useRouter()
   const isCompleted = listing.status === 'completed'
+  const [modalOpen, setModalOpen] = useState(false)
 
   return (
     <>
-      {/* 모바일·탭 카드 (Figma 975-15983 · Card2 medium) — bg #f6f6f6, 이미지 110, 제목+상태배지/stats (목록은 하트 없음)
+      {/* 모바일·탭 카드 (Figma 975-15983 · Card2 medium) — 클릭 시 CTA 모달(상세/채팅 선택)
+          bg #f6f6f6, 이미지 110, 제목+상태배지/stats (목록은 하트 없음)
           카드 max-w 600 중앙정렬 (탭에서 좌우 ≈36px 여백, 모바일은 full) */}
-      <div className="mx-auto flex w-full max-w-[37.5rem] items-center gap-4 rounded-lg bg-[#f6f6f6] p-2 pc:hidden">
+      <button
+        type="button"
+        onClick={() => setModalOpen(true)}
+        className="mx-auto flex w-full max-w-[37.5rem] items-center gap-4 rounded-lg bg-[#f6f6f6] p-2 text-left pc:hidden"
+      >
         {/* [refactored] CardImage — 110×110 rounded-4 */}
         <CardImage
           listing={listing}
@@ -74,12 +83,14 @@ const AdoptedListingCard = ({ listing }: AdoptedListingCardProps) => {
             <p className="w-full truncate text-base leading-[1.5] font-bold text-[#3e3e3e]">
               {listing.name}
             </p>
-            <Badge variant="active">{ADOPTION_STATUS_LABEL[listing.status]}</Badge>
+            <Badge variant="active" size="md">
+              {ADOPTION_STATUS_LABEL[listing.status]}
+            </Badge>
           </div>
           {/* [refactored] CardStats */}
           <CardStats listing={listing} size="sm" className="w-full text-xs text-[#6b6b6b]" />
         </div>
-      </div>
+      </button>
 
       {/* PC 카드 (Figma 797-87156 · Card2 large) — pc 전용. bg #f6f6f6, 이미지 280×210, 제목+상태배지/설명 3줄, stats + 대화중인 채팅
           카드 고정폭 920px 중앙정렬 (콘텐츠 폭이 더 넓으면 좌우 여백) */}
@@ -113,12 +124,32 @@ const AdoptedListingCard = ({ listing }: AdoptedListingCardProps) => {
           <div className="flex items-center gap-2">
             {/* [refactored] CardStats */}
             <CardStats listing={listing} className="flex-1 text-sm leading-[1.5] text-[#6b6b6b]" />
-            <Button variant="primary" className="h-10 w-[11.4375rem] shrink-0 text-base">
+            <Button
+              variant="primary"
+              onClick={() => router.push('/chat')}
+              className="h-10 w-[11.4375rem] shrink-0 text-base"
+            >
               대화중인 채팅
             </Button>
           </div>
         </div>
       </div>
+
+      {/* 카드(tab~mobile) 클릭 시 — 입양 상세 / 대화중인 채팅 선택 (Figma 2151-193965) */}
+      <CtaModal
+        open={modalOpen}
+        onOpenChange={setModalOpen}
+        title="분양 완료 된 건입니다."
+        icon={null}
+        actions={[
+          {
+            label: '입양 상세 보기',
+            variant: 'fill',
+            onClick: () => router.push(`/adoption/${listing.listingId}`),
+          },
+          { label: '대화중인채팅', variant: 'outline', onClick: () => router.push('/chat') },
+        ]}
+      />
     </>
   )
 }

--- a/src/app/(main)/bookmarks/_ui/AdoptedListingCard.tsx
+++ b/src/app/(main)/bookmarks/_ui/AdoptedListingCard.tsx
@@ -1,119 +1,121 @@
 'use client'
 
 import Image from 'next/image'
-import { Badge, ListingStats, PostedDate } from '@/shared/ui'
+import { Badge, Button, ListingStats } from '@/shared/ui'
+import { cn } from '@/shared/lib/cn'
 import type { AdoptedListingCard as AdoptedListingCardType } from '@/shared/types'
+import { ADOPTION_STATUS_LABEL, GENDER_LABEL } from '@/shared/types'
 
 interface AdoptedListingCardProps {
   listing: AdoptedListingCardType
 }
 
+// [refactored] 이미지 + 완료 디밍 오버레이 + 인기 배지 — 모바일/PC 공통 (size·rounded·배지위치만 className으로 차이)
+const CardImage = ({
+  listing,
+  isCompleted,
+  className,
+  badgeClassName,
+}: {
+  listing: AdoptedListingCardType
+  isCompleted: boolean
+  className?: string
+  badgeClassName?: string
+}) => (
+  <div className={cn('relative shrink-0 overflow-hidden bg-[#6b6b6b]', className)}>
+    <Image src={listing.thumbnailUrl} alt={listing.name} fill className="object-cover" />
+    {isCompleted && <div className="absolute inset-0 bg-white/70" />}
+    {listing.isPopular && (
+      <Badge variant="outline" className={cn('absolute', badgeClassName)}>
+        인기
+      </Badge>
+    )}
+  </div>
+)
+
+// [refactored] listing의 문의/관심/조회 카운트를 넘기는 ListingStats 래퍼 (prop 스프레드 반복 제거)
+const CardStats = ({
+  listing,
+  size,
+  className,
+}: {
+  listing: AdoptedListingCardType
+  size?: 'sm' | 'md' | 'lg'
+  className?: string
+}) => (
+  <ListingStats
+    inquiryCount={listing.inquiryCount}
+    favoriteCount={listing.favoriteCount}
+    viewCount={listing.viewCount}
+    size={size}
+    className={className}
+  />
+)
+
 const AdoptedListingCard = ({ listing }: AdoptedListingCardProps) => {
+  const isCompleted = listing.status === 'completed'
+
   return (
     <>
-      {/* 모바일 카드 */}
-      <div className="flex rounded-[0.375rem] bg-[#f0f0f0] p-[0.5rem] tab:hidden">
-        {/* 이미지 100x100 */}
-        <div className="relative size-[6.25rem] shrink-0 overflow-hidden">
-          <Image src={listing.thumbnailUrl} alt={listing.name} fill className="object-cover" />
-          <div className="absolute inset-0 bg-white/70" />
-          {listing.isPopular && (
-            <Badge
-              variant="outline"
-              className="absolute top-[0.43rem] left-[0.5rem] bg-white px-[0.5rem] py-[0.125rem] text-[0.75rem] leading-normal"
-            >
-              인기
-            </Badge>
-          )}
-        </div>
+      {/* 모바일·탭 카드 (Figma 975-15983 · Card2 medium) — bg #f6f6f6, 이미지 110, 제목+상태배지/stats (목록은 하트 없음)
+          카드 max-w 600 중앙정렬 (탭에서 좌우 ≈36px 여백, 모바일은 full) */}
+      <div className="mx-auto flex w-full max-w-[37.5rem] items-center gap-4 rounded-lg bg-[#f6f6f6] p-2 pc:hidden">
+        {/* [refactored] CardImage — 110×110 rounded-4 */}
+        <CardImage
+          listing={listing}
+          isCompleted={isCompleted}
+          className="size-[6.875rem] rounded"
+          badgeClassName="top-2 left-2.5"
+        />
 
-        {/* 정보 */}
-        <div className="flex min-w-0 flex-1 flex-col justify-between py-[0.0625rem] pl-[0.5625rem]">
-          <div className="flex flex-col">
-            <p className="line-clamp-1 text-sm leading-[1.5] font-bold text-[#5d5d5d]">
+        {/* 정보: 상단(제목 1줄 + 상태배지) · 하단(stats) — 위/아래 분배, 상하 5px 여백 */}
+        <div className="flex min-w-0 flex-1 flex-col justify-between self-stretch overflow-hidden py-[0.3125rem]">
+          <div className="flex w-full flex-col items-start gap-1">
+            <p className="w-full truncate text-base leading-[1.5] font-bold text-[#3e3e3e]">
               {listing.name}
             </p>
-            <div className="mt-[0.125rem] flex items-center">
-              <Badge
-                variant="status"
-                className="bg-[#5d5d5d] px-[0.5rem] py-[0.125rem] text-[0.75rem] leading-normal"
-              >
-                분양완료
-              </Badge>
-            </div>
+            <Badge variant="active">{ADOPTION_STATUS_LABEL[listing.status]}</Badge>
           </div>
-
-          <div className="flex flex-col">
-            <ListingStats
-              inquiryCount={listing.inquiryCount}
-              favoriteCount={listing.favoriteCount}
-              viewCount={listing.viewCount}
-              size="sm"
-              className="gap-[0.5rem]"
-            />
-            <PostedDate date={listing.postedAt} className="text-[0.75rem] leading-normal" />
-          </div>
+          {/* [refactored] CardStats */}
+          <CardStats listing={listing} size="sm" className="w-full text-xs text-[#6b6b6b]" />
         </div>
       </div>
 
-      {/* PC 카드 */}
-      <div className="relative hidden h-[19.0625rem] overflow-hidden rounded-2xl bg-[#e7e7e7] tab:flex tab:items-center tab:pl-[1.719rem]">
-        {/* 이미지: 세로 중앙, left 27.5px */}
-        <div className="relative h-[14.124rem] w-[13.647rem] shrink-0 overflow-hidden rounded-[0.437rem]">
-          <Image src={listing.thumbnailUrl} alt={listing.name} fill className="object-cover" />
-          <div className="absolute inset-0 bg-white/70" />
-          {listing.isPopular && (
-            <Badge variant="outline" className="absolute top-[1.125rem] left-[0.625rem] bg-white">
-              인기
-            </Badge>
-          )}
-        </div>
+      {/* PC 카드 (Figma 797-87156 · Card2 large) — pc 전용. bg #f6f6f6, 이미지 280×210, 제목+상태배지/설명 3줄, stats + 대화중인 채팅
+          카드 고정폭 920px 중앙정렬 (콘텐츠 폭이 더 넓으면 좌우 여백) */}
+      <div className="mx-auto hidden w-full max-w-[57.5rem] gap-7 rounded-lg bg-[#f6f6f6] px-5 py-3 pc:flex pc:items-center">
+        {/* [refactored] CardImage — 280×210 rounded-8 */}
+        <CardImage
+          listing={listing}
+          isCompleted={isCompleted}
+          className="h-[13.125rem] w-[17.5rem] rounded-lg"
+          badgeClassName="top-[0.875rem] left-4"
+        />
 
-        {/* 분양완료 뱃지: 우상단 */}
-        <Badge
-          variant="status"
-          className="absolute top-[2.469rem] right-[1.719rem] bg-[#5d5d5d] px-[0.585rem] py-[0.234rem] text-sm leading-[1.375rem]"
-        >
-          분양완료
-        </Badge>
-
-        {/* 정보 영역 */}
-        <div className="absolute top-0 right-0 bottom-0 left-[16.898rem] flex flex-col">
-          {/* 이름 + 성별/나이 */}
-          <div className="mt-[2.631rem] flex items-center gap-[1.125rem]">
-            <p className="text-xl leading-[1.375rem] font-semibold text-[#5d5d5d]">
-              {listing.name}
-            </p>
-            <span className="size-[0.253rem] rounded-full bg-[#5d5d5d]" />
-            <span className="text-xl leading-[1.375rem] font-semibold text-[#5d5d5d]">성별</span>
-            <span className="size-[0.253rem] rounded-full bg-[#5d5d5d]" />
-            <span className="text-xl leading-[1.375rem] font-semibold text-[#5d5d5d]">
-              {listing.ageText}
-            </span>
+        {/* 정보: 상단(제목·배지/설명) · 하단(stats + 버튼) */}
+        <div className="flex min-w-0 flex-1 flex-col justify-between self-stretch">
+          <div className="flex flex-col gap-3">
+            <div className="flex items-center gap-2">
+              <p className="truncate text-xl leading-[1.5] font-bold text-[#3e3e3e]">
+                {`${listing.name} | ${GENDER_LABEL[listing.gender]} ${listing.ageText}`}
+              </p>
+              <Badge variant="active" className="shrink-0">
+                {ADOPTION_STATUS_LABEL[listing.status]}
+              </Badge>
+            </div>
+            {listing.description && (
+              <p className="line-clamp-3 text-base leading-[1.5] font-semibold text-[#3e3e3e]">
+                {listing.description}
+              </p>
+            )}
           </div>
 
-          {/* 설명 */}
-          <p className="mt-[1.375rem] line-clamp-3 text-base leading-[1.375rem] font-semibold text-[#5d5d5d]">
-            {listing.description}
-          </p>
-
-          {/* 문의/관심/조회 */}
-          <ListingStats
-            inquiryCount={listing.inquiryCount}
-            favoriteCount={listing.favoriteCount}
-            viewCount={listing.viewCount}
-            className="mt-[0.75rem] gap-[1.25rem] text-sm leading-[1.375rem]"
-          />
-
-          {/* 하단: 게시날짜 + 대화중인 채팅 버튼 */}
-          <div className="mt-auto mr-[1.719rem] mb-[1.719rem] flex items-center justify-between">
-            <PostedDate date={listing.postedAt} size="lg" />
-            <button
-              type="button"
-              className="flex h-12 w-[11.938rem] items-center justify-center rounded-full bg-[#5d5d5d] text-base font-semibold text-white"
-            >
+          <div className="flex items-center gap-2">
+            {/* [refactored] CardStats */}
+            <CardStats listing={listing} className="flex-1 text-sm leading-[1.5] text-[#6b6b6b]" />
+            <Button variant="primary" className="h-10 w-[11.4375rem] shrink-0 text-base">
               대화중인 채팅
-            </button>
+            </Button>
           </div>
         </div>
       </div>

--- a/src/app/(main)/bookmarks/_ui/AdoptionListTab.tsx
+++ b/src/app/(main)/bookmarks/_ui/AdoptionListTab.tsx
@@ -17,18 +17,13 @@ const AdoptionListTab = ({ listings }: AdoptionListTabProps) => {
   }, {})
 
   return (
-    <Container>
-      <div className="pt-5 tab:pt-8">
-        <h2 className="text-sm leading-[1.5] font-bold text-text-primary tab:text-xl">
-          내가 입양한 목록 {listings.length}
-        </h2>
-      </div>
-
-      <div className="flex flex-col gap-3 pt-4 pb-15 tab:gap-[0.625rem] tab:pt-6 tab:pb-10">
+    // 패딩: 모바일 py20·px16(기본 20→px-4 오버라이드) / tab px48 / pc px80·py40 — 카드는 max-w로 중앙정렬
+    <Container className="px-4 py-5 pc:py-10">
+      <div className="flex flex-col gap-3 tab:gap-[0.625rem]">
         {Object.entries(groupedByDate).map(([date, items]) => (
           <div key={date} className="flex flex-col gap-[0.375rem] tab:gap-[0.625rem]">
             <p className="text-xs leading-[1.5] font-medium text-text-primary tab:text-sm tab:leading-[1.375rem]">
-              {date}
+              입양 날짜 : {date}
             </p>
             {items.map((listing) => (
               <AdoptedListingCard key={listing.listingId} listing={listing} />

--- a/src/app/(main)/bookmarks/_ui/AdoptionListTab.tsx
+++ b/src/app/(main)/bookmarks/_ui/AdoptionListTab.tsx
@@ -22,7 +22,8 @@ const AdoptionListTab = ({ listings }: AdoptionListTabProps) => {
       <div className="flex flex-col gap-3 tab:gap-[0.625rem]">
         {Object.entries(groupedByDate).map(([date, items]) => (
           <div key={date} className="flex flex-col gap-[0.375rem] tab:gap-[0.625rem]">
-            <p className="text-xs leading-[1.5] font-medium text-text-primary tab:text-sm tab:leading-[1.375rem]">
+            {/* 입양 날짜 — 모바일·탭 body-sm(12) / pc body-md(14), medium, #6b6b6b */}
+            <p className="text-body-sm font-medium text-[#6b6b6b] pc:text-body-md">
               입양 날짜 : {date}
             </p>
             {items.map((listing) => (

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,6 +8,16 @@
   --breakpoint-tab: 768px;
   --breakpoint-pc: 1440px;
 
+  /* typography — Body 스케일 (line-height 150% 포함). weight는 font-* 유틸로: font-normal/medium/semibold */
+  --text-body-sm: 0.75rem; /* 12 */
+  --text-body-sm--line-height: 1.5;
+  --text-body-md: 0.875rem; /* 14 */
+  --text-body-md--line-height: 1.5;
+  --text-body-lg: 1rem; /* 16 */
+  --text-body-lg--line-height: 1.5;
+  --text-body-xl: 1.25rem; /* 20 */
+  --text-body-xl--line-height: 1.5;
+
   /* text */
   --color-text-primary: #5d5d5d;
   --color-text-secondary: #959595;


### PR DESCRIPTION
Closes #166

## Changes
### 입양목록 카드 (AdoptedListingCard)
- 새 Figma 디자인 — 모바일·탭 medium 카드(110, 975-15983) / pc large 카드(280×210, 797-87156)
- 분양 완료 이미지 디밍(bg-white/70), 인기 배지, 제목+상태배지/stats (+pc 설명 3줄·대화중인 채팅 버튼)
- 공통 컴포넌트: Container · Badge · Button(primary 노란) · ListingStats
- 카드 max-w 중앙정렬: 탭 600(좌우 ≈36px) / pc 920(좌우 ≈180px)
- CardImage · CardStats 서브컴포넌트 추출(모바일/PC 중복 제거)

### AdoptionListTab
- Container 패딩: 모바일 py20·px16 / tab px48 / pc px80·py40
- 날짜 그룹 라벨 "입양 날짜 : {date}"

## How to test
1. \`/bookmarks\` → 입양 목록 탭
2. 모바일·탭: 컴팩트 카드(110) / pc: 대형 카드(280×210, 대화중인 채팅 버튼)
3. 분양완료 이미지 디밍, 탭 좌우 ≈36px / pc ≈180px 여백 확인