### PR TITLE
refactor(shared): 탭 바 최대 너비를 PAGE_WIDTH_CLASS로 통일

### DIFF
--- a/src/shared/ui/TabBar.tsx
+++ b/src/shared/ui/TabBar.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import type { CSSProperties, ReactNode } from 'react'
+import { PAGE_WIDTH_CLASS } from '@/shared/config/layout'
 import { cn } from '@/shared/lib/cn'
 import { Tabs, TabsList, TabsTrigger } from './Tabs'
 
@@ -49,10 +50,14 @@ const TabBar = ({
         className={cn('w-full border-b border-neutral-300 bg-white', barClassName)}
         style={barStyle}
       >
+        {/* 폭은 페이지 셸과 동일(PAGE_WIDTH_CLASS), 여백만 탭 바 디자인에 맞춤.
+            Container를 쓰지 않는 이유: 모바일 좌우 여백 없이 348px 목록을 가운데 두는 배치라
+            Container의 px를 전부 덮어써야 한다. */}
         <div
           className={cn(
-            'mx-auto w-full pt-3 tab:max-w-[48rem] tab:px-12 tab:pt-4 pc:px-20',
-            isTwoTabs ? 'pc:max-w-[90rem]' : 'pc:max-w-[58.75rem]',
+            PAGE_WIDTH_CLASS,
+            'pt-3 tab:px-12 tab:pt-4 pc:px-20',
+            !isTwoTabs && 'pc:max-w-[58.75rem]',
           )}
         >
           <TabsList


### PR DESCRIPTION
#196 셀프 코드 리뷰에서 나온 항목 중 PR #197 머지 이후에 정리한 건이라 별도 PR로 올린다.

## Changes

TabBar가 `tab:max-w-[48rem] pc:max-w-[90rem]` 를 직접 하드코딩하고 있었는데, `shared/config/layout`의 `PAGE_WIDTH_CLASS`와 값이 그대로 같아 상수로 교체했다.

```tsx
className={cn(
  PAGE_WIDTH_CLASS,                    // mo 23.4375 / tab 48 / pc 90rem
  'pt-3 tab:px-12 tab:pt-4 pc:px-20',
  !isTwoTabs && 'pc:max-w-[58.75rem]', // 3탭 레이아웃만 override
)}
```

`Container`를 쓰지 않는 이유는 주석으로 남겼다 — 모바일에서 좌우 여백 없이 348px 목록을 가운데 두는 배치라 Container의 `px`를 전부 덮어써야 한다.

## 동작 확인

- twMerge가 `pc:max-w-[90rem]` -> `pc:max-w-[58.75rem]` 로 교체하는 것 확인 (3탭 케이스)
- 2탭은 조건이 false라 상수 값 그대로 유지 = 기존 동작 동일
- 새로 붙는 모바일 `max-w-[23.4375rem]` 은 `mx-auto` + TabsList `w-[21.75rem] mx-auto` 조합이라 375px 초과 뷰포트에서도 결과 동일. 하단 border는 바깥 div가 `w-full` 이라 풀폭 유지
- type-check / lint 통과

## How to test

1. `/home` (마이홈 2탭 / 브리더 3탭) 탭 바 정렬 확인
2. `/explore` (2탭), `/bookmarks` (3탭) PC 폭에서 탭 목록 위치 확인
3. 모바일 375px / 430px 에서 탭 목록이 가운데 정렬되는지 확인