### PR TITLE
fix(chat): 채팅방 목록 폴링 중복 제거 및 응답 형태 혼재 대응

### DIFF
--- a/src/app/(main)/chat/_lib/useChatRoomFilter.ts
+++ b/src/app/(main)/chat/_lib/useChatRoomFilter.ts
@@ -8,9 +8,11 @@ import { type FilterTab, filterRooms } from './constants'
 // [refactored] sidebar/list가 동일하게 가지고 있던 필터 상태 + 방 필터링 로직을 훅으로 추출
 const useChatRoomFilter = () => {
   const [filter, setFilter] = React.useState<FilterTab>('all')
+  // 방을 열면 소켓 이벤트가 rooms를 invalidate하므로, 폴링은 목록만 보고 있을 때의 보조 수단이다.
+  // 폴링 선언은 이 훅 한 곳에만 둔다 (옵저버마다 걸면 인터벌이 각자 돌아 요청이 중복된다).
   const roomsQuery = useQuery({
     ...chatQueries.rooms(),
-    refetchInterval: 5_000,
+    refetchInterval: 30_000,
     refetchIntervalInBackground: false,
   })
   const filteredRooms = React.useMemo(

--- a/src/app/(main)/chat/_ui/ChatPageContent.tsx
+++ b/src/app/(main)/chat/_ui/ChatPageContent.tsx
@@ -13,11 +13,8 @@ import { ChatRoomPanel } from './ChatRoomPanel'
 const ChatPageContent = () => {
   const [activeRoomId, setActiveRoomId] = React.useState<string | null>(null)
   const isPC = useBreakpoint('pc')
-  const roomsQuery = useQuery({
-    ...chatQueries.rooms(),
-    refetchInterval: 5_000,
-    refetchIntervalInBackground: false,
-  })
+  // activeRoomId로 방을 찾기 위한 캐시 구독만 한다. 폴링은 useChatRoomFilter가 담당.
+  const roomsQuery = useQuery(chatQueries.rooms())
   const profileQuery = useQuery({
     ...profileQueries.me(),
     enabled: !!activeRoomId,

--- a/src/entities/chat/api/chat.api.ts
+++ b/src/entities/chat/api/chat.api.ts
@@ -1,5 +1,18 @@
+import type { AxiosResponse } from 'axios'
 import { apiClient, API_VERSION, unwrap } from '@/shared/api'
 import type { ApiResponseFull, ChatRoomResponseDto, ChatMessageResponseDto } from '@/shared/types'
+
+type ChatListPayload<T> = ApiResponseFull<T[]> | T[]
+
+/** 개발 서버의 raw 배열과 표준 ApiResponseDto 봉투를 모두 정규화한다. */
+const unwrapChatListResponse = <T>(
+  response: AxiosResponse<ChatListPayload<T>>,
+  fallbackMessage: string,
+): T[] => {
+  if (Array.isArray(response.data)) return response.data
+
+  return unwrap({ status: response.status, data: response.data }, fallbackMessage)
+}
 
 /** 서버 정렬을 신뢰하지 않고 시간 오름차순으로 맞춘다(동시각은 messageId로 안정 정렬). */
 const sortMessages = (messages: ChatMessageResponseDto[]) =>
@@ -11,13 +24,15 @@ const sortMessages = (messages: ChatMessageResponseDto[]) =>
 /** 내 채팅방 목록 조회 */
 export const getChatRooms = () =>
   apiClient
-    .get<ApiResponseFull<ChatRoomResponseDto[]>>(`${API_VERSION}/chat/rooms`)
-    .then((response) => unwrap(response, '채팅방 목록을 불러오지 못했습니다.'))
+    .get<ChatListPayload<ChatRoomResponseDto>>(`${API_VERSION}/chat/rooms`)
+    .then((response) => unwrapChatListResponse(response, '채팅방 목록을 불러오지 못했습니다.'))
 
 /** 채팅 메시지 내역 조회 (커서 기반 페이지네이션) */
 export const getChatMessages = (roomId: string, limit?: number, before?: string) =>
   apiClient
     .get<
-      ApiResponseFull<ChatMessageResponseDto[]>
+      ChatListPayload<ChatMessageResponseDto>
     >(`${API_VERSION}/chat/rooms/${roomId}/messages`, { params: { limit, before } })
-    .then((response) => sortMessages(unwrap(response, '메시지를 불러오지 못했습니다.')))
+    .then((response) =>
+      sortMessages(unwrapChatListResponse(response, '메시지를 불러오지 못했습니다.')),
+    )


### PR DESCRIPTION
Closes #211
Closes #212

#210 머지 이후 발견된 채팅 회귀 2건을 수정한다.

## 변경 사항

### 응답 형태 혼재 대응 (#212)
`GET /api/v2/chat/rooms`, `.../messages`는 swagger상 `ApiResponseDto` 봉투로 선언돼 있으나 dev 서버는 배열을 그대로 내려준다. #210에서 선언만 보고 `unwrap`을 적용한 탓에 요청이 200으로 성공해도 `success`를 찾지 못해 예외가 발생, 채팅방 목록이 에러 상태로 빠졌다.

- `unwrapChatListResponse` 추가 — 배열/봉투 양쪽을 정규화

### 폴링 중복 제거 (#211)
`chatQueries.rooms()` 옵저버 두 곳이 각각 `refetchInterval: 5000`을 걸고 있었다. 같은 queryKey라 동시 요청은 dedup되지만 인터벌은 옵저버마다 따로 돈다.

- `ChatPageContent` — `refetchInterval` 제거 (`activeRoomId`로 방을 찾는 캐시 구독만 유지)
- `useChatRoomFilter` — 폴링 선언을 이 한 곳으로 통합, 5초 -> 30초

방을 연 상태에서는 `useChatRoom`이 소켓 이벤트마다 `chatQueries.rooms()`를 invalidate하므로, 폴링은 목록만 보고 있을 때의 보조 수단이다.

## 테스트 방법

1. `/chat` 진입 -> 채팅방 목록이 정상 렌더되는지 확인
2. 채팅방 진입 -> 메시지 내역이 정상 렌더되는지 확인
3. DevTools Network에서 `rooms` 요청이 30초당 1회인지 확인
4. 메시지 수신 시 목록이 소켓으로 즉시 갱신되는지 확인
5. 탭을 백그라운드로 전환하면 폴링이 멈추는지 확인

## 후속 확인 필요

- 채팅 응답이 배열/봉투 중 어느 쪽이 정본인지 백엔드 확인 후 shim 제거 또는 swagger 수정
- 소켓이 현재 방(`join_room`) 외 다른 방 메시지도 전달하는지에 따라 목록 폴링 주기 재조정