### PR TITLE
fix(explore): 스크롤 시 고정 필터바가 탭바에 겹쳐 칩 잘림

### DIFF
--- a/src/app/(main)/explore/_ui/ExploreContent.tsx
+++ b/src/app/(main)/explore/_ui/ExploreContent.tsx
@@ -92,12 +92,15 @@ const ExploreContent = () => {
   const stickyBarTop = gnbH + (isTabUp ? headerH : 0)
 
   useEffect(() => {
-    const measure = () => {
-      if (headerRef.current) setHeaderH(headerRef.current.offsetHeight)
-    }
+    const el = headerRef.current
+    if (!el) return
+    // ResizeObserver로 탭바 높이 상시 추적 (window resize만으론 폰트로드·HMR·동적변경 시
+    // 높이 변화를 못 잡아 headerH가 stale → 컴팩트바가 탭바에 겹쳐 칩이 잘림)
+    const measure = () => setHeaderH(el.offsetHeight)
     measure()
-    window.addEventListener('resize', measure)
-    return () => window.removeEventListener('resize', measure)
+    const observer = new ResizeObserver(measure)
+    observer.observe(el)
+    return () => observer.disconnect()
   }, [])
 
   useEffect(() => {


### PR DESCRIPTION
Closes #199

## 원인
컴팩트 필터바 top = gnbH + 탭바높이(headerH). headerH를 window resize로만 측정해 폰트로드·HMR·동적 재렌더로 탭바 높이가 바뀌면 stale → 컴팩트바가 탭바에 겹쳐 칩 상단이 잘림.

## 수정
headerH 측정을 `ResizeObserver`로 상시 추적 (gnbH가 이미 쓰는 방식과 동일).

## 검증
- 실제 DOM 좌표 측정: 탭바 bottom 126px = 컴팩트바 top 126px, 겹침 0
- pnpm type-check 통과

## How to test
1. /explore → 스크롤 다운 → 고정 필터바 칩이 탭바에 안 겹치는지 확인 (tab/desktop)