### PR TITLE
fix(profile): 마이홈 프로필 카드 Figma 디자인 정렬

### DIFF
--- a/src/app/(main)/home/_ui/ProfileCard.tsx
+++ b/src/app/(main)/home/_ui/ProfileCard.tsx
@@ -54,19 +54,29 @@ interface ProfileCardBreederProps {
 
 type ProfileCardProps = ProfileCardBaseProps | ProfileCardBreederProps
 
+// 모바일은 가로(아바타 → 라벨), PC는 세로(라벨 → 아바타). DOM 순서는 하나로 두고
+// flex-col-reverse로 뒤집어 마크업 중복을 피한다.
 const FollowerSection = ({
-  followerCount,
+  vertical,
   className,
   textClassName,
   onClick,
 }: {
-  followerCount: number
+  vertical?: boolean
   className?: string
   textClassName?: string
   onClick?: () => void
 }) => (
-  <button type="button" onClick={onClick} className={cn('flex items-center gap-0.5', className)}>
-    {/* 팔로워 미리보기 — ProfileAvatar xsmall(24) + 회색 테두리, 살짝 겹침 */}
+  <button
+    type="button"
+    onClick={onClick}
+    className={cn(
+      'flex gap-0.5',
+      vertical ? 'flex-col-reverse items-start gap-2' : 'items-center',
+      className,
+    )}
+  >
+    {/* 친구 목록 미리보기 — ProfileAvatar xsmall(24) + 회색 테두리, 살짝 겹침 */}
     <div className="flex items-center">
       {[0, 1, 2].map((i) => (
         <ProfileAvatar
@@ -76,9 +86,7 @@ const FollowerSection = ({
         />
       ))}
     </div>
-    <span className={cn('font-medium text-neutral-850', textClassName)}>
-      팔로워 {followerCount}
-    </span>
+    <span className={cn('font-medium text-neutral-850', textClassName)}>친구 목록</span>
   </button>
 )
 
@@ -139,7 +147,7 @@ const FavoriteButton = ({ className }: { className?: string }) => (
 const EditButton = () => (
   <Link
     href="/home/edit"
-    className="flex h-10 flex-1 items-center justify-center rounded-full border border-neutral-300 p-2 text-base leading-[1.5] font-semibold text-neutral-850 tab:h-12"
+    className="flex h-8 flex-1 items-center justify-center rounded-full border border-neutral-300 p-2 text-sm leading-[1.5] font-semibold text-neutral-850 tab:h-10 tab:text-base"
   >
     프로필 편집
   </Link>
@@ -189,15 +197,16 @@ const ProfileCard = ({ profile, mode = 'mine' }: ProfileCardProps) => {
     ? `${breederProfile.businessLocation.city} ${breederProfile.businessLocation.district}`
     : null
 
-  // 상단 뱃지 (전 모드 공통, 채운 #3e3e3e) — 모바일 md(14px) / 데스크탑 lg(16px)
+  // 상단 뱃지 (전 모드 공통) — point-500 채움 + primary-500 테두리/텍스트
+  // 모바일 md(10px·h-24) / PC lg(14px). PC 높이는 디자인 노드 기준 32px로 맞춘다.
   const renderBadges = (size?: 'md') => (
     <>
       {isBreederProfile && (
-        <Badge variant="active" size={size}>
+        <Badge variant="pointFilled" size={size} className={size ? undefined : 'h-8'}>
           브리더
         </Badge>
       )}
-      <Badge variant="active" size={size}>
+      <Badge variant="pointFilled" size={size} className={size ? undefined : 'h-8'}>
         {profile.bpm} BPM
       </Badge>
     </>
@@ -225,12 +234,8 @@ const ProfileCard = ({ profile, mode = 'mine' }: ProfileCardProps) => {
           {/* 소개 */}
           <ProfileBio className="w-full text-sm">{profile.bio}</ProfileBio>
           {locationText && <LocationInfo location={locationText} />}
-          {/* 팔로워 */}
-          <FollowerSection
-            followerCount={profile.followerCount}
-            textClassName="text-xs"
-            onClick={() => setFollowOpen(true)}
-          />
+          {/* 친구 목록 */}
+          <FollowerSection textClassName="text-xs" onClick={() => setFollowOpen(true)} />
         </div>
         {/* 하단: 모드별 버튼 (풀폭, gap-10, h-40) */}
         <div className="flex w-full items-start gap-2.5">
@@ -239,7 +244,7 @@ const ProfileCard = ({ profile, mode = 'mine' }: ProfileCardProps) => {
       </div>
 
       {/* ===== Desktop (디자인 node 1021-20324) ===== */}
-      <div className="mx-auto hidden max-w-[59.25rem] overflow-hidden rounded-lg bg-neutral-50 tab:block">
+      <div className="mx-auto hidden max-w-[59.25rem] overflow-hidden rounded-lg bg-point-50 tab:block">
         {/* 상단: 좌(뱃지·이름·소개) / 우(팔로워·아바타) — h-204 고정, 콘텐츠 가운데 정렬 */}
         <div className="flex h-[12.75rem] items-center justify-center overflow-hidden px-5 py-8">
           <div className="flex w-full max-w-[48.75rem] items-end justify-between gap-3">
@@ -247,11 +252,12 @@ const ProfileCard = ({ profile, mode = 'mine' }: ProfileCardProps) => {
               <div className="flex items-start gap-3">{renderBadges()}</div>
               <ProfileName className="text-2xl">{profile.nickname}</ProfileName>
               {locationText && <LocationInfo location={locationText} />}
-              <ProfileBio className="text-base">{profile.bio}</ProfileBio>
+              {/* 디자인상 이름·소개 블록 폭 440 */}
+              <ProfileBio className="w-full max-w-[27.5rem] text-base">{profile.bio}</ProfileBio>
             </div>
             <div className="flex shrink-0 items-end gap-3">
               <FollowerSection
-                followerCount={profile.followerCount}
+                vertical
                 textClassName="text-xs"
                 onClick={() => setFollowOpen(true)}
               />
@@ -263,7 +269,7 @@ const ProfileCard = ({ profile, mode = 'mine' }: ProfileCardProps) => {
         {/* 하단: 구분선 + 모드별 버튼 */}
         <div className="flex flex-col items-center gap-3 pb-8">
           <div className="h-px w-full bg-neutral-150" />
-          <div className="flex w-full max-w-[36.625rem] items-center gap-6 px-5">
+          <div className="flex w-full max-w-[43rem] items-center gap-6 px-5">
             <Actions />
           </div>
         </div>


### PR DESCRIPTION
Closes #214

Figma: profile-myhome (node 1023-22119)

## 변경 사항

| 항목 | 이전 | 이후 |
|---|---|---|
| 상단 뱃지 | `active` (neutral-850 채움) | `pointFilled` (point-500 채움 + primary-500 테두리/텍스트) |
| PC 카드 배경 | `neutral-50` | `point-50` |
| 팔로워 라벨 | `팔로워 {N}` | `친구 목록` |
| PC 팔로워 배치 | 가로 (아바타 -> 라벨) | 세로 (라벨 위 / 아바타 아래) |
| PC 버튼 행 폭 | 586px | 688px |
| 프로필 편집 버튼 높이 | 40 / PC 48 | 32 / PC 40 |
| PC 소개 폭 | 제한 없음 | 440px |

`FollowerSection`은 DOM 순서를 하나로 두고 `flex-col-reverse`로 뒤집어 모바일 가로 / PC 세로를 처리했다. 마크업을 두 벌 만들지 않기 위함.

디자인 토큰은 모두 프로젝트 토큰과 그대로 대응된다.
`#fffff1`->`point-50`, `#fffe72`->`point-500`, `#ad651d`->`primary-500`, `#3e3e3e`->`neutral-850`, `#e4e4e4`->`neutral-150`, `#cacaca`->`neutral-300`

## 테스트 방법

1. `/home` 진입 후 모바일(375) / PC 각각에서 프로필 카드 확인
2. 뱃지 색상·크기가 디자인과 일치하는지 확인
3. 친구 목록 아바타 3개 배치가 브레이크포인트별로 디자인과 일치하는지 확인
4. 브리더 계정에서 뱃지(브리더 / BPM) 2개 노출이 정상인지 확인

## 확인 필요

- **팔로워 카운트가 라벨에서 사라진다.** 숫자는 이제 팔로워 모달 안에서만 보인다. 디자인 의도가 맞는지 확인 필요.
- **PC 뱃지 높이**가 디자인 노드는 32px인데 디자인 시스템 label-badge lg 토큰은 29px다. 노드 기준으로 `h-8`을 덮었으나, 토큰을 따르는 게 맞다면 되돌려야 한다.