### PR TITLE
feat(adoption): 입양 상세 관심 토글 낙관적 갱신 및 공유 모달 SNS 연동

### DIFF
--- a/src/app/(main)/adoption/[id]/_ui/AdoptionCtaBar.tsx
+++ b/src/app/(main)/adoption/[id]/_ui/AdoptionCtaBar.tsx
@@ -1,32 +1,45 @@
 import Link from 'next/link'
 import { FavoriteIcon } from '@/shared/assets/icons'
+import { FAVORITE_ACTIVE } from '@/shared/ui'
 
 interface AdoptionCtaBarProps {
   listingId: string
+  isFavorite: boolean
+  onToggleFavorite: () => void
 }
 
 /* ── 하단 고정 CTA 바 (입양 신청) ──
    피그마 btn layout — 모바일(1654:148608) / 탭(1654:148637) / pc(1654:148643)
    - 모바일: px-16 py-16, 가운데 정렬 · 하트(48) + 노란 버튼(h-48, 가득 max-297)
-   - 탭:    px-48 py-12, 우측 정렬 · 하트(48) + 노란 버튼(h-32, max-258)
+   - 탭:    px-48 py-12, 우측 정렬 · 노란 버튼만 (h-40, max-258) — 하트 없음
    - pc:    px-80 py-12, 우측 정렬 · 노란 버튼만 (하트 숨김)
    세 상태를 한 트리에서 반응형 클래스로만 분기 (중복 최소화) */
-const AdoptionCtaBar = ({ listingId }: AdoptionCtaBarProps) => (
+const AdoptionCtaBar = ({ listingId, isFavorite, onToggleFavorite }: AdoptionCtaBarProps) => (
   <div className="fixed right-0 bottom-0 left-0 z-10 flex items-center justify-center gap-[0.625rem] bg-white px-[1rem] py-[1rem] tab:justify-end tab:gap-[1.25rem] tab:px-[3rem] tab:py-[0.75rem] pc:px-[5rem]">
     {/* 탭·pc 우측 정렬용 좌측 스페이서 (피그마 flex-1 h-45) */}
     <div className="hidden tab:block tab:h-[2.8125rem] tab:flex-1" />
 
     {/* 하트 + 버튼 그룹 — 모바일: 가득 / 탭·pc: w-360 우측 고정 */}
     <div className="flex w-full items-center justify-center gap-[0.625rem] tab:w-[22.5rem] tab:max-w-[33.5rem] tab:min-w-[22.5rem] tab:justify-end tab:gap-[1.25rem]">
-      {/* 관심(하트) — pc에서는 숨김 */}
-      <button type="button" aria-label="관심있어요" className="shrink-0 pc:hidden">
-        <FavoriteIcon size="lg" className="text-[#5d5d5d]" />
+      {/* 관심(하트) — 모바일 전용(탭·pc는 없음). size="lg"(48px)가 Figma 스펙이라 FavoriteToggle 대신 직접 사용 */}
+      <button
+        type="button"
+        aria-label="관심있어요"
+        aria-pressed={isFavorite}
+        onClick={onToggleFavorite}
+        className="shrink-0 tab:hidden"
+      >
+        <FavoriteIcon
+          size="lg"
+          status={isFavorite ? 'fill' : 'default'}
+          className={isFavorite ? FAVORITE_ACTIVE : 'text-[#5d5d5d]'}
+        />
       </button>
 
       <Link
         href={`/adoption/${listingId}/apply`}
         // hover: 글씨 #6b6b6b / press(active): 배경 #f3ec59 · 글씨 #3e3e3e (피그마 743-70327·743-70329)
-        className="flex h-[3rem] max-w-[18.5625rem] flex-1 items-center justify-center rounded-full bg-[#fffa94] px-[0.5rem] text-[1rem] font-semibold text-neutral-850 hover:text-neutral-700 active:bg-[#f3ec59] active:text-neutral-850 tab:h-[2rem] tab:max-w-[16.125rem] tab:text-[0.875rem]"
+        className="flex h-[3rem] max-w-[18.5625rem] flex-1 items-center justify-center rounded-full bg-point-500 px-[0.5rem] text-[1rem] font-semibold text-neutral-850 hover:text-neutral-700 active:bg-point-600 active:text-neutral-850 tab:h-[2.5rem] tab:max-w-[16.125rem]"
       >
         입양 신청하기
       </Link>

--- a/src/app/(main)/adoption/[id]/_ui/AdoptionDetailContent.tsx
+++ b/src/app/(main)/adoption/[id]/_ui/AdoptionDetailContent.tsx
@@ -2,9 +2,10 @@
 
 import { useRouter } from 'next/navigation'
 import type { ReactNode } from 'react'
-import { Container, Separator, ImageModal } from '@/shared/ui'
+import { Container, Separator, ImageDetailModal } from '@/shared/ui'
 import { ArrowBackIcon, MoreVertIcon } from '@/shared/assets/icons'
 import { useImageModal } from '@/shared/lib/useImageModal'
+import { useToggleAdoptionFavorite } from '@/features/adoption'
 import type { AdoptionDetailDto } from '@/shared/types'
 import { HealthInfoCard } from './HealthInfoCard'
 import { ParentInfoCard } from './ParentInfoCard'
@@ -21,11 +22,17 @@ interface AdoptionDetailContentProps {
    입양 상세 페이지 오케스트레이터
    - 모바일 서브헤더 + 히어로 + 하단 섹션 + CTA + 이미지 모달
    - 이미지 모달 상태는 히어로/하단 카드가 공유하므로 여기서 보관
+   - 관심 상태도 히어로(pc)/CTA바(모바일·탭)가 공유하므로 여기서 보관
    ═══════════════════════════════════════════════ */
 const AdoptionDetailContent = ({ detail }: AdoptionDetailContentProps) => {
   const router = useRouter()
   const { imageModalOpen, setImageModalOpen, modalImages, modalInitialIndex, openImageModal } =
     useImageModal(detail.imageUrls)
+  // listingId = petId (mapAdoptionDetail)
+  const { isFavorite, toggleFavorite } = useToggleAdoptionFavorite(
+    detail.listingId,
+    detail.isFavorited,
+  )
 
   return (
     <div className="pb-[6rem] tab:pb-[6rem]">
@@ -45,7 +52,12 @@ const AdoptionDetailContent = ({ detail }: AdoptionDetailContentProps) => {
       </div>
 
       {/* ═══ 히어로 섹션 ═══ */}
-      <AdoptionDetailHero detail={detail} onImageClick={openImageModal} />
+      <AdoptionDetailHero
+        detail={detail}
+        onImageClick={openImageModal}
+        isFavorite={isFavorite}
+        onToggleFavorite={toggleFavorite}
+      />
 
       {/* ═══ 하단 콘텐츠 ═══ 피그마 tab: 섹션별 컨테이너 px-48 py-12 */}
       {/* [refactored] 반복되던 <Container className="tab:py-[0.75rem] pc:py-[1.25rem]"> 를 Section으로 추출 */}
@@ -78,14 +90,21 @@ const AdoptionDetailContent = ({ detail }: AdoptionDetailContentProps) => {
       </Section>
 
       {/* ═══ CTA 하단 고정 바 ═══ */}
-      <AdoptionCtaBar listingId={detail.listingId} />
+      <AdoptionCtaBar
+        listingId={detail.listingId}
+        isFavorite={isFavorite}
+        onToggleFavorite={toggleFavorite}
+      />
 
-      {/* ═══ 이미지 모달 ═══ */}
-      <ImageModal
+      {/* ═══ 이미지 모달 — 공통 ImageDetailModal (Figma 1952-260350: 이미지+대표뱃지+캐러셀만,
+          프로필/소개/투표/버튼 없음) ═══ */}
+      <ImageDetailModal
         images={modalImages}
         initialIndex={modalInitialIndex}
         open={imageModalOpen}
         onOpenChange={setImageModalOpen}
+        representativeIndex={0}
+        showActions={false}
       />
     </div>
   )

--- a/src/app/(main)/adoption/[id]/_ui/AdoptionDetailHero.tsx
+++ b/src/app/(main)/adoption/[id]/_ui/AdoptionDetailHero.tsx
@@ -4,18 +4,17 @@ import Link from 'next/link'
 import { Fragment, type ReactNode } from 'react'
 import {
   AffectionBadge,
-  Badge,
   Container,
   PopularBadge,
   ProfileAvatar,
   ListingStats,
-  Separator,
   DropdownMenu,
   DropdownMenuTrigger,
   DropdownMenuContent,
   DropdownMenuItem,
 } from '@/shared/ui'
 import { ArrowRightIcon, CheckIcon, GenderIcon } from '@/shared/assets/icons'
+import { cn } from '@/shared/lib/cn'
 import { GENDER_LABEL } from '@/shared/types'
 import type { AdoptionDetailDto, AdoptionStatus } from '@/shared/types'
 import { ADOPTION_CARD_STATUS } from '@/entities/adoption'
@@ -25,158 +24,180 @@ import { FavoriteShareActions } from './FavoriteShareActions'
 interface AdoptionDetailHeroProps {
   detail: AdoptionDetailDto
   onImageClick: (images: string[], index?: number) => void
+  isFavorite: boolean
+  onToggleFavorite: () => void
 }
 
+// [refactored] JSX 안에 있던 브레드크럼 라벨을 모듈 상수로 분리
+const BREADCRUMB = ['홈', '입양', '도마뱀']
+
+// [refactored] InfoItem과 소개글이 각자 들고 있던 동일한 타이포 클래스를 상수로 통일
+// 피그마: 라벨 body/lg/medium 16px neutral-700 (pc 20px), 값 body/lg/bold 16px neutral-850
+const INFO_LABEL_CLASS = 'text-[1rem] leading-[1.5] font-medium text-neutral-700 pc:text-[1.25rem]'
+const INFO_VALUE_CLASS =
+  'text-[1rem] leading-[1.5] font-semibold text-neutral-850 pc:text-[1.25rem]'
+
 /* ── 입양 상세 히어로 (브레드크럼 + 이미지 + 브리더 프로필 | 정보) ── */
-const AdoptionDetailHero = ({ detail, onImageClick }: AdoptionDetailHeroProps) => (
-  // 좌우 패딩(모바일16/탭48/pc80)은 Container가 담당, 이미지만 음수마진으로 풀블리드. pc 섹션 py-20
-  <Container className="px-[1rem] pc:py-[1.25rem]">
-    <div className="pc:flex pc:items-start pc:gap-[1.25rem]">
-      {/* ── 좌측 섹션: 브레드크럼 + 이미지 + 브리더 프로필 ── 피그마: w-500, gap-12 */}
-      <div className="relative -mx-[1rem] tab:-mx-[3rem] pc:mx-0 pc:flex pc:w-[31.25rem] pc:shrink-0 pc:flex-col pc:gap-[0.75rem]">
-        {/* 브레드크럼 (데스크탑 전용) — 피그마: 라벨(body/md/bold 14px #6b6b6b) + chevron */}
-        <div className="hidden items-end py-[0.625rem] pc:flex">
-          {['홈', '입양', '도마뱀'].map((label, index) => (
-            <Fragment key={label}>
-              {index > 0 && <ArrowRightIcon className="size-[1.5rem] text-neutral-700" />}
-              <span className="p-[0.125rem] text-[0.875rem] leading-[1.5] font-semibold text-neutral-700">
-                {label}
-              </span>
-            </Fragment>
-          ))}
-        </div>
+const AdoptionDetailHero = ({
+  detail,
+  onImageClick,
+  isFavorite,
+  onToggleFavorite,
+}: AdoptionDetailHeroProps) => {
+  // [refactored] 모바일·pc 두 블록이 똑같이 넘기던 props를 한 곳에서 만든다
+  const statsProps = {
+    inquiryCount: detail.inquiryCount,
+    favoriteCount: detail.favoriteCount,
+    viewCount: detail.viewCount,
+  }
+  const shareProps = {
+    shareTitle: detail.name,
+    shareDescription: detail.description,
+    shareImageUrl: detail.imageUrls[0],
+  }
 
-        {/* 이미지 영역 (클릭 시 모달, 좌우 슬라이드 네비게이션) */}
-        <HeroImageCarousel
-          images={detail.imageUrls}
-          alt={detail.name}
-          onImageClick={(index) => onImageClick(detail.imageUrls, index)}
-        />
-
-        {/* ── 브리더 프로필 (데스크탑 전용) ── 아바타 + 닉네임 + 애정도 배지 ··· 브리더홈 > */}
-        <div className="hidden items-center gap-[1.75rem] pc:flex">
-          <div className="flex flex-1 items-center gap-[1.25rem]">
-            <div className="flex items-center gap-[0.5rem]">
-              {/* [refactored] 로컬 아바타 → 공통 ProfileAvatar (빈 src 폴백 내장) */}
-              <ProfileAvatar
-                src={detail.breeder.profileImageUrl}
-                alt={detail.breeder.nickname}
-                size="medium"
-                className="shrink-0"
-              />
-              <p className="text-[1rem] leading-[1.5] font-semibold text-neutral-850">
-                {detail.breeder.nickname}
-              </p>
-            </div>
-            <AffectionBadge />
+  return (
+    // 좌우 패딩(모바일16/탭48/pc80)은 Container가 담당, 이미지만 음수마진으로 풀블리드. pc 섹션 py-20
+    <Container className="px-[1rem] pc:py-[1.25rem]">
+      <div className="pc:flex pc:items-start pc:gap-[1.25rem]">
+        {/* ── 좌측 섹션: 브레드크럼 + 이미지 + 브리더 프로필 ── 피그마: w-500, gap-12 */}
+        <div className="relative -mx-[1rem] tab:-mx-[3rem] pc:mx-0 pc:flex pc:w-[31.25rem] pc:shrink-0 pc:flex-col pc:gap-[0.75rem]">
+          {/* 브레드크럼 (데스크탑 전용) — 피그마: 라벨(body/md/bold 14px #6b6b6b) + chevron */}
+          <div className="hidden items-end py-[0.625rem] pc:flex">
+            {BREADCRUMB.map((label, index) => (
+              <Fragment key={label}>
+                {index > 0 && <ArrowRightIcon className="size-[1.5rem] text-neutral-700" />}
+                <span className="p-[0.125rem] text-[0.875rem] leading-[1.5] font-semibold text-neutral-700">
+                  {label}
+                </span>
+              </Fragment>
+            ))}
           </div>
-          <Link
-            href={`/home/${detail.breeder.id}`}
-            className="flex items-center gap-[0.125rem] px-[0.25rem] text-[0.875rem] leading-[1.5] font-semibold text-neutral-850"
-          >
-            브리더홈
-            <ArrowRightIcon className="size-[1.25rem]" />
-          </Link>
-        </div>
-      </div>
 
-      {/* ── 우측 섹션: 이름 ~ 관심/공유 ── 좌우 px는 바깥 Container가, 여기는 py만 (px 없음) */}
-      {/* pc: self-stretch가 동작하려면 height가 auto여야 함(h-full 제거) → justify-between + py-48로 하단 그룹을 이미지 바닥에 정렬 */}
-      <div className="flex w-full flex-col py-[0.75rem] pc:flex-1 pc:items-end pc:justify-between pc:self-stretch pc:py-[3rem]">
-        {/* 브리더 프로필 (모바일만 여기서 표시) */}
-        <div className="w-full pc:hidden">
-          <div className="flex items-center gap-[0.375rem]">
-            {/* [refactored] 로컬 아바타 → 공통 ProfileAvatar (빈 src 폴백 내장) */}
-            <ProfileAvatar
-              src={detail.breeder.profileImageUrl}
-              alt={detail.breeder.nickname}
-              size="medium"
-              className="size-11 shrink-0"
+          {/* 이미지 영역 (클릭 시 모달, 좌우 슬라이드 네비게이션) */}
+          <HeroImageCarousel
+            images={detail.imageUrls}
+            alt={detail.name}
+            onImageClick={(index) => onImageClick(detail.imageUrls, index)}
+          />
+
+          {/* 브리더 프로필 (데스크탑 전용) */}
+          <BreederProfileRow breeder={detail.breeder} className="hidden pc:flex" />
+        </div>
+
+        {/* ── 우측 섹션: 이름 ~ 관심/공유 ── 좌우 px는 바깥 Container가, 여기는 py만 (px 없음) */}
+        {/* pc: self-stretch가 동작하려면 height가 auto여야 함(h-full 제거) → justify-between + py-48로 하단 그룹을 이미지 바닥에 정렬 */}
+        <div className="flex w-full flex-col py-[0.75rem] pc:flex-1 pc:items-end pc:justify-between pc:self-stretch pc:py-[3rem]">
+          {/* 브리더 프로필 (모바일·탭만 여기서 표시 — pc는 좌측 이미지 컬럼 아래) */}
+          <BreederProfileRow breeder={detail.breeder} className="mb-[0.75rem] flex pc:hidden" />
+
+          {/* ── 상단 그룹: 이름 ~ 소개글 ── 피그마 Component10 gap-12 (pc는 20) */}
+          <div className="flex w-full flex-col gap-[0.75rem] pc:gap-[1.25rem]">
+            {/* 이름 + 상태 배지(드롭다운) + 인기 배지 (피그마: 모바일 body/xl/bold 20px, pc 24px) */}
+            <div className="flex flex-wrap items-center gap-[0.5rem]">
+              <p className="text-[1.25rem] leading-[1.5] font-semibold text-neutral-850 pc:text-[1.5rem]">
+                {detail.name}
+              </p>
+              <StatusDropdown currentStatus={detail.status} />
+              {detail.isPopular && (
+                <PopularBadge
+                  variant="outline"
+                  className="h-[1.375rem] bg-white px-[0.5rem] py-[0.125rem] text-[0.75rem] leading-normal"
+                />
+              )}
+            </div>
+
+            {/* 분양가 / 태어난 날 / 성별 / 소개글 — 피그마 정보 블록 gap-8 */}
+            <div className="flex w-full flex-col pc:gap-5 gap-2">
+              <InfoItem label="분양가" value={detail.price} />
+              <InfoItem label="태어난 날" value={detail.birthDate} />
+              <InfoItem
+                label="성별"
+                value={GENDER_LABEL[detail.gender]}
+                trailing={
+                  <GenderIcon gender={detail.gender} className="size-[2rem] text-neutral-700" />
+                }
+              />
+
+              {/* 소개글 (라벨 ↔ 내용 gap-4px, 내용 body/lg/bold 16px) */}
+              <div className="flex flex-col gap-[0.25rem]">
+                {/* [refactored] 중복 타이포 클래스 → INFO_LABEL_CLASS / INFO_VALUE_CLASS */}
+                <p className={INFO_LABEL_CLASS}>소개글</p>
+                <p className={cn(INFO_VALUE_CLASS, 'whitespace-pre-wrap')}>{detail.description}</p>
+              </div>
+            </div>
+          </div>
+
+          {/* 문의/관심/조회 + 공유 (모바일·탭) — 피그마 1943:128143: 좌측 통계(flex-1) + 우측 공유 */}
+          <div className="mt-[0.75rem] flex w-full items-end justify-between gap-[0.75rem] pc:hidden">
+            {/* 피그마 CardInfo: body/sm/medium 12px neutral-700 (공용 base 색 #8e8e8e는 호출부에서만 덮음) */}
+            {/* [refactored] 반복되던 카운트·공유 props → statsProps / shareProps */}
+            <ListingStats {...statsProps} size="md" className="text-neutral-700" />
+            <FavoriteShareActions
+              {...shareProps}
+              className="gap-[0.5rem]"
+              labelClassName="hidden text-neutral-700 tab:inline"
+              isFavorite={isFavorite}
+              onToggle={onToggleFavorite}
             />
-            <div className="flex flex-1 flex-col">
-              <p className="text-[0.875rem] leading-[1.5] font-bold text-[#5d5d5d]">
-                {detail.breeder.nickname}
-              </p>
-              <p className="text-[0.75rem] leading-[1.5] font-semibold text-[#5d5d5d]">
-                {detail.breeder.location}
-              </p>
-            </div>
-            <Badge
-              variant="outline"
-              className="h-[1.5rem] px-[0.625rem] py-[0.25rem] text-[0.75rem] leading-[1.375rem]"
-            >
-              {detail.breeder.bpm} BPM
-            </Badge>
-          </div>
-          <Separator className="my-[0.625rem] bg-[#d4d4d4]" />
-        </div>
-
-        {/* ── 상단 그룹: 이름 ~ 소개 (한 줄씩 gap-20px) ── */}
-        <div className="flex w-full flex-col gap-[1.25rem]">
-          {/* 이름 + 상태 배지(드롭다운) + 인기 배지 (피그마: body/2xl/bolder 24px) */}
-          <div className="flex flex-wrap items-center gap-[0.4375rem] pc:gap-[0.5rem]">
-            <p className="text-[0.875rem] leading-[1.5] font-bold text-[#5d5d5d] pc:text-[1.5rem] pc:text-neutral-850">
-              {detail.name}
-            </p>
-            <StatusDropdown currentStatus={detail.status} />
-            {detail.isPopular && (
-              <PopularBadge
-                variant="outline"
-                className="h-[1.375rem] bg-white px-[0.5rem] py-[0.125rem] text-[0.75rem] leading-normal"
-              />
-            )}
           </div>
 
-          {/* 분양가 / 태어난 날 / 성별 — 동일한 라벨 ↔ 내용 구조 (gap-12px) */}
-          <InfoItem label="분양가" value={detail.price} />
-          <InfoItem label="태어난 날" value={detail.birthDate} />
-          <InfoItem
-            label="성별"
-            value={GENDER_LABEL[detail.gender]}
-            trailing={
-              <GenderIcon gender={detail.gender} className="size-[1.5rem] text-neutral-700" />
-            }
-          />
-
-          {/* 소개 (라벨 ↔ 내용 gap-4px, 내용 body/lg/bold 16px) */}
-          <div className="flex flex-col gap-[0.25rem] text-[#5d5d5d]">
-            <p className="text-[0.75rem] leading-[1.5] font-medium pc:text-[1.25rem] pc:text-neutral-700">
-              소개
-            </p>
-            <p className="text-[0.875rem] leading-[1.5] font-semibold whitespace-pre-wrap pc:text-[1rem] pc:text-neutral-850">
-              {detail.description}
-            </p>
+          {/* ── 하단 그룹: 문의/관심/조회 + 관심/공유 (데스크탑 전용) ── */}
+          <div className="hidden flex-col items-end gap-[0.5rem] pc:flex">
+            <ListingStats {...statsProps} size="lg" />
+            <FavoriteShareActions
+              {...shareProps}
+              isFavorite={isFavorite}
+              onToggle={onToggleFavorite}
+            />
           </div>
-        </div>
-
-        {/* 문의/관심/조회 + 공유 (모바일·탭) — 피그마 1943:128143: 좌측 통계(flex-1) + 우측 공유 */}
-        <div className="mt-[0.5rem] flex w-full items-center justify-between pc:hidden">
-          <ListingStats
-            inquiryCount={detail.inquiryCount}
-            favoriteCount={detail.favoriteCount}
-            viewCount={detail.viewCount}
-            size="sm"
-          />
-          <FavoriteShareActions showFavorite={false} />
-        </div>
-
-        {/* ── 하단 그룹: 문의/관심/조회 + 관심/공유 (데스크탑 전용) ── */}
-        <div className="hidden flex-col items-end gap-[0.5rem] pc:flex">
-          <ListingStats
-            inquiryCount={detail.inquiryCount}
-            favoriteCount={detail.favoriteCount}
-            viewCount={detail.viewCount}
-            size="lg"
-          />
-          <FavoriteShareActions />
         </div>
       </div>
+    </Container>
+  )
+}
+
+/* [refactored] 모바일·pc에 22줄씩 중복돼 있던 브리더 프로필 행을 하나로 추출 ──
+   아바타 + 닉네임 + 애정도 ··· 브리더홈 >
+   pc는 좌측 이미지 컬럼 아래, 모바일·탭은 우측 정보 컬럼 상단이라 DOM 위치가 달라 두 번 렌더한다.
+   두 곳의 차이(아바타 32/40, 닉네임 14/16, 뱃지 md/lg, gap)는 전부 반응형 클래스로 흡수 — 보이는 쪽 클래스만 적용된다.
+   피그마 모바일·탭 1867:182868 */
+const BreederProfileRow = ({
+  breeder,
+  className,
+}: {
+  breeder: AdoptionDetailDto['breeder']
+  className?: string
+}) => (
+  <div className={cn('w-full items-center gap-0 pc:gap-[1.75rem]', className)}>
+    <div className="flex min-w-px flex-1 items-center gap-[0.5rem] pc:gap-[1.25rem]">
+      <div className="flex items-center gap-[0.5rem]">
+        {/* [refactored] 로컬 아바타 → 공통 ProfileAvatar (빈 src 폴백 내장) */}
+        <ProfileAvatar
+          src={breeder.profileImageUrl}
+          alt={breeder.nickname}
+          size="responsivePc"
+          className="shrink-0"
+        />
+        <p className="text-[0.875rem] leading-[1.5] font-semibold text-neutral-850 pc:text-[1rem]">
+          {breeder.nickname}
+        </p>
+      </div>
+      {/* 뱃지는 size prop이 반응형이 아니라 md 기준 + pc에서 lg 치수로 덮는다 */}
+      <AffectionBadge size="md" className="pc:h-[1.8125rem] pc:py-1 pc:text-sm" />
     </div>
-  </Container>
+    <Link
+      href={`/home/${breeder.id}`}
+      className="flex shrink-0 items-center gap-0 px-[0.25rem] text-[0.875rem] leading-[1.5] font-semibold text-neutral-850 pc:gap-[0.125rem]"
+    >
+      브리더홈
+      <ArrowRightIcon className="size-[1.25rem]" />
+    </Link>
+  </div>
 )
 
 /* ── 정보 항목 (라벨 ↔ 내용: 가로 배치 gap-12px) ── */
-/* 피그마: 라벨 body/xl/medium #6b6b6b, 내용 body/xl/bold #3e3e3e (leading 1.5) */
+/* 피그마: 라벨 body/lg/medium 16px neutral-700, 내용 body/lg/bold 16px neutral-850 (leading 1.5) — pc는 라벨만 20px */
 const InfoItem = ({
   label,
   value,
@@ -186,14 +207,11 @@ const InfoItem = ({
   value: string
   trailing?: ReactNode
 }) => (
-  <div className="flex items-center gap-[0.75rem] text-[#5d5d5d]">
-    <p className="shrink-0 text-[0.75rem] leading-[1.5] font-medium pc:text-[1.25rem] pc:text-neutral-700">
-      {label}
-    </p>
+  <div className="flex items-center gap-[0.75rem]">
+    {/* [refactored] 중복 타이포 클래스 → INFO_LABEL_CLASS / INFO_VALUE_CLASS */}
+    <p className={cn('shrink-0', INFO_LABEL_CLASS)}>{label}</p>
     <div className="flex items-center gap-[0.25rem]">
-      <p className="text-[0.875rem] leading-[1.5] font-semibold pc:text-[1.25rem] pc:text-neutral-850">
-        {value}
-      </p>
+      <p className={INFO_VALUE_CLASS}>{value}</p>
       {trailing}
     </div>
   </div>

--- a/src/app/(main)/adoption/[id]/_ui/BaseInfoCard.tsx
+++ b/src/app/(main)/adoption/[id]/_ui/BaseInfoCard.tsx
@@ -8,9 +8,7 @@ interface BaseInfoCardProps {
 }
 
 const BaseInfoCard = ({ title, className, children }: BaseInfoCardProps) => (
-  <div
-    className={cn('overflow-hidden rounded-xl bg-point-50 p-[0.75rem] pc:p-5', className)}
-  >
+  <div className={cn('overflow-hidden rounded-xl bg-point-50 p-[0.75rem] pc:p-5', className)}>
     <p className="text-[0.75rem] leading-[1.375rem] font-medium text-[#5d5d5d] pc:text-[1.25rem] pc:leading-[1.5] pc:font-semibold pc:text-neutral-850">
       {title}
     </p>

--- a/src/app/(main)/adoption/[id]/_ui/FavoriteShareActions.tsx
+++ b/src/app/(main)/adoption/[id]/_ui/FavoriteShareActions.tsx
@@ -11,6 +11,13 @@ interface FavoriteShareActionsProps {
   // 피그마 Frame1707484443 like/share 토글 — pc는 둘 다, 모바일·탭 하단은 공유만(showFavorite=false)
   showFavorite?: boolean
   showShare?: boolean
+  // 라벨 스타일 — 모바일은 아이콘만, 탭+는 라벨 노출이라 boolean이 아닌 반응형 클래스로 제어
+  // (피그마 모바일 1943:112830 라벨 없음 / 탭 1654:148613 라벨 12px neutral-700)
+  labelClassName?: string
+  // 공유 모달 메타 (카카오/OS 공유용) — 없으면 현재 페이지 URL·title 기본값
+  shareTitle?: string
+  shareDescription?: string
+  shareImageUrl?: string
   className?: string
 }
 
@@ -21,6 +28,10 @@ const FavoriteShareActions = ({
   onToggle,
   showFavorite = true,
   showShare = true,
+  labelClassName,
+  shareTitle,
+  shareDescription,
+  shareImageUrl,
   className,
 }: FavoriteShareActionsProps) => {
   const [shareOpen, setShareOpen] = useState(false)
@@ -32,6 +43,7 @@ const FavoriteShareActions = ({
           size="lg"
           className="gap-0 p-0 text-[0.75rem] font-semibold text-neutral-850"
           iconClassName="size-[2rem]"
+          labelClassName={labelClassName}
           isFavorite={isFavorite}
           onToggle={onToggle}
         />
@@ -40,13 +52,20 @@ const FavoriteShareActions = ({
         <button
           type="button"
           onClick={() => setShareOpen(true)}
+          aria-label="공유"
           className="flex items-center gap-0 text-[0.75rem] font-semibold text-neutral-850"
         >
           <ShareIcon className="size-[2rem]" />
-          <span>공유</span>
+          <span className={labelClassName}>공유</span>
         </button>
       )}
-      <ShareModal open={shareOpen} onOpenChange={setShareOpen} />
+      <ShareModal
+        open={shareOpen}
+        onOpenChange={setShareOpen}
+        title={shareTitle}
+        description={shareDescription}
+        imageUrl={shareImageUrl}
+      />
     </div>
   )
 }

--- a/src/app/(main)/bookmarks/_ui/AdoptedListingCard.tsx
+++ b/src/app/(main)/bookmarks/_ui/AdoptedListingCard.tsx
@@ -120,7 +120,10 @@ const AdoptedListingCard = ({ listing }: AdoptedListingCardProps) => {
 
           <div className="flex items-center gap-2">
             {/* [refactored] CardStats */}
-            <CardStats listing={listing} className="flex-1 text-sm leading-[1.5] text-neutral-700" />
+            <CardStats
+              listing={listing}
+              className="flex-1 text-sm leading-[1.5] text-neutral-700"
+            />
             <Button
               variant="primary"
               onClick={() => router.push('/chat')}

--- a/src/app/(main)/explore/_ui/ExploreAdoptionCard.tsx
+++ b/src/app/(main)/explore/_ui/ExploreAdoptionCard.tsx
@@ -11,9 +11,7 @@ const ExploreAdoptionCard = ({ listing }: { listing: AdoptionListingCard }) => {
     listing.isFavorited,
   )
 
-  return (
-    <AdoptionGridCard listing={listing} isFavorite={isFavorite} onToggle={toggleFavorite} />
-  )
+  return <AdoptionGridCard listing={listing} isFavorite={isFavorite} onToggle={toggleFavorite} />
 }
 
 export { ExploreAdoptionCard }

--- a/src/app/(main)/home/_ui/FavoriteBreedersContent.tsx
+++ b/src/app/(main)/home/_ui/FavoriteBreedersContent.tsx
@@ -11,7 +11,10 @@ const FavoriteBreedersContent = () => {
       {/* 모바일 전용: 나만 보기 버튼 (디자인 1023-39468 · 1023-39688) */}
       {/* ponytail: 필터 동작 미연결, 실데이터 붙을 때 드롭다운 연결 */}
       <div className="px-4 pt-5 tab:hidden">
-        <button type="button" className="flex h-10 items-center gap-1 rounded-lg bg-neutral-850 px-2">
+        <button
+          type="button"
+          className="flex h-10 items-center gap-1 rounded-lg bg-neutral-850 px-2"
+        >
           <span className="text-base leading-[1.5] font-semibold text-neutral-50">나만 보기</span>
           <ChevronIcon className="size-4 text-neutral-50" />
         </button>

--- a/src/app/(main)/home/_ui/ProfileCard.tsx
+++ b/src/app/(main)/home/_ui/ProfileCard.tsx
@@ -76,7 +76,9 @@ const FollowerSection = ({
         />
       ))}
     </div>
-    <span className={cn('font-medium text-neutral-850', textClassName)}>팔로워 {followerCount}</span>
+    <span className={cn('font-medium text-neutral-850', textClassName)}>
+      팔로워 {followerCount}
+    </span>
   </button>
 )
 

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link'
 export default function NotFound() {
   return (
     <div className="flex min-h-screen flex-col items-center justify-center px-4">
-      <h1 className="text-primary-500 mb-4 text-4xl font-bold">404</h1>
+      <h1 className="mb-4 text-4xl font-bold text-primary-500">404</h1>
       <p className="text-body-m text-grayscale-gray5 mb-6">페이지를 찾을 수 없습니다</p>
       <Link
         href="/"

--- a/src/entities/community/ui/CommunityBox.tsx
+++ b/src/entities/community/ui/CommunityBox.tsx
@@ -65,7 +65,11 @@ const CommunityBox = ({
         ) : (
           profile
         )}
-        <button type="button" aria-label="게시글 더보기" className="size-6 shrink-0 text-neutral-850">
+        <button
+          type="button"
+          aria-label="게시글 더보기"
+          className="size-6 shrink-0 text-neutral-850"
+        >
           <MoreVertIcon className="size-6" />
         </button>
       </header>

--- a/src/features/adoption/api/adoption.mutations.ts
+++ b/src/features/adoption/api/adoption.mutations.ts
@@ -1,50 +1,122 @@
 'use client'
 
-import { useState } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { adoptionQueries } from '@/entities/adoption'
-import type { CreateAdoptionApplicationRequest } from '@/shared/types'
+import type { AdoptionFavoriteResponse, CreateAdoptionApplicationRequest } from '@/shared/types'
 import {
   addAdoptionFavorite,
   removeAdoptionFavorite,
   createAdoptionApplication,
 } from './adoption.api'
 
-export const useAddAdoptionFavorite = () => {
-  const qc = useQueryClient()
-  return useMutation({
-    mutationFn: (petId: string) => addAdoptionFavorite(petId),
-    onSuccess: () => {
-      void qc.invalidateQueries({ queryKey: adoptionQueries.all() })
-    },
-  })
+/** 관심 캐시 패치에 필요한 공통 필드 — 목록 카드와 상세가 함께 가진다(AdoptionPetDetail extends AdoptionPetCard) */
+interface FavoritablePet {
+  petId: string
+  isFavorited: boolean
+  favoriteCount: number
 }
 
-export const useRemoveAdoptionFavorite = () => {
-  const qc = useQueryClient()
-  return useMutation({
-    mutationFn: (petId: string) => removeAdoptionFavorite(petId),
-    onSuccess: () => {
-      void qc.invalidateQueries({ queryKey: adoptionQueries.all() })
-    },
-  })
+const isFavoritablePet = (value: unknown): value is FavoritablePet =>
+  typeof value === 'object' &&
+  value !== null &&
+  'petId' in value &&
+  'isFavorited' in value &&
+  'favoriteCount' in value
+
+/**
+ * adoption 캐시 안의 특정 펫만 갈아끼운다.
+ * 캐시에 들어있는 형태는 세 가지뿐이다 — 무한 목록(InfiniteData<PaginationResponse>), 배열(popular), 단일 상세.
+ */
+const patchAdoptionCache = (
+  data: unknown,
+  petId: string,
+  patch: (pet: FavoritablePet) => FavoritablePet,
+): unknown => {
+  const applyToPet = (value: unknown) =>
+    isFavoritablePet(value) && value.petId === petId ? patch(value) : value
+
+  if (Array.isArray(data)) return data.map(applyToPet)
+  if (typeof data !== 'object' || data === null) return data
+
+  if ('pages' in data && Array.isArray(data.pages)) {
+    return {
+      ...data,
+      pages: data.pages.map((page: unknown) =>
+        typeof page === 'object' && page !== null && 'items' in page && Array.isArray(page.items)
+          ? { ...page, items: page.items.map(applyToPet) }
+          : page,
+      ),
+    }
+  }
+  return applyToPet(data)
 }
 
 /**
- * 관심(좋아요) 토글 — 낙관적 UI 상태 + add/remove mutation 연결.
- * 카드가 mock 데이터라 실제 API는 404일 수 있으므로 낙관적 상태를 유지(롤백 없음)한다.
- * 백엔드 연동 후에는 onError 롤백을 추가한다.
+ * 관심 등록/해제 공통 mutation — 캐시를 직접 패치해 refetch 없이 즉시 반영한다.
+ *
+ * 예전에는 onSuccess에서 adoptionQueries.all()을 통째로 invalidate 했는데,
+ * 하트 한 번에 list/popular/breederPets/detail이 전부 재요청됐다.
+ * 지금은 onMutate에서 해당 펫만 갈아끼우고, onSettled는 refetchType 'none'으로
+ * "다음 마운트 때 최신화" 표시만 남긴다 → 토글당 네트워크 요청은 mutation 1건뿐.
  */
-export const useToggleAdoptionFavorite = (petId: string, initialFavorite: boolean) => {
-  const [isFavorite, setIsFavorite] = useState(initialFavorite)
+const useToggleFavoriteMutation = (
+  mutationFn: (petId: string) => Promise<AdoptionFavoriteResponse>,
+  nextFavorited: boolean,
+) => {
+  const qc = useQueryClient()
+  const scope = { queryKey: adoptionQueries.all() }
+
+  return useMutation({
+    mutationFn,
+    onMutate: async (petId: string) => {
+      // 진행 중인 refetch가 낙관적 패치를 덮어쓰지 않도록 먼저 취소
+      await qc.cancelQueries(scope)
+      const snapshot = qc.getQueriesData(scope)
+      qc.setQueriesData(scope, (data) =>
+        patchAdoptionCache(data, petId, (pet) => ({
+          ...pet,
+          isFavorited: nextFavorited,
+          // 멱등 API라 이미 같은 상태면 카운트를 건드리지 않는다
+          favoriteCount:
+            pet.isFavorited === nextFavorited
+              ? pet.favoriteCount
+              : pet.favoriteCount + (nextFavorited ? 1 : -1),
+        })),
+      )
+      return { snapshot }
+    },
+    onError: (_error, _petId, context) => {
+      context?.snapshot.forEach(([queryKey, data]) => qc.setQueryData(queryKey, data))
+    },
+    // 서버가 확정 카운트를 돌려주므로 낙관적 ±1을 실제 값으로 교정
+    onSuccess: (result) => {
+      qc.setQueriesData(scope, (data) =>
+        patchAdoptionCache(data, result.petId, (pet) => ({
+          ...pet,
+          favoriteCount: result.favoriteCount,
+        })),
+      )
+    },
+    onSettled: () => qc.invalidateQueries({ ...scope, refetchType: 'none' }),
+  })
+}
+
+export const useAddAdoptionFavorite = () => useToggleFavoriteMutation(addAdoptionFavorite, true)
+
+export const useRemoveAdoptionFavorite = () =>
+  useToggleFavoriteMutation(removeAdoptionFavorite, false)
+
+/**
+ * 관심(좋아요) 토글 — 캐시가 단일 진실이라 로컬 state가 없다.
+ * 낙관적 반영/롤백은 mutation의 캐시 패치가 담당하고, isFavorite은 호출부가 넘긴 쿼리 값이 그대로 흐른다.
+ */
+export const useToggleAdoptionFavorite = (petId: string, isFavorite: boolean) => {
   const addFavorite = useAddAdoptionFavorite()
   const removeFavorite = useRemoveAdoptionFavorite()
 
   const toggleFavorite = () => {
-    const next = !isFavorite
-    setIsFavorite(next)
-    if (next) addFavorite.mutate(petId)
-    else removeFavorite.mutate(petId)
+    if (isFavorite) removeFavorite.mutate(petId)
+    else addFavorite.mutate(petId)
   }
 
   return { isFavorite, toggleFavorite }
@@ -54,8 +126,7 @@ export const useCreateAdoptionApplication = () => {
   const qc = useQueryClient()
   return useMutation({
     mutationFn: (data: CreateAdoptionApplicationRequest) => createAdoptionApplication(data),
-    onSuccess: () => {
-      void qc.invalidateQueries({ queryKey: adoptionQueries.all() })
-    },
+    // 신청은 상태/카운트가 여러 곳에 걸쳐 바뀌므로 관심 토글과 달리 전체 무효화가 맞다
+    onSuccess: () => qc.invalidateQueries({ queryKey: adoptionQueries.all() }),
   })
 }

--- a/src/features/adoption/api/adoption.mutations.ts
+++ b/src/features/adoption/api/adoption.mutations.ts
@@ -51,26 +51,36 @@ const patchAdoptionCache = (
   return applyToPet(data)
 }
 
+interface ToggleFavoriteVariables {
+  petId: string
+  nextFavorited: boolean
+}
+
 /**
- * 관심 등록/해제 공통 mutation — 캐시를 직접 패치해 refetch 없이 즉시 반영한다.
+ * 관심 등록/해제 mutation — 캐시를 직접 패치해 refetch 없이 즉시 반영한다.
  *
  * 예전에는 onSuccess에서 adoptionQueries.all()을 통째로 invalidate 했는데,
  * 하트 한 번에 list/popular/breederPets/detail이 전부 재요청됐다.
  * 지금은 onMutate에서 해당 펫만 갈아끼우고, onSettled는 refetchType 'none'으로
  * "다음 마운트 때 최신화" 표시만 남긴다 → 토글당 네트워크 요청은 mutation 1건뿐.
+ *
+ * 등록/해제를 분리하지 않고 nextFavorited를 variables로 받는다.
+ * 카드마다 호출되는 훅이라 mutation을 두 개 만들면 목록 하나에 observer가 2배로 붙는다.
  */
-const useToggleFavoriteMutation = (
-  mutationFn: (petId: string) => Promise<AdoptionFavoriteResponse>,
-  nextFavorited: boolean,
-) => {
+const useToggleFavoriteMutation = () => {
   const qc = useQueryClient()
   const scope = { queryKey: adoptionQueries.all() }
 
   return useMutation({
-    mutationFn,
-    onMutate: async (petId: string) => {
-      // 진행 중인 refetch가 낙관적 패치를 덮어쓰지 않도록 먼저 취소
-      await qc.cancelQueries(scope)
+    mutationFn: ({ petId, nextFavorited }: ToggleFavoriteVariables) =>
+      nextFavorited ? addAdoptionFavorite(petId) : removeAdoptionFavorite(petId),
+    onMutate: async ({ petId, nextFavorited }) => {
+      // 진행 중인 refetch가 낙관적 패치를 덮어쓰지 않도록 먼저 취소.
+      // 단 최초 로딩(데이터 없음)까지 끊으면 재요청 없이 pending으로 남으므로 제외한다.
+      await qc.cancelQueries({
+        ...scope,
+        predicate: (query) => query.state.data !== undefined,
+      })
       const snapshot = qc.getQueriesData(scope)
       qc.setQueriesData(scope, (data) =>
         patchAdoptionCache(data, petId, (pet) => ({
@@ -85,11 +95,11 @@ const useToggleFavoriteMutation = (
       )
       return { snapshot }
     },
-    onError: (_error, _petId, context) => {
+    onError: (_error, _variables, context) => {
       context?.snapshot.forEach(([queryKey, data]) => qc.setQueryData(queryKey, data))
     },
     // 서버가 확정 카운트를 돌려주므로 낙관적 ±1을 실제 값으로 교정
-    onSuccess: (result) => {
+    onSuccess: (result: AdoptionFavoriteResponse) => {
       qc.setQueriesData(scope, (data) =>
         patchAdoptionCache(data, result.petId, (pet) => ({
           ...pet,
@@ -101,25 +111,17 @@ const useToggleFavoriteMutation = (
   })
 }
 
-export const useAddAdoptionFavorite = () => useToggleFavoriteMutation(addAdoptionFavorite, true)
-
-export const useRemoveAdoptionFavorite = () =>
-  useToggleFavoriteMutation(removeAdoptionFavorite, false)
-
 /**
  * 관심(좋아요) 토글 — 캐시가 단일 진실이라 로컬 state가 없다.
  * 낙관적 반영/롤백은 mutation의 캐시 패치가 담당하고, isFavorite은 호출부가 넘긴 쿼리 값이 그대로 흐른다.
  */
 export const useToggleAdoptionFavorite = (petId: string, isFavorite: boolean) => {
-  const addFavorite = useAddAdoptionFavorite()
-  const removeFavorite = useRemoveAdoptionFavorite()
+  const { mutate } = useToggleFavoriteMutation()
 
-  const toggleFavorite = () => {
-    if (isFavorite) removeFavorite.mutate(petId)
-    else addFavorite.mutate(petId)
+  return {
+    isFavorite,
+    toggleFavorite: () => mutate({ petId, nextFavorited: !isFavorite }),
   }
-
-  return { isFavorite, toggleFavorite }
 }
 
 export const useCreateAdoptionApplication = () => {

--- a/src/features/category-browse/ui/CategoryBrowse.tsx
+++ b/src/features/category-browse/ui/CategoryBrowse.tsx
@@ -84,7 +84,10 @@ const CategoryBrowse = () => {
           </div>
           <div className="relative z-10 flex items-center gap-[0.4375rem]">
             <p
-              className={cn(cafe24Proup.className, 'text-xs leading-[1.5] text-primary-600 pc:text-sm')}
+              className={cn(
+                cafe24Proup.className,
+                'text-xs leading-[1.5] text-primary-600 pc:text-sm',
+              )}
             >
               신뢰할 수 있는 브리더 포퐁에서 만나요 !
             </p>

--- a/src/features/category-filter/ui/CategoryFilter.tsx
+++ b/src/features/category-filter/ui/CategoryFilter.tsx
@@ -7,10 +7,7 @@ import type { AnimalCategory } from '@/shared/types'
 
 // 카테고리별 완성 칩 SVG (기본/선택). 도마뱀은 강아지 칩 재사용 (전용 아트 나오면 교체).
 // 칩은 동물머리+pill+라벨이 한 장에 포함 — 높이는 pill이 하단에 정렬되도록 items-end + uniform scale.
-const CHIP: Record<
-  AnimalCategory,
-  { src: string; on: string; ratio: string; height: string }
-> = {
+const CHIP: Record<AnimalCategory, { src: string; on: string; ratio: string; height: string }> = {
   all: {
     src: '/images/category/filter-all.svg',
     on: '/images/category/filter-all-active.svg',
@@ -66,12 +63,7 @@ const CategoryFilter = ({ selected, onChange, className }: CategoryFilterProps) 
             className={cn('relative w-auto shrink-0', chip.height, chip.ratio)}
           >
             {/* 라벨은 button의 aria-label이 담당 — 이미지는 장식 */}
-            <Image
-              src={active ? chip.on : chip.src}
-              alt=""
-              fill
-              className="object-contain"
-            />
+            <Image src={active ? chip.on : chip.src} alt="" fill className="object-contain" />
           </button>
         )
       })}

--- a/src/shared/lib/kakao.ts
+++ b/src/shared/lib/kakao.ts
@@ -1,0 +1,113 @@
+// Kakao JS SDK를 필요 시점에만 로드/초기화 (전역 <Script> 대신 lazy — 공유 클릭 시에만 로드)
+
+const SDK_URL = 'https://t1.kakaocdn.net/kakao_js_sdk/2.7.4/kakao.min.js'
+
+interface KakaoLink {
+  mobileWebUrl: string
+  webUrl: string
+}
+
+type KakaoFeedShareSettings = {
+  objectType: 'feed'
+  content: {
+    title: string
+    description: string
+    imageUrl: string
+    link: KakaoLink
+  }
+  buttons?: { title: string; link: KakaoLink }[]
+}
+
+type KakaoTextShareSettings = {
+  objectType: 'text'
+  text: string
+  link: KakaoLink
+  buttonTitle?: string
+}
+
+type KakaoShareSettings = KakaoFeedShareSettings | KakaoTextShareSettings
+
+export interface KakaoSDK {
+  isInitialized: () => boolean
+  init: (key: string) => void
+  Share: {
+    sendDefault: (settings: KakaoShareSettings) => void
+  }
+}
+
+declare global {
+  interface Window {
+    Kakao?: KakaoSDK
+  }
+}
+
+let scriptPromise: Promise<void> | null = null
+
+const loadScript = () => {
+  if (scriptPromise) return scriptPromise
+  scriptPromise = new Promise<void>((resolve, reject) => {
+    if (window.Kakao) return resolve()
+    const script = document.createElement('script')
+    script.src = SDK_URL
+    script.async = true
+    script.onload = () => resolve()
+    script.onerror = () => {
+      scriptPromise = null
+      reject(new Error('Kakao SDK 로드 실패'))
+    }
+    document.head.appendChild(script)
+  })
+  return scriptPromise
+}
+
+/** SDK 로드 + init 후 window.Kakao 반환. 실패 사유는 호출부에서 사용자에게 안내한다. */
+export const getKakao = async (): Promise<KakaoSDK> => {
+  const key = process.env.NEXT_PUBLIC_KAKAO_JS_KEY
+  if (!key) throw new Error('카카오 JavaScript 키가 설정되지 않았습니다.')
+  await loadScript()
+  if (!window.Kakao) throw new Error('카카오 SDK를 초기화하지 못했습니다.')
+  if (!window.Kakao.isInitialized()) window.Kakao.init(key)
+  return window.Kakao
+}
+
+// [refactored] 카카오 공유 페이로드 조립 + 전송을 SDK 세부사항과 함께 이 파일에 모음
+export interface KakaoSharePayload {
+  url: string
+  title: string
+  description?: string
+  /** 절대 URL 권장 — 상대 경로는 현재 origin 기준으로 변환한다 */
+  imageUrl?: string
+}
+
+/**
+ * 카카오 공유창 열기.
+ * SDK가 window.open을 동기로 호출하므로 반드시 클릭 핸들러 안에서 await 없이 호출해야 팝업이 차단되지 않는다.
+ * (사전에 getKakao()로 로드/init 되어 있어야 한다)
+ */
+export const shareToKakao = ({ url, title, description, imageUrl }: KakaoSharePayload) => {
+  const kakao = window.Kakao
+  if (!kakao?.isInitialized()) {
+    throw new Error('카카오 공유를 준비하지 못했습니다. 잠시 후 다시 시도해주세요.')
+  }
+
+  const link = { mobileWebUrl: url, webUrl: url }
+  kakao.Share.sendDefault(
+    imageUrl
+      ? {
+          objectType: 'feed',
+          content: {
+            title,
+            description: description ?? '',
+            imageUrl: new URL(imageUrl, window.location.origin).href,
+            link,
+          },
+          buttons: [{ title: '자세히 보기', link }],
+        }
+      : {
+          objectType: 'text',
+          text: description ? `${title}\n${description}` : title,
+          link,
+          buttonTitle: '자세히 보기',
+        },
+  )
+}

--- a/src/shared/ui/Badge.tsx
+++ b/src/shared/ui/Badge.tsx
@@ -83,12 +83,14 @@ export const PopularBadgeContent = ({
 /** 애정도 뱃지 (Figma 743-68293) — pointFilled(bg-point-500 + primary 테두리/텍스트) */
 export const AffectionBadge = ({
   children = '애정도',
+  size = 'lg',
   className,
 }: {
   children?: React.ReactNode
+  size?: BadgeProps['size']
   className?: string
 }) => (
-  <Badge variant="pointFilled" size="lg" className={className}>
+  <Badge variant="pointFilled" size={size} className={className}>
     {children}
   </Badge>
 )

--- a/src/shared/ui/FavoriteButton.tsx
+++ b/src/shared/ui/FavoriteButton.tsx
@@ -26,6 +26,8 @@ const favoriteIconSize = {
 interface FavoriteButtonProps extends VariantProps<typeof favoriteButtonVariants> {
   className?: string
   iconClassName?: string
+  /** 라벨 스타일 — 브레이크포인트별 노출/색 제어용 (예: 'hidden tab:inline') */
+  labelClassName?: string
   // 제어형: 관심 여부와 토글 콜백은 상위(카드)에서 mutation과 연결한다
   isFavorite?: boolean
   onToggle?: () => void
@@ -35,6 +37,7 @@ const FavoriteButton = ({
   size = 'lg',
   className,
   iconClassName,
+  labelClassName,
   isFavorite = false,
   onToggle,
 }: FavoriteButtonProps) => {
@@ -56,7 +59,7 @@ const FavoriteButton = ({
         isFavorite={isFavorite}
         className={cn(favoriteIconSize[size ?? 'lg'], iconClassName)}
       />
-      <span>관심있어요</span>
+      <span className={labelClassName}>관심있어요</span>
     </button>
   )
 }

--- a/src/shared/ui/ImageDetailModal.tsx
+++ b/src/shared/ui/ImageDetailModal.tsx
@@ -57,7 +57,8 @@ const CarouselIndicator = ({ count, currentIndex }: CarouselIndicatorProps) => (
         key={index}
         className={cn(
           'h-2 rounded-lg transition-[width,background-color]',
-          index === currentIndex ? 'w-5 bg-secondary-500' : 'w-2 bg-white/30',
+          // 히어로 캐러셀과 동일한 노란 pill (#fffa94 활성 / #a9835a 비활성)
+          index === currentIndex ? 'w-5 bg-[#fffa94]' : 'w-2 bg-[#a9835a]',
         )}
       />
     ))}
@@ -83,6 +84,10 @@ const ImageDetailModal = ({
   const { currentIndex, handlePrev, handleNext } = useImageCarousel(images, initialIndex)
   const hasCarousel = images.length > 1
   const hasActions = showActions && Boolean(footer)
+  // 프로필/설명/투표/버튼이 전혀 없는 순수 이미지 뷰(입양 상세) — 박스를 이미지 폭에 맞춰
+  // 좌우 여백/멀어진 화살표로 불규칙해 보이던 문제를 제거 (Figma 1952-260350)
+  const isPlain =
+    !profile && !description && !hasActions && voteCount === undefined && !showVoteStatus
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -163,7 +168,13 @@ const ImageDetailModal = ({
 
             {/* 이미지 + 좌우 네비게이션 */}
             <div className="relative flex min-h-0 w-full flex-1 shrink-0 items-center justify-center tab:h-[28.40625rem] tab:flex-none pc:h-auto pc:flex-1">
-              <div className="relative size-full max-w-[37.875rem] overflow-hidden bg-neutral-700 tab:rounded-lg pc:aspect-[4/3] pc:h-full pc:w-auto">
+              <div
+                className={cn(
+                  'relative size-full max-w-[37.875rem] overflow-hidden bg-neutral-700 tab:rounded-lg pc:aspect-[4/3] pc:h-full pc:w-auto',
+                  // 순수 이미지 뷰(입양 상세)는 pc에서 폭 캡을 풀어 높이 기준 4/3 가로형으로 (Figma 1952-260350)
+                  isPlain && 'pc:max-w-[48.75rem] pc:rounded-[1.25rem]',
+                )}
+              >
                 {images[currentIndex] && (
                   <Image
                     src={images[currentIndex]}
@@ -210,7 +221,10 @@ const ImageDetailModal = ({
               </div>
             </div>
 
-            {hasCarousel && <CarouselIndicator count={images.length} currentIndex={currentIndex} />}
+            {/* 순수 이미지 뷰(입양)는 히어로처럼 1장이어도 인디케이터를 사진 밑에 노출 */}
+            {(hasCarousel || isPlain) && (
+              <CarouselIndicator count={images.length} currentIndex={currentIndex} />
+            )}
 
             {/* 하단 버튼 — showActions로 독립 제어 */}
             {hasActions && (

--- a/src/shared/ui/ProfileHeader.tsx
+++ b/src/shared/ui/ProfileHeader.tsx
@@ -71,7 +71,9 @@ const ProfileHeader = ({
             >
               {preview}
             </p>
-            <span className={cn('shrink-0 leading-[1.5] font-medium text-neutral-700', previewSize)}>
+            <span
+              className={cn('shrink-0 leading-[1.5] font-medium text-neutral-700', previewSize)}
+            >
               [더보기]
             </span>
           </div>

--- a/src/shared/ui/ShareModal.tsx
+++ b/src/shared/ui/ShareModal.tsx
@@ -1,9 +1,11 @@
 'use client'
 
+import { useEffect, useState } from 'react'
 import * as DialogPrimitive from '@radix-ui/react-dialog'
 import Image from 'next/image'
 import { CloseIcon } from '@/shared/assets/icons'
 import { cn } from '@/shared/lib/cn'
+import { getKakao, shareToKakao } from '@/shared/lib/kakao'
 import { Dialog, DialogOverlay, DialogPortal } from './Dialog'
 
 /* 공유하기 모달 (Figma 1949-253368) — 인스타/카카오톡/페이스북/URL 복사 */
@@ -13,10 +15,21 @@ interface ShareModalProps {
   onOpenChange: (open: boolean) => void
   /** 공유할 URL (기본: 현재 페이지) */
   url?: string
+  /** 카카오/OS 공유 시 제목 (기본: document.title) */
+  title?: string
+  /** 카카오 공유 설명 */
+  description?: string
+  /** 카카오 공유 썸네일 (절대 URL) */
+  imageUrl?: string
   className?: string
 }
 
 type ShareKey = 'instagram' | 'kakao' | 'facebook' | 'copy'
+
+interface ShareFeedback {
+  tone: 'success' | 'info' | 'error'
+  message: string
+}
 
 const OPTIONS: { key: ShareKey; label: string; icon: string; circle: string }[] = [
   {
@@ -26,30 +39,128 @@ const OPTIONS: { key: ShareKey; label: string; icon: string; circle: string }[] 
     circle: 'border border-neutral-150 bg-white',
   },
   { key: 'kakao', label: '카카오톡', icon: '/images/share/kakaotalk.svg', circle: 'bg-[#ffe812]' },
-  { key: 'facebook', label: '페이스북', icon: '/images/share/facebook.png', circle: 'bg-[#0866ff]' },
+  {
+    key: 'facebook',
+    label: '페이스북',
+    icon: '/images/share/facebook.png',
+    circle: 'bg-[#0866ff]',
+  },
   { key: 'copy', label: 'URL 복사', icon: '/images/share/link.svg', circle: 'bg-neutral-100' },
 ]
 
-const ShareModal = ({ open, onOpenChange, url, className }: ShareModalProps) => {
-  const share = (key: ShareKey) => {
-    const shareUrl = url ?? window.location.href
-    switch (key) {
-      case 'copy':
-        void navigator.clipboard.writeText(shareUrl)
-        break
-      case 'facebook':
-        window.open(
-          `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(shareUrl)}`,
-          '_blank',
-          'noopener,noreferrer',
-        )
-        break
-      // ponytail: 카카오톡은 Kakao SDK, 인스타는 웹 공유 인텐트가 없어 별도 연동 필요 — 연동 시 여기 처리
-      case 'kakao':
-      case 'instagram':
-        break
+/** Async Clipboard를 우선 사용하고, HTTP·구형 브라우저에서는 동기 복사로 폴백한다. */
+const copyToClipboard = async (text: string) => {
+  if (window.isSecureContext && navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(text)
+    return
+  }
+
+  const textarea = document.createElement('textarea')
+  textarea.value = text
+  textarea.setAttribute('readonly', '')
+  textarea.style.position = 'fixed'
+  textarea.style.opacity = '0'
+  document.body.appendChild(textarea)
+  textarea.select()
+
+  try {
+    if (!document.execCommand('copy')) throw new Error('URL을 복사하지 못했습니다.')
+  } finally {
+    textarea.remove()
+  }
+}
+
+const isAbortError = (error: unknown) => error instanceof DOMException && error.name === 'AbortError'
+
+const ShareModal = ({
+  open,
+  onOpenChange,
+  url,
+  title,
+  description,
+  imageUrl,
+  className,
+}: ShareModalProps) => {
+  // [refactored] 4-state enum -> boolean (로드 완료 여부만 쓰인다)
+  const [kakaoReady, setKakaoReady] = useState(false)
+  const [feedback, setFeedback] = useState<ShareFeedback | null>(null)
+
+  // 모달이 열린 동안 SDK를 미리 로드/init만 해둔다. 실제 공유는 클릭 시 동기로 호출.
+  useEffect(() => {
+    if (!open) {
+      setKakaoReady(false)
+      setFeedback(null)
+      return
     }
-    onOpenChange(false)
+
+    let cancelled = false
+    void getKakao()
+      .then(() => {
+        if (!cancelled) setKakaoReady(true)
+      })
+      .catch(() => {})
+
+    return () => {
+      cancelled = true
+    }
+  }, [open])
+
+  const share = async (key: ShareKey) => {
+    const shareUrl = new URL(url ?? window.location.href, window.location.href).href
+    const shareTitle = title ?? document.title
+    setFeedback(null)
+
+    try {
+      switch (key) {
+        case 'copy': {
+          await copyToClipboard(shareUrl)
+          setFeedback({ tone: 'success', message: 'URL을 복사했습니다.' })
+          break
+        }
+        case 'facebook': {
+          const popup = window.open(
+            `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(shareUrl)}`,
+            '_blank',
+            'popup,width=720,height=640',
+          )
+          if (!popup) throw new Error('팝업이 차단되었습니다.')
+          popup.opener = null
+          setFeedback({ tone: 'success', message: '페이스북 공유 창을 열었습니다.' })
+          break
+        }
+        case 'instagram': {
+          const shareData = { title: shareTitle, text: description, url: shareUrl }
+          if (navigator.share && (!navigator.canShare || navigator.canShare(shareData))) {
+            await navigator.share(shareData)
+            setFeedback({ tone: 'success', message: '공유를 완료했습니다.' })
+          } else {
+            await copyToClipboard(shareUrl)
+            setFeedback({
+              tone: 'info',
+              message: '이 브라우저에서는 인스타그램 직접 공유를 지원하지 않아 URL을 복사했습니다.',
+            })
+          }
+          break
+        }
+        // [refactored] SDK 페이로드 조립은 shared/lib/kakao로 이동. await 없이 동기 호출해야 팝업이 안 막힌다.
+        case 'kakao': {
+          shareToKakao({ url: shareUrl, title: shareTitle, description, imageUrl })
+          break
+        }
+      }
+    } catch (error) {
+      if (isAbortError(error)) {
+        setFeedback({ tone: 'info', message: '공유를 취소했습니다.' })
+        return
+      }
+      setFeedback({
+        tone: 'error',
+        message:
+          error instanceof Error && error.message
+            ? error.message
+            : '공유하지 못했습니다. 잠시 후 다시 시도해주세요.',
+      })
+    }
   }
 
   return (
@@ -57,7 +168,7 @@ const ShareModal = ({ open, onOpenChange, url, className }: ShareModalProps) => 
       <DialogPortal>
         <DialogOverlay />
         <DialogPrimitive.Content
-          aria-describedby={undefined}
+          aria-describedby="share-modal-description"
           className={cn(
             'fixed top-1/2 left-1/2 z-50 w-[22.5rem] max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 rounded-[0.75rem] bg-white data-[state=closed]:opacity-0 data-[state=open]:opacity-100',
             className,
@@ -73,37 +184,57 @@ const ShareModal = ({ open, onOpenChange, url, className }: ShareModalProps) => 
             <DialogPrimitive.Title className="text-xl leading-[1.5] font-semibold text-neutral-850">
               공유하기
             </DialogPrimitive.Title>
+            <DialogPrimitive.Description id="share-modal-description" className="sr-only">
+              공유할 서비스를 선택하세요.
+            </DialogPrimitive.Description>
           </div>
 
           {/* 공유 옵션 행 (Figma 1945-136563) */}
           <div className="flex flex-wrap items-start justify-center gap-x-8 gap-y-6 px-3 py-5">
-            {OPTIONS.map((option) => (
-              <button
-                key={option.key}
-                type="button"
-                onClick={() => share(option.key)}
-                className="flex flex-col items-center gap-0.5"
-              >
-                <span
-                  className={cn(
-                    'flex size-11 items-center justify-center rounded-full',
-                    option.circle,
-                  )}
+            {OPTIONS.map((option) => {
+              const isKakao = option.key === 'kakao'
+              return (
+                <button
+                  key={option.key}
+                  type="button"
+                  onClick={() => void share(option.key)}
+                  aria-busy={isKakao && !kakaoReady}
+                  className="flex flex-col items-center gap-0.5 rounded-md focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:outline-none"
                 >
-                  <Image
-                    src={option.icon}
-                    alt=""
-                    width={24}
-                    height={24}
-                    className="size-6 object-contain"
-                  />
-                </span>
-                <span className="text-sm leading-[1.5] font-medium text-neutral-850">
-                  {option.label}
-                </span>
-              </button>
-            ))}
+                  <span
+                    className={cn(
+                      'flex size-11 items-center justify-center rounded-full',
+                      option.circle,
+                    )}
+                  >
+                    <Image
+                      src={option.icon}
+                      alt=""
+                      width={24}
+                      height={24}
+                      className="size-6 object-contain"
+                    />
+                  </span>
+                  <span className="text-sm leading-[1.5] font-medium text-neutral-850">
+                    {option.label}
+                  </span>
+                </button>
+              )
+            })}
           </div>
+
+          {feedback && (
+            <p
+              role="status"
+              aria-live="polite"
+              className={cn(
+                'px-5 pb-5 text-center text-sm leading-[1.5] font-medium',
+                feedback.tone === 'error' ? 'text-red-600' : 'text-neutral-700',
+              )}
+            >
+              {feedback.message}
+            </p>
+          )}
         </DialogPrimitive.Content>
       </DialogPortal>
     </Dialog>

--- a/src/widgets/banner/ui/Banner.tsx
+++ b/src/widgets/banner/ui/Banner.tsx
@@ -106,7 +106,9 @@ const Banner = () => {
             }
             className={cn(
               'h-[0.556875rem] rounded-full transition-[width,background-color]',
-              index === activeIndex ? 'w-[1.3922rem] bg-secondary-500' : 'w-[0.556875rem] bg-neutral-100',
+              index === activeIndex
+                ? 'w-[1.3922rem] bg-secondary-500'
+                : 'w-[0.556875rem] bg-neutral-100',
             )}
           />
         ))}


### PR DESCRIPTION
Closes #203

## 변경 사항

### 관심(하트) 토글 낙관적 갱신
- `useAddAdoptionFavorite` / `useRemoveAdoptionFavorite` -> `useToggleAdoptionFavorite` 하나로 통합
- 기존에는 `onSuccess`에서 `adoptionQueries.all()`을 통째로 invalidate 해서 하트 한 번에 list/popular/breederPets/detail이 전부 재요청됐다
- `onMutate`에서 캐시 안의 해당 펫만 갈아끼우고, `onSettled`는 `refetchType: 'none'`으로 "다음 마운트 때 최신화" 표시만 남긴다 -> 토글당 네트워크 요청은 mutation 1건
- 캐시 형태 3종(무한 목록 / 배열 / 단일 상세)을 `patchAdoptionCache`에서 함께 처리

### 상세 관심 상태 공유
- 히어로(pc)와 CTA바(모바일·탭)가 같은 상태를 봐야 해서 `AdoptionDetailContent`에서 보관 후 내려준다
- CTA바 하트는 `tab:hidden` (모바일 전용), 버튼 색상을 `bg-point-500` 토큰으로 교체

### 공유 모달 SNS 연동
- 카카오톡 / 페이스북 / 인스타그램(Web Share) / URL 복사 실제 동작 연결
- 카카오 JS SDK는 `shared/lib/kakao.ts`에서 모달 오픈 시점에만 lazy 로드 + init
- SDK가 `window.open`을 동기로 호출하므로 `sendDefault`는 `await` 없이 클릭 핸들러 안에서 호출해야 팝업이 차단되지 않는다 (`shareToKakao`)
- 클립보드는 Async Clipboard 우선, HTTP·구형 브라우저는 `execCommand` 폴백

### 기타
- 상세 이미지 모달을 공통 `ImageDetailModal`로 교체 (`showActions={false}`)
- `Badge`에 `size` prop, `FavoriteButton`에 `labelClassName` 추가
- 소개글 값 타이포가 pc에서 16px로 남아 있던 것 수정 (`INFO_VALUE_CLASS`에 `pc:text-[1.25rem]` 흡수)

## 테스트 방법
1. `/adoption/{id}` 진입
2. 하트 토글 -> 네트워크 탭에 mutation 1건만, 관심 카운트 즉시 반영
3. 다른 목록(탐색/북마크)으로 이동 시 관심 상태 유지되는지 확인
4. 공유 버튼 -> 카카오톡 클릭 시 sharer 팝업 노출
   - DevTools 디바이스 툴바를 켜면 `maxTouchPoints > 1` + macOS UA 때문에 SDK가 iPad로 판정해 모바일 스킴 경로를 탄다. 데스크탑 확인 시에는 꺼야 한다
5. pc 폭에서 분양가 / 태어난 날 / 성별 / 소개글 값이 모두 20px

## 참고
- `pnpm-lock.yaml`이 prettier로 4400줄 포매팅되는 상태다. `.prettierignore`에 lockfile 추가가 필요해 보여 이번 PR에서는 제외했다