### PR TITLE
fix(adoption): 입양 상세 CTA 하트·공유 아이콘 색상 Figma 정렬 및 하단 네비 정리

### DIFF
--- a/src/app/(main)/adoption/[id]/_ui/AdoptionCtaBar.tsx
+++ b/src/app/(main)/adoption/[id]/_ui/AdoptionCtaBar.tsx
@@ -32,7 +32,7 @@ const AdoptionCtaBar = ({ listingId, isFavorite, onToggleFavorite }: AdoptionCta
         <FavoriteIcon
           size="lg"
           status={isFavorite ? 'fill' : 'default'}
-          className={isFavorite ? FAVORITE_ACTIVE : 'text-[#5d5d5d]'}
+          className={isFavorite ? FAVORITE_ACTIVE : 'text-neutral-500'}
         />
       </button>
 

--- a/src/app/(main)/adoption/[id]/_ui/FavoriteShareActions.tsx
+++ b/src/app/(main)/adoption/[id]/_ui/FavoriteShareActions.tsx
@@ -55,7 +55,7 @@ const FavoriteShareActions = ({
           aria-label="공유"
           className="flex items-center gap-0 text-[0.75rem] font-semibold text-neutral-850"
         >
-          <ShareIcon className="size-[2rem]" />
+          <ShareIcon className="size-[2rem] text-neutral-700" />
           <span className={labelClassName}>공유</span>
         </button>
       )}

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,5 +1,5 @@
 import { Gnb } from '@/widgets/gnb'
-import { BottomNav } from '@/widgets/bottom-nav'
+// import { BottomNav } from '@/widgets/bottom-nav'
 
 const MainLayout = ({ children }: { children: React.ReactNode }) => {
   return (
@@ -7,7 +7,7 @@ const MainLayout = ({ children }: { children: React.ReactNode }) => {
       <Gnb />
       {/* 하단 고정 BottomNav(모바일·탭)에 콘텐츠가 가리지 않도록 pb 확보 */}
       <main className="flex flex-1 flex-col pb-[5rem] pc:pb-0">{children}</main>
-      <BottomNav />
+      {/* <BottomNav /> */}
     </div>
   )
 }


### PR DESCRIPTION
Closes #207

## Changes
- 입양 상세 하단 CTA 하트 기본색 → Figma icon/tertiary `#a6a6a6`(neutral-500)
- 공유 아이콘 색 → Figma `#6b6b6b`(neutral-700)
- 전역 하단 BottomNav 주석 처리 (상세/신청 페이지 하단 CTA 바와 겹침 제거)

## 주의
- BottomNav 주석은 (main) 전 페이지에서 하단 메뉴를 제거합니다. 상세/신청 외 페이지 영향 확인 필요.

## How to test
1. /adoption/{id} 모바일: 하트 `#a6a6a6`, 공유 아이콘 `#6b6b6b`
2. 하단 CTA 바가 하단 메뉴에 가려지지 않는지 확인