### PR TITLE
feat(profile): 마이홈 즐겨찾는 브리더 실 API 연결

### DIFF
--- a/src/app/(main)/home/_ui/FavoriteBreedersContent.tsx
+++ b/src/app/(main)/home/_ui/FavoriteBreedersContent.tsx
@@ -1,34 +1,51 @@
-import { ChevronIcon } from '@/shared/assets/icons'
-import { Container } from '@/shared/ui'
-import { MOCK_FAVORITE_BREEDERS } from '@/shared/mocks/myHome'
+'use client'
+
+import { useInfiniteQuery } from '@tanstack/react-query'
+import { Container, InfiniteScrollTrigger } from '@/shared/ui'
+import { profileQueries } from '@/entities/profile'
+import type { FavoriteBreederCard } from '@/shared/types'
+import type { FavoriteBreeder } from '@/shared/mocks/myHome'
 import { BreederCard } from './BreederCard'
 
+// 백엔드 FavoriteBreederCard → BreederCard 뷰 모델(FavoriteBreeder) 매핑
+// (badges/date는 카드에서 렌더하지 않아 최소값만 채움)
+const toBreederCardModel = (breeder: FavoriteBreederCard): FavoriteBreeder => ({
+  id: breeder.breederId,
+  nickname: breeder.nickname,
+  imageUrl: breeder.profileImageUrl ?? null,
+  badges: [],
+  isBreeding: breeder.recentPetStatus === 'available',
+  location: breeder.breederLocation,
+  date: breeder.addedAt,
+})
+
 const FavoriteBreedersContent = () => {
-  const breeders = MOCK_FAVORITE_BREEDERS
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery(
+    profileQueries.favoriteBreeders(),
+  )
+
+  const breeders = (data?.pages ?? []).flatMap((page) => page.items.map(toBreederCardModel))
 
   return (
-    <>
-      {/* 모바일 전용: 나만 보기 버튼 (디자인 1023-39468 · 1023-39688) */}
-      {/* ponytail: 필터 동작 미연결, 실데이터 붙을 때 드롭다운 연결 */}
-      <div className="px-4 pt-5 tab:hidden">
-        <button
-          type="button"
-          className="flex h-10 items-center gap-1 rounded-lg bg-neutral-850 px-2"
-        >
-          <span className="text-base leading-[1.5] font-semibold text-neutral-50">나만 보기</span>
-          <ChevronIcon className="size-4 text-neutral-50" />
-        </button>
-      </div>
-
-      {/* 디자인(1023-38692): 모바일 2열 / PC 4열, gap-20. PC는 1188px로 묶어 가운데 정렬 */}
-      <Container className="px-4 py-5 tab:py-10 pc:pb-27">
+    /* 디자인(1023-38692): 모바일 2열 / PC 4열, gap-20. PC는 1188px로 묶어 가운데 정렬 */
+    <Container className="px-4 py-5 tab:py-10 pc:pb-27">
+      {breeders.length === 0 ? (
+        <p className="py-10 text-center text-sm leading-[1.5] font-medium text-neutral-700">
+          즐겨찾는 브리더가 없습니다.
+        </p>
+      ) : (
         <div className="grid grid-cols-2 gap-x-2.5 gap-y-4 tab:grid-cols-3 tab:gap-5 pc:mx-auto pc:max-w-[74.25rem] pc:grid-cols-4">
           {breeders.map((breeder) => (
             <BreederCard key={breeder.id} breeder={breeder} />
           ))}
         </div>
-      </Container>
-    </>
+      )}
+      <InfiniteScrollTrigger
+        onIntersect={fetchNextPage}
+        hasNextPage={hasNextPage}
+        isFetchingNextPage={isFetchingNextPage}
+      />
+    </Container>
   )
 }
 

--- a/src/app/(main)/home/_ui/MyHomeContent.tsx
+++ b/src/app/(main)/home/_ui/MyHomeContent.tsx
@@ -179,7 +179,7 @@ const MyHomeContent = () => {
 
         {/* 디자인: 모바일(1023-23241) px-16·py-24 / 탭·PC(2046-160971) px-48·80·py-40 */}
         <TabPanel value="posts" className="px-4 py-6 tab:py-10">
-          <PostList posts={posts} />
+          <PostList posts={posts} emptyText="내가 쓴 글이 없습니다." />
         </TabPanel>
 
         <TabsContent value="breeders" className="mt-0">

--- a/src/app/(main)/home/_ui/PostList.tsx
+++ b/src/app/(main)/home/_ui/PostList.tsx
@@ -4,11 +4,21 @@ import { toPostCardProps, type MyHomePost } from '@/shared/mocks/myHome'
 
 interface PostListProps {
   posts: MyHomePost[]
+  /** 글이 없을 때 문구 (마이홈은 '내가 쓴 글이 없습니다.') */
+  emptyText?: string
 }
 
 // 디자인(2046-160971): 모바일은 카드 stack(gap-20), 탭·PC는 #cacaca 보더 박스(rounded-8) + 구분선, 게시글 간 gap-32
 // 박스는 max-w-948(59.25rem) 중앙 정렬(frame items-center), 세로 여백(spacing-40)은 래퍼 Container의 py가 담당
-const PostList = ({ posts }: PostListProps) => {
+const PostList = ({ posts, emptyText = '게시글이 없습니다.' }: PostListProps) => {
+  if (posts.length === 0) {
+    return (
+      <p className="py-10 text-center text-sm leading-[1.5] font-medium text-neutral-700">
+        {emptyText}
+      </p>
+    )
+  }
+
   return (
     <div className="flex flex-col gap-5 tab:mx-auto tab:max-w-[59.25rem] tab:gap-8 tab:rounded-lg tab:border tab:border-neutral-300 tab:p-3">
       {posts.map((post, index) => (


### PR DESCRIPTION
## 변경사항
- 마이홈 '즐겨찾는 브리더' 탭을 실 API로 연결 (`GET /api/v2/profile/me/favorite-breeders`)
  - `entities/profile`에 이미 있던 `profileQueries.favoriteBreeders()` 재사용, 새 api/query 추가 없음
  - `FavoriteBreederCard` → `BreederCard` 뷰 모델 매핑 (`recentPetStatus === 'available'` → 분양중)
  - `InfiniteScrollTrigger`로 다음 페이지 로드, 목데이터 사용 제거
- 동작이 연결되지 않았던 '나만 보기' 버튼 제거
- 빈 상태 문구 추가
  - 즐겨찾는 브리더: "즐겨찾는 브리더가 없습니다."
  - `PostList`: 기본 "게시글이 없습니다." / 마이홈은 "내가 쓴 글이 없습니다."

## 확인
- `pnpm type-check` 통과
- 게시글 탭은 기존에 이미 `communityQueries.myPosts()`로 실 API 연결되어 있어 변경 없음

Closes #217