### PR TITLE
feat(mypage): 회원 탈퇴 사유 선택 모달 + 프로필 변경 시 커뮤니티 작성자 캐시 무효화

### DIFF
--- a/src/app/(main)/home/edit/_ui/ProfileEditContent.tsx
+++ b/src/app/(main)/home/edit/_ui/ProfileEditContent.tsx
@@ -24,6 +24,7 @@ import {
   TextareaField,
 } from '@/shared/ui'
 import { CheckIcon } from '@/shared/assets/icons'
+import { WithdrawReasonModal } from './WithdrawReasonModal'
 
 // [refactored] 매직 넘버·문자열 상수화
 const TOAST_DURATION_MS = 3000
@@ -71,7 +72,12 @@ const ProfileEditContent = () => {
   const [name, setName] = useState('')
   const [bio, setBio] = useState('')
   const [showApply, setShowApply] = useState(false)
-  const [showLeave, setShowLeave] = useState(false)
+  const [showReason, setShowReason] = useState(false) // 탈퇴 사유 선택 단계
+  const [showLeave, setShowLeave] = useState(false) // 탈퇴 최종 확인 단계
+  // 선택한 탈퇴 사유(확인 모달에서 실제 요청 시 사용)
+  const [withdraw, setWithdraw] = useState<{ reason: WithdrawReason; otherReason?: string } | null>(
+    null,
+  )
 
   const toast = useToast() // [refactored]
 
@@ -174,11 +180,22 @@ const ProfileEditContent = () => {
     }
   }
 
-  // 탈퇴: reason은 'other' 고정 (사유 선택 UI는 추후)
+  // 사유 선택 완료 → 최종 확인 모달로 전환
+  const handleReasonNext = (reason: WithdrawReason, otherReason?: string) => {
+    setWithdraw({ reason, otherReason })
+    setShowReason(false)
+    setShowLeave(true)
+  }
+
+  // 탈퇴: 사용자가 선택한 사유(+기타 상세)로 요청 — reason='other'면 otherReason 동반
   const handleLeave = async () => {
+    if (!withdraw) return
     setShowLeave(false)
     try {
-      await deleteAccount.mutateAsync({ reason: WithdrawReason.OTHER })
+      await deleteAccount.mutateAsync({
+        reason: withdraw.reason,
+        ...(withdraw.otherReason ? { otherReason: withdraw.otherReason } : {}),
+      })
       router.replace('/')
     } catch {
       // TODO: 실패 처리
@@ -272,7 +289,7 @@ const ProfileEditContent = () => {
         <div className="flex items-center gap-10">
           {/* 탈퇴는 입양자 전용 API(useDeleteAdopterAccount) — 브리더에선 숨김 */}
           {!isBreeder && (
-            <Button variant="text" onClick={() => setShowLeave(true)}>
+            <Button variant="text" onClick={() => setShowReason(true)}>
               탈퇴
             </Button>
           )}
@@ -344,6 +361,9 @@ const ProfileEditContent = () => {
           { label: '적용하기', variant: 'fill', onClick: handleApply },
         ]}
       />
+
+      {/* 탈퇴 사유 선택 (확인 모달 앞 단계) — 선택 완료 시 최종 확인 모달로 전환 */}
+      <WithdrawReasonModal open={showReason} onOpenChange={setShowReason} onNext={handleReasonNext} />
 
       {/* 계정 탈퇴 확인 (디자인 2145-193207 / 모바일·탭 2145-193342) */}
       <ConfirmModal

--- a/src/app/(main)/home/edit/_ui/WithdrawReasonModal.tsx
+++ b/src/app/(main)/home/edit/_ui/WithdrawReasonModal.tsx
@@ -1,0 +1,138 @@
+'use client'
+
+import { useState } from 'react'
+import * as DialogPrimitive from '@radix-ui/react-dialog'
+import { WithdrawReason } from '@/shared/types'
+import { Dialog, DialogOverlay, DialogPortal, Textarea, ctaModalButton } from '@/shared/ui'
+import { CheckIcon } from '@/shared/assets/icons'
+import { cn } from '@/shared/lib/cn'
+
+// 탈퇴 사유 옵션 (백엔드 AdopterWithdrawReason / Figma 설문 기준)
+const WITHDRAW_REASONS: { value: WithdrawReason; label: string }[] = [
+  { value: WithdrawReason.ALREADY_ADOPTED, label: '이미 입양을 마쳤어요' },
+  { value: WithdrawReason.NO_SUITABLE_PET, label: '마음에 드는 아이가 없어요' },
+  { value: WithdrawReason.ADOPTION_FEE_BURDEN, label: '입양비가 부담돼요' },
+  { value: WithdrawReason.UNCOMFORTABLE_UI, label: '사용하기 불편했어요' },
+  { value: WithdrawReason.PRIVACY_CONCERN, label: '개인정보나 보안이 걱정돼요' },
+  { value: WithdrawReason.OTHER, label: '다른 이유로 탈퇴하고 싶어요' },
+]
+
+const OTHER_REASON_MAX_LENGTH = 200
+
+interface WithdrawReasonModalProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** 사유 선택 완료 → 다음(확인) 단계로. reason='other'면 otherReason 동반. */
+  onNext: (reason: WithdrawReason, otherReason?: string) => void
+}
+
+/**
+ * 회원 탈퇴 사유 선택 모달 (기존 확인 모달 앞 단계).
+ * 팀원의 CtaModal/확인 모달은 그대로 두고, 그 앞에 사유 설문 단계만 추가한다.
+ * 컨테이너·버튼 스타일은 CtaModal 토큰(ctaModalButton, rounded-xl 등)을 재사용해 톤을 맞춘다.
+ */
+const WithdrawReasonModal = ({ open, onOpenChange, onNext }: WithdrawReasonModalProps) => {
+  const [reason, setReason] = useState<WithdrawReason | null>(null)
+  const [otherReason, setOtherReason] = useState('')
+
+  // 모달을 닫을 때 선택 상태를 초기화해, 다시 열었을 때 이전 선택이 남지 않게 한다.
+  // effect 대신 렌더 중 상태 동기화(React 권장 패턴) — open 전환을 감지해 초기화한다.
+  const [prevOpen, setPrevOpen] = useState(open)
+  if (prevOpen !== open) {
+    setPrevOpen(open)
+    if (!open) {
+      setReason(null)
+      setOtherReason('')
+    }
+  }
+
+  const isOther = reason === WithdrawReason.OTHER
+  const canProceed = reason !== null && (!isOther || otherReason.trim().length > 0)
+
+  const handleNext = () => {
+    if (!canProceed || reason === null) return
+    onNext(reason, isOther ? otherReason.trim() : undefined)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogPortal>
+        <DialogOverlay />
+        <DialogPrimitive.Content
+          aria-describedby={undefined}
+          className="fixed top-1/2 left-1/2 z-50 flex w-[calc(100vw-2.5rem)] max-w-[19.5rem] -translate-x-1/2 -translate-y-1/2 flex-col gap-4 rounded-xl bg-white p-5 data-[state=closed]:opacity-0 data-[state=open]:opacity-100 pc:max-w-[22.5rem]"
+        >
+          <DialogPrimitive.Title className="text-center text-xl leading-normal font-semibold text-[#3e3e3e]">
+            탈퇴하는 이유를 알려주세요
+          </DialogPrimitive.Title>
+
+          {/* 단일 선택(라디오) 사유 목록 */}
+          <div role="radiogroup" aria-label="탈퇴 사유" className="flex flex-col gap-2">
+            {WITHDRAW_REASONS.map(({ value, label }) => {
+              const selected = reason === value
+              return (
+                <button
+                  key={value}
+                  type="button"
+                  role="radio"
+                  aria-checked={selected}
+                  onClick={() => setReason(value)}
+                  className={cn(
+                    'flex items-center justify-between gap-2 rounded-lg border px-3 py-2.5 text-left text-sm font-medium transition-colors',
+                    selected
+                      ? 'border-[#3e3e3e] bg-[#f5f5f5] text-[#3e3e3e]'
+                      : 'border-[#e4e4e4] text-[#6b6b6b] hover:bg-[#f5f5f5]',
+                  )}
+                >
+                  <span>{label}</span>
+                  {selected && <CheckIcon className="size-4 shrink-0 text-[#3e3e3e]" />}
+                </button>
+              )
+            })}
+          </div>
+
+          {/* 'other' 선택 시 상세 사유 입력 (백엔드에서 필수) */}
+          {isOther && (
+            <div className="flex flex-col gap-1">
+              <Textarea
+                value={otherReason}
+                onChange={(e) => setOtherReason(e.target.value)}
+                maxLength={OTHER_REASON_MAX_LENGTH}
+                placeholder="탈퇴 사유를 입력해주세요"
+                state={otherReason.trim().length > 0 ? 'fill' : 'default'}
+                className="h-[5rem]"
+              />
+              <p className="self-end text-[0.625rem] leading-[1.5] font-medium text-[#6b6b6b]">
+                {otherReason.length}/{OTHER_REASON_MAX_LENGTH}
+              </p>
+            </div>
+          )}
+
+          {/* 하단 버튼 — 모바일·탭 세로 → pc 가로 (CtaModal responsive 규칙과 동일) */}
+          <div className="flex flex-col-reverse gap-2 pc:flex-row pc:gap-4">
+            <button
+              type="button"
+              onClick={() => onOpenChange(false)}
+              className={ctaModalButton({ variant: 'outline' })}
+            >
+              취소
+            </button>
+            <button
+              type="button"
+              onClick={handleNext}
+              disabled={!canProceed}
+              className={cn(
+                ctaModalButton({ variant: 'fill' }),
+                !canProceed && 'cursor-not-allowed opacity-50',
+              )}
+            >
+              다음
+            </button>
+          </div>
+        </DialogPrimitive.Content>
+      </DialogPortal>
+    </Dialog>
+  )
+}
+
+export { WithdrawReasonModal }

--- a/src/features/adopter/api/adopter.mutations.ts
+++ b/src/features/adopter/api/adopter.mutations.ts
@@ -2,6 +2,7 @@
 
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { adopterQueries } from '@/entities/adopter'
+import { communityQueries } from '@/entities/community'
 import {
   updateAdopterProfile,
   deleteAdopterAccount,
@@ -21,6 +22,9 @@ export const useUpdateAdopterProfile = () => {
     mutationFn: (data: AdopterProfileUpdateRequest) => updateAdopterProfile(data),
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: adopterQueries.profile().queryKey })
+      // 닉네임/프로필 이미지는 커뮤니티 게시글·댓글에 작성자 snapshot 으로 복제돼 있어,
+      // 프로필 변경 시 커뮤니티 목록(내가 쓴 글/피드/상세)도 갱신되도록 무효화한다.
+      void qc.invalidateQueries({ queryKey: communityQueries.all() })
     },
   })
 }

--- a/src/features/breeder/api/breeder.mutations.ts
+++ b/src/features/breeder/api/breeder.mutations.ts
@@ -2,6 +2,7 @@
 
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { breederQueries } from '@/entities/breeder'
+import { communityQueries } from '@/entities/community'
 import type {
   ProfileUpdateRequestDto,
   ApplicationStatusUpdateRequest,
@@ -43,6 +44,8 @@ export const useUpdateBreederProfile = () => {
     mutationFn: (data: ProfileUpdateRequestDto) => updateBreederProfile(data),
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: breederQueries.all() })
+      // 프로필 이미지는 커뮤니티 작성자 snapshot 으로 복제돼 있어, 변경 시 커뮤니티 목록도 갱신되도록 무효화한다.
+      void qc.invalidateQueries({ queryKey: communityQueries.all() })
     },
   })
 }


### PR DESCRIPTION
## Changes
- 회원 탈퇴 사유 선택 UI 구현 (기존 `reason: 'other'` 하드코딩으로 백엔드 설문 검증 400 나던 문제 해소)
  - 팀원의 확인 모달(`CtaModal`)은 그대로 두고, 그 앞 단계로 `WithdrawReasonModal` 추가 (`Dialog`·`ctaModalButton`·`Textarea` 재사용)
  - 사유 6종 단일 선택 + 'other' 선택 시 상세 입력 → `reason`(+`otherReason`) 전송
- 프로필 변경 시 커뮤니티 작성자 캐시 무효화
  - `useUpdateAdopterProfile`/`useUpdateBreederProfile` `onSuccess` 에서 `communityQueries.all()` 무효화
  - 닉네임·프로필 이미지가 커뮤니티 게시글/댓글 작성자 snapshot 으로 복제돼 있어, 변경 후 '내가 쓴 글'/피드/상세가 즉시 리페치되도록 함

## How to test
1. `pnpm type-check` / `eslint` 통과
2. 마이홈 → 프로필 편집 → 탈퇴 → 사유 선택 모달에서 사유 선택('기타' 시 상세 입력 필수) → 확인 모달 → 탈퇴 정상 동작
3. 닉네임/프로필 사진 변경 후 마이홈 '내가 쓴 글'에 즉시 반영되는지 확인
