### PR TITLE
feat(explore): explore 페이지 리디자인

### DIFF
--- a/src/app/(main)/explore/_ui/ExploreAdoptionCard.tsx
+++ b/src/app/(main)/explore/_ui/ExploreAdoptionCard.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import { useToggleAdoptionFavorite } from '@/features/adoption'
+import { AdoptionGridCard } from '@/entities/adoption'
+import type { AdoptionListingCard } from '@/shared/types'
+
+// 탐색 그리드 카드 — 공용 AdoptionGridCard에 관심 토글만 연결
+const ExploreAdoptionCard = ({ listing }: { listing: AdoptionListingCard }) => {
+  const { isFavorite, toggleFavorite } = useToggleAdoptionFavorite(
+    listing.listingId,
+    listing.isFavorited,
+  )
+
+  return (
+    <AdoptionGridCard listing={listing} isFavorite={isFavorite} onToggle={toggleFavorite} />
+  )
+}
+
+export { ExploreAdoptionCard }

--- a/src/app/(main)/explore/_ui/ExploreContent.tsx
+++ b/src/app/(main)/explore/_ui/ExploreContent.tsx
@@ -1,8 +1,15 @@
 'use client'
 
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useSearchParams, useRouter, usePathname } from 'next/navigation'
-import { Container, Tabs, TabsList, TabsTrigger } from '@/shared/ui'
+import {
+  badgeVariants,
+  Container,
+  PopularBadgeContent,
+  Tabs,
+  TabsList,
+  TabsTrigger,
+} from '@/shared/ui'
 import { SearchSection } from '@/features/search'
 import { CategorySection } from '@/features/category-filter'
 import { cn } from '@/shared/lib/cn'
@@ -11,15 +18,22 @@ import { useGnbHeight } from '@/shared/lib/useGnbHeight'
 import { createMockListings } from '@/shared/mocks/adoption'
 import { ANIMAL_CATEGORIES } from '@/shared/types'
 import type { AnimalCategory } from '@/shared/types'
-import { FavoriteAdoptionCard } from '@/features/adoption'
 import { BreederExploreContent } from './BreederExploreContent'
+import { ExploreAdoptionCard } from './ExploreAdoptionCard'
 import { ExploreListingSection } from './ExploreListingSection'
 import { ExploreFilterBar } from './ExploreFilterBar'
 import { EXPLORE_TABS, SEARCH_PLACEHOLDERS, EXPLORE_SECTION_CONTAINER } from '../_lib/constants'
 import type { ExploreType } from '../_lib/constants'
 
 const mockListings = createMockListings()
-const popularListings = mockListings.filter((l) => l.isPopular)
+
+type AdoptionListFilter = 'all' | 'available' | 'popular'
+
+const ADOPTION_LIST_FILTERS: Array<{ value: AdoptionListFilter; label: string }> = [
+  { value: 'all', label: '전체' },
+  { value: 'available', label: '분양중' },
+  { value: 'popular', label: '인기' },
+]
 
 const ExploreContent = () => {
   const searchParams = useSearchParams()
@@ -28,6 +42,17 @@ const ExploreContent = () => {
 
   const typeParam = searchParams.get('type')
   const selectedType: ExploreType = typeParam === 'breeder' ? 'breeder' : 'adoption'
+  const [adoptionListFilter, setAdoptionListFilter] = useState<AdoptionListFilter>('all')
+
+  const filteredListings = useMemo(() => {
+    if (adoptionListFilter === 'available') {
+      return mockListings.filter((listing) => listing.status === 'available')
+    }
+    if (adoptionListFilter === 'popular') {
+      return mockListings.filter((listing) => listing.isPopular)
+    }
+    return mockListings
+  }, [adoptionListFilter])
 
   const categoryParam = searchParams.get('category')
   const selectedCategory: AnimalCategory =
@@ -145,23 +170,43 @@ const ExploreContent = () => {
         <BreederExploreContent />
       ) : (
         <>
-          {/* 인기 브리더와 동일 — 섹션별 Container, padding 세로 mo 20px→tab+ 40px, 가로 mo 16px/tab 48/pc 80 */}
-          {/* [refactored] 공용 ExploreListingSection — 인기 동물만 tab 가로 80px(margin/pc, Figma 1652-125625) */}
-          <Container className={cn(EXPLORE_SECTION_CONTAINER, 'tab:px-20')}>
-            <ExploreListingSection
-              title="인기 동물"
-              items={popularListings}
-              getKey={(listing) => listing.listingId}
-              renderCard={(listing) => <FavoriteAdoptionCard listing={listing} />}
-              variant="featured"
-            />
-          </Container>
           <Container className={EXPLORE_SECTION_CONTAINER}>
             <ExploreListingSection
-              title="전체 입양 소식"
-              items={mockListings}
+              title="전체 분양 소식"
+              items={filteredListings}
+              totalCount={mockListings.length}
               getKey={(listing) => listing.listingId}
-              renderCard={(listing) => <FavoriteAdoptionCard listing={listing} />}
+              renderCard={(listing) => <ExploreAdoptionCard listing={listing} />}
+              headerSlot={
+                <div className="flex shrink-0 items-center gap-2" aria-label="분양 소식 필터">
+                  {ADOPTION_LIST_FILTERS.map((filter) => {
+                    const isSelected = adoptionListFilter === filter.value
+
+                    return (
+                      <button
+                        key={filter.value}
+                        type="button"
+                        aria-pressed={isSelected}
+                        onClick={() => setAdoptionListFilter(filter.value)}
+                        className={cn(
+                          badgeVariants({
+                            variant: isSelected ? 'primaryFilled' : 'primaryOutline',
+                            size: 'md',
+                          }),
+                          // 모바일 md(10px) → tab+ lg(14px·h-29)
+                          'tab:h-[1.8125rem] tab:py-1 tab:text-sm',
+                        )}
+                      >
+                        {filter.value === 'popular' ? (
+                          <PopularBadgeContent size="responsive" />
+                        ) : (
+                          filter.label
+                        )}
+                      </button>
+                    )
+                  })}
+                </div>
+              }
             />
           </Container>
         </>

--- a/src/app/(main)/explore/_ui/ExploreFilterBar.tsx
+++ b/src/app/(main)/explore/_ui/ExploreFilterBar.tsx
@@ -76,14 +76,16 @@ const ExploreFilterBar = ({ selected, onChange, className }: ExploreFilterBarPro
         </>
       ) : (
         <>
-          {/* 카테고리 칩 — 공통 Badge(default/active) */}
+          {/* 카테고리 칩 — 공통 Badge(primary 채움/아웃라인, Figma 1652-81786) */}
           <div className="flex flex-wrap items-center gap-2">
             {ANIMAL_CATEGORIES.map((category) => (
               <button
                 key={category}
                 type="button"
                 onClick={() => onChange(category)}
-                className={badgeVariants({ variant: selected === category ? 'active' : 'default' })}
+                className={badgeVariants({
+                  variant: selected === category ? 'primaryFilled' : 'primaryOutline',
+                })}
               >
                 {CATEGORY_LABEL[category]}
               </button>

--- a/src/app/(main)/explore/_ui/ExploreListingSection.tsx
+++ b/src/app/(main)/explore/_ui/ExploreListingSection.tsx
@@ -24,6 +24,9 @@ interface ExploreListingSectionProps<T> {
   /** featured: 인기 섹션(모바일 4개 2x2, tab+ 3개 중앙) / grid(기본): 전체 소식 그리드 */
   variant?: 'featured' | 'grid'
   className?: string
+  headerSlot?: ReactNode
+  /** 필터링 전 전체 개수처럼 items.length와 다른 값을 제목에 표시할 때 사용 */
+  totalCount?: number
 }
 
 const ExploreListingSection = <T,>({
@@ -33,6 +36,8 @@ const ExploreListingSection = <T,>({
   renderCard,
   variant = 'grid',
   className,
+  headerSlot,
+  totalCount,
 }: ExploreListingSectionProps<T>) => {
   if (variant === 'featured') {
     return (
@@ -55,9 +60,10 @@ const ExploreListingSection = <T,>({
 
   return (
     <TitledSection
-      title={`${title} ${items.length}`}
+      title={`${title} ${totalCount ?? items.length}`}
       titleClassName={EXPLORE_SECTION_TITLE_CLASS}
       className={cn(GRID_SECTION_CLASS, className)}
+      headerSlot={headerSlot}
     >
       <div className={CARD_GRID}>
         {items.map((item) => (

--- a/src/app/(main)/explore/_ui/TitledSection.tsx
+++ b/src/app/(main)/explore/_ui/TitledSection.tsx
@@ -8,13 +8,28 @@ interface TitledSectionProps {
   titleClassName?: string
   /** 섹션 래퍼 추가 클래스 (상단 여백·좌우 패딩 등) */
   className?: string
+  /** 제목과 같은 행 우측에 표시할 요소 */
+  headerSlot?: React.ReactNode
   children: React.ReactNode
 }
 
 // 섹션 헤더(제목) + 콘텐츠 래퍼
-const TitledSection = ({ title, titleClassName, className, children }: TitledSectionProps) => (
+const TitledSection = ({
+  title,
+  titleClassName,
+  className,
+  headerSlot,
+  children,
+}: TitledSectionProps) => (
   <section className={cn('flex flex-col gap-[0.75rem]', className)}>
-    <SectionHeader title={title} titleClassName={titleClassName} />
+    {headerSlot ? (
+      <div className="flex items-center justify-between gap-3">
+        <SectionHeader title={title} titleClassName={titleClassName} className="min-w-0 flex-1" />
+        {headerSlot}
+      </div>
+    ) : (
+      <SectionHeader title={title} titleClassName={titleClassName} />
+    )}
     {children}
   </section>
 )

--- a/src/entities/adoption/index.ts
+++ b/src/entities/adoption/index.ts
@@ -1,5 +1,7 @@
 export { AdoptionCard, AdoptionCardHorizontal } from './ui/AdoptionCard'
+export { AdoptionGridCard } from './ui/AdoptionGridCard'
 export { AdoptionShowcaseCard } from './ui/AdoptionShowcaseCard'
 export type { AdoptionShowcaseCardProps } from './ui/AdoptionShowcaseCard'
 export { ADOPTION_STATUS_BG } from './ui/statusBg'
+export { ADOPTION_CARD_STATUS_LABEL, ADOPTION_CARD_STATUS_VARIANT } from './ui/adoptionCardStatus'
 export * from './api/adoption.queries'

--- a/src/entities/adoption/ui/AdoptionGridCard.tsx
+++ b/src/entities/adoption/ui/AdoptionGridCard.tsx
@@ -1,0 +1,90 @@
+'use client'
+
+import Image from 'next/image'
+import Link from 'next/link'
+import { GenderIcon } from '@/shared/assets/icons'
+import { cn } from '@/shared/lib/cn'
+import type { AdoptionListingCard } from '@/shared/types'
+import { Badge, FavoriteToggle, PopularBadgeContent } from '@/shared/ui'
+import { ADOPTION_CARD_STATUS_LABEL, ADOPTION_CARD_STATUS_VARIANT } from './adoptionCardStatus'
+
+interface AdoptionGridCardProps {
+  listing: AdoptionListingCard
+  isFavorite?: boolean
+  onToggle?: () => void
+  className?: string
+}
+
+/** 탐색/홈 공용 세로형 카드 (프레젠테이셔널). 관심 연결은 호출부(features 래퍼)가 담당한다. */
+const AdoptionGridCard = ({ listing, isFavorite, onToggle, className }: AdoptionGridCardProps) => {
+  const { status } = listing
+
+  return (
+    <Link
+      href={`/adoption/${listing.listingId}`}
+      className={cn(
+        'flex h-full w-full flex-col transition-shadow tab:hover:overflow-hidden tab:hover:rounded-[1.25rem] tab:hover:bg-white tab:hover:shadow-[0_7px_7px_0_rgba(55,55,55,0.1)]',
+        className,
+      )}
+    >
+      <div className="relative aspect-[348/284] w-full overflow-hidden rounded-[0.5rem] bg-neutral-700">
+        <Image src={listing.thumbnailUrl} alt={listing.name} fill className="object-cover" />
+
+        {status === 'completed' && <div className="absolute inset-0 bg-white/70" />}
+
+        <div className="absolute top-2 right-3 left-3 flex items-center gap-1">
+          {listing.isPopular && (
+            <Badge
+              variant="primaryOutline"
+              size="md"
+              className="gap-1 bg-white tab:h-[1.8125rem] tab:py-1 tab:text-sm"
+            >
+              <PopularBadgeContent size="responsive" />
+            </Badge>
+          )}
+          <Badge
+            variant={ADOPTION_CARD_STATUS_VARIANT[status]}
+            size="md"
+            className="ml-auto shrink-0 tab:hidden"
+          >
+            {ADOPTION_CARD_STATUS_LABEL[status]}
+          </Badge>
+        </div>
+
+        <FavoriteToggle
+          isFavorite={isFavorite}
+          onToggle={onToggle}
+          className="absolute right-2 bottom-1 tab:right-3 tab:bottom-2"
+          iconClassName={cn('size-8 tab:size-12', !isFavorite && '!text-neutral-50')}
+        />
+      </div>
+
+      <div className="flex min-h-[4.3125rem] items-start justify-between gap-2 p-2 tab:p-3">
+        <div className="flex min-w-0 flex-1 flex-col">
+          <div className="flex min-w-0 items-center">
+            <p className="truncate text-sm leading-[1.5] font-semibold text-neutral-850 tab:text-base">
+              {listing.name}
+            </p>
+            <GenderIcon
+              gender={listing.gender}
+              className="size-5 shrink-0 text-neutral-850 tab:size-6"
+            />
+          </div>
+          <p className="truncate text-xs leading-[1.5] font-medium text-neutral-850 tab:text-sm">
+            {listing.ageText}
+          </p>
+        </div>
+
+        <Badge
+          variant={ADOPTION_CARD_STATUS_VARIANT[status]}
+          size="md"
+          className="hidden shrink-0 tab:flex tab:h-[1.8125rem] tab:py-1 tab:text-sm"
+        >
+          {ADOPTION_CARD_STATUS_LABEL[status]}
+        </Badge>
+      </div>
+    </Link>
+  )
+}
+
+export { AdoptionGridCard }

--- a/src/entities/adoption/ui/AdoptionShowcaseCard.tsx
+++ b/src/entities/adoption/ui/AdoptionShowcaseCard.tsx
@@ -1,23 +1,5 @@
-'use client'
-
-import Image from 'next/image'
-import Link from 'next/link'
-import { FireIcon, GenderIcon } from '@/shared/assets/icons'
-import { cn } from '@/shared/lib/cn'
 import type { AdoptionListingCard } from '@/shared/types'
-import { Badge, FavoriteToggle } from '@/shared/ui'
-
-const STATUS_BADGE_CLASS: Record<AdoptionListingCard['status'], string> = {
-  available: 'bg-primary-500 text-white',
-  reserved: 'bg-primary-500 text-white',
-  completed: 'bg-neutral-150 text-neutral-400',
-}
-
-const STATUS_BADGE_LABEL: Record<AdoptionListingCard['status'], string> = {
-  available: '분양중',
-  reserved: '예약중',
-  completed: '분양완료',
-}
+import { AdoptionGridCard } from './AdoptionGridCard'
 
 interface AdoptionShowcaseCardProps {
   listing: AdoptionListingCard
@@ -26,76 +8,19 @@ interface AdoptionShowcaseCardProps {
   onToggle?: () => void
 }
 
-/** 홈 분양 쇼케이스용 프레젠테이셔널 카드. 즐겨찾기 연결은 features 래퍼가 담당한다. */
+/** 홈 분양 쇼케이스용 카드 — 공용 AdoptionGridCard(layout="showcase") 위임. 관심 연결은 features 래퍼가 담당한다. */
 const AdoptionShowcaseCard = ({
   listing,
   className,
   isFavorite,
   onToggle,
 }: AdoptionShowcaseCardProps) => (
-  <Link
-    href={`/adoption/${listing.listingId}`}
-    className={cn('flex w-[10.25rem] flex-col pc:w-auto', className)}
-  >
-    <div className="relative h-[8.3649rem] w-[10.25rem] overflow-hidden rounded bg-neutral-700 pc:aspect-[348/284] pc:h-auto pc:w-full pc:rounded-[0.5rem]">
-      <div className="absolute inset-0 pc:inset-auto pc:top-[-14.064%] pc:left-[-15.28%] pc:h-[132.476%] pc:w-[144.064%]">
-        <Image src={listing.thumbnailUrl} alt={listing.name} fill className="object-cover" />
-      </div>
-      {listing.isPopular && (
-        <Badge
-          variant="outline"
-          className="absolute top-2 left-3 hidden h-[1.8125rem] gap-1 border-primary-500 bg-white px-2 py-0 text-sm leading-[1.5] font-semibold text-primary-500 pc:flex"
-        >
-          <FireIcon className="h-[1.125rem] w-4 shrink-0" />
-          인기
-        </Badge>
-      )}
-      <div className="absolute top-0 left-0 flex items-center gap-1 px-2 py-1 pc:hidden">
-        <Badge className={cn('h-6 px-2 py-0 text-[0.625rem]', STATUS_BADGE_CLASS[listing.status])}>
-          {STATUS_BADGE_LABEL[listing.status]}
-        </Badge>
-        {listing.isPopular && (
-          <Badge
-            variant="outline"
-            className="h-6 border-primary-500 bg-white px-2 py-0 text-[0.625rem] font-semibold text-primary-500"
-          >
-            인기
-          </Badge>
-        )}
-      </div>
-      <FavoriteToggle
-        isFavorite={isFavorite}
-        onToggle={onToggle}
-        className="absolute right-2 bottom-1 pc:right-3 pc:bottom-2"
-        iconClassName={cn('size-8 pc:size-12', !isFavorite && '!text-neutral-50')}
-      />
-    </div>
-
-    <div className="flex items-start justify-between gap-[0.5rem] p-2 pc:p-[0.75rem]">
-      <div className="flex min-w-0 flex-col">
-        <div className="flex items-center">
-          <p className="truncate text-sm leading-[1.5] font-semibold text-neutral-850 pc:text-base">
-            {listing.name}
-          </p>
-          <GenderIcon
-            gender={listing.gender}
-            className="size-5 shrink-0 text-neutral-850 pc:size-6"
-          />
-        </div>
-        <p className="truncate text-xs leading-[1.5] font-medium text-neutral-850 pc:text-sm">
-          {listing.ageText}
-        </p>
-      </div>
-      <Badge
-        className={cn(
-          'hidden h-[1.8125rem] shrink-0 px-2 py-1 text-sm pc:flex',
-          STATUS_BADGE_CLASS[listing.status],
-        )}
-      >
-        {STATUS_BADGE_LABEL[listing.status]}
-      </Badge>
-    </div>
-  </Link>
+  <AdoptionGridCard
+    listing={listing}
+    className={className}
+    isFavorite={isFavorite}
+    onToggle={onToggle}
+  />
 )
 
 export { AdoptionShowcaseCard }

--- a/src/entities/adoption/ui/adoptionCardStatus.ts
+++ b/src/entities/adoption/ui/adoptionCardStatus.ts
@@ -1,0 +1,20 @@
+import type { AdoptionListingCard } from '@/shared/types'
+
+// [refactored] 카드 배지용 상태 라벨/variant — ExploreAdoptionCard·AdoptionShowcaseCard 공용
+// (shared/types의 ADOPTION_STATUS_LABEL과 문구가 다름: 카드는 "분양중"/"분양완료")
+
+export const ADOPTION_CARD_STATUS_LABEL: Record<AdoptionListingCard['status'], string> = {
+  available: '분양중',
+  reserved: '예약중',
+  completed: '분양완료',
+}
+
+// 분양중/예약중 → 파랑 채움, 분양완료 → 회색 채움
+export const ADOPTION_CARD_STATUS_VARIANT: Record<
+  AdoptionListingCard['status'],
+  'primaryFilled' | 'neutralFilled'
+> = {
+  available: 'primaryFilled',
+  reserved: 'primaryFilled',
+  completed: 'neutralFilled',
+}

--- a/src/shared/ui/Badge.tsx
+++ b/src/shared/ui/Badge.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { tv, type VariantProps } from 'tailwind-variants'
+import { FireIcon } from '@/shared/assets/icons'
 import { cn } from '@/shared/lib/cn'
 
 const badgeVariants = tv({
@@ -17,6 +18,11 @@ const badgeVariants = tv({
         'border border-neutral-300 bg-white px-2 py-1 text-base leading-[1.5] font-medium text-neutral-700',
       active: 'bg-neutral-850 px-2 py-1 text-base leading-[1.5] font-medium text-neutral-50',
       disabled: 'bg-neutral-150 px-2 py-1 text-base leading-[1.5] font-medium text-neutral-400',
+      // Figma label-badge (975-19584) — primary 채움/아웃라인, lg 14px·h-29 / md 10px·h-24
+      primaryFilled: 'bg-primary-500 text-white',
+      primaryOutline: 'border border-primary-500 bg-white text-primary-500',
+      // primaryFilled와 동일 사이즈의 회색 채움 (분양완료 등 비활성 상태)
+      neutralFilled: 'bg-neutral-150 text-neutral-400',
     },
     size: {
       lg: '',
@@ -26,9 +32,21 @@ const badgeVariants = tv({
   compoundVariants: [
     // medium: h-24 / py-2 / 14px (default·active·disabled 전용)
     { variant: ['default', 'active', 'disabled'], size: 'md', class: 'h-6 px-2 py-0.5 text-sm' },
+    // label-badge primary: lg 14px·h-29 / md 10px·h-24
+    {
+      variant: ['primaryFilled', 'primaryOutline', 'neutralFilled'],
+      size: 'lg',
+      class: 'h-[1.8125rem] px-2 py-1 text-sm',
+    },
+    {
+      variant: ['primaryFilled', 'primaryOutline', 'neutralFilled'],
+      size: 'md',
+      class: 'h-6 px-2 py-0 text-[0.625rem]',
+    },
   ],
   defaultVariants: {
     variant: 'outline',
+    size: 'lg',
   },
 })
 
@@ -37,5 +55,27 @@ type BadgeProps = React.HTMLAttributes<HTMLSpanElement> & VariantProps<typeof ba
 export const Badge = ({ className, variant, size, ...props }: BadgeProps) => {
   return <span className={cn(badgeVariants({ variant, size }), className)} {...props} />
 }
+
+type PopularBadgeContentSize = 'md' | 'lg' | 'responsive'
+
+const POPULAR_BADGE_ICON_SIZE: Record<PopularBadgeContentSize, string> = {
+  md: 'h-3.5 w-3',
+  lg: 'h-[1.125rem] w-4',
+  responsive: 'h-3.5 w-3 tab:h-[1.125rem] tab:w-4',
+}
+
+/** 인기 Badge와 인기 필터가 공유하는 불 아이콘 + 라벨. */
+export const PopularBadgeContent = ({
+  size = 'lg',
+  iconClassName,
+}: {
+  size?: PopularBadgeContentSize
+  iconClassName?: string
+}) => (
+  <>
+    <FireIcon className={cn('shrink-0', POPULAR_BADGE_ICON_SIZE[size], iconClassName)} />
+    인기
+  </>
+)
 
 export { badgeVariants }

--- a/src/shared/ui/Tabs.tsx
+++ b/src/shared/ui/Tabs.tsx
@@ -40,12 +40,12 @@ const tabsTriggerVariants = tv({
   variants: {
     variant: {
       default: '',
-      // Figma: 라벨 상단 + 하단 갈색 바, 고정 높이(텍스트-바 간격). 활성 갈색/비활성 회색.
+      // Figma: 라벨 상단 + 하단 바, 고정 높이(텍스트-바 간격). 활성 primary/비활성 회색.
       // cafe24 폰트 — 변수 단독으론 미적용이라 className 병행
       underline: cn(
         cafe24Proup.className,
-        'relative flex-1 items-start font-cafe24 text-neutral-500 data-[state=active]:text-[#a9835a]',
-        'after:absolute after:bottom-0 after:left-0 after:w-full after:bg-[#a9835a]',
+        'relative flex-1 items-start font-cafe24 text-neutral-500 data-[state=active]:text-primary-500',
+        'after:absolute after:bottom-0 after:left-0 after:w-full after:bg-primary-500',
         'after:opacity-0 data-[state=active]:after:opacity-100',
       ),
     },


### PR DESCRIPTION
Closes #190

## Changes
- 인기 동물 섹션 제거, "전체 분양 소식" 필터(전체/분양중/인기) 추가
- 분양 소식 필터 배지 반응형: 모바일 md(10px) → tab+ lg(14px)
- 스크롤 컴팩트 필터바 카테고리 칩을 primary 파랑(채움/아웃라인)으로 (Figma 1652-81786)
- Badge에 `primaryFilled`/`primaryOutline`/`neutralFilled` variant 추가, `PopularBadgeContent` size prop(md/lg/responsive)
- 탐색/홈 카드를 공용 `AdoptionGridCard`로 통합 (프레젠테이셔널), 상태 라벨/variant 공용 상수화
- 탭 underline 활성색 `#a9835a` → `primary-500`

## How to test
1. `/explore` 접속 → 필터 배지·카드·스크롤 컴팩트바 확인 (모바일/태블릿)
2. 홈 `/` 분양중인 동물 섹션 카드가 explore와 동일 렌더인지 확인
3. `pnpm type-check` / `pnpm build` 통과