### PR TITLE
feat(community): 카드 좋아요·북마크 실 API 연결 및 리액션 mutation 정리

### DIFF
--- a/src/app/(main)/bookmarks/_ui/SavedFeedsTab.tsx
+++ b/src/app/(main)/bookmarks/_ui/SavedFeedsTab.tsx
@@ -2,7 +2,8 @@
 
 import { useMemo } from 'react'
 import { useInfiniteQuery } from '@tanstack/react-query'
-import { communityQueries, PostCard, toCommunityPreviewProps } from '@/entities/community'
+import { communityQueries, toCommunityPreviewProps } from '@/entities/community'
+import { ConnectedPostCard } from '@/features/community'
 import { dedupeBy } from '@/shared/lib/dedupeBy'
 import { Container, InfiniteScrollTrigger, ListState } from '@/shared/ui'
 
@@ -31,7 +32,11 @@ const SavedFeedsTab = () => {
           {feeds.map((post) => (
             <div key={post.postId} className="rounded-lg border border-neutral-300 bg-white">
               {/* 저장피드: ProfileHeader sm 헤더 + 모바일 좌우 패딩 보완(px-3) */}
-              <PostCard profileType="sm" className="px-3" {...toCommunityPreviewProps(post)} />
+              <ConnectedPostCard
+                profileType="sm"
+                className="px-3"
+                {...toCommunityPreviewProps(post)}
+              />
             </div>
           ))}
         </ListState>

--- a/src/app/(main)/community/[postId]/_ui/PostDetailContent.tsx
+++ b/src/app/(main)/community/[postId]/_ui/PostDetailContent.tsx
@@ -21,10 +21,9 @@ import { communityQueries } from '@/entities/community'
 import { profileQueries } from '@/entities/profile'
 import {
   useToggleCommunityPostLike,
+  useToggleCommunityPostBookmark,
   useCreateCommunityComment,
   useDeleteCommunityPost,
-  useBookmarkCommunityPost,
-  useUnbookmarkCommunityPost,
 } from '@/features/community'
 import { useAuthStatus } from '@/features/auth'
 import type { CommunityComment } from '@/shared/types'
@@ -62,9 +61,8 @@ const PostDetailContent = ({ postId }: PostDetailContentProps) => {
   } = useInfiniteQuery(communityQueries.comments(postId))
   const comments = commentsData?.pages.flatMap((page) => page.items) ?? []
 
-  const toggleLike = useToggleCommunityPostLike(postId)
-  const bookmark = useBookmarkCommunityPost()
-  const unbookmark = useUnbookmarkCommunityPost()
+  const toggleLike = useToggleCommunityPostLike(postId, post?.isLiked ?? false)
+  const toggleBookmark = useToggleCommunityPostBookmark(postId, post?.isSaved ?? false)
   const createComment = useCreateCommunityComment(postId)
   const deletePost = useDeleteCommunityPost()
 
@@ -168,7 +166,7 @@ const PostDetailContent = ({ postId }: PostDetailContentProps) => {
                 ariaLabel="좋아요"
                 active={post.isLiked}
                 iconStatus={post.isLiked ? 'fill' : 'default'}
-                onClick={() => toggleLike.mutate(post.isLiked)}
+                onClick={toggleLike.toggleLike}
                 disabled={toggleLike.isPending}
               />
               <PostActionButton
@@ -182,8 +180,8 @@ const PostDetailContent = ({ postId }: PostDetailContentProps) => {
                 ariaLabel="북마크"
                 active={post.isSaved}
                 activeClassName={BOOKMARK_ACTIVE}
-                onClick={() => (post.isSaved ? unbookmark : bookmark).mutate(postId)}
-                disabled={bookmark.isPending || unbookmark.isPending}
+                onClick={toggleBookmark.toggleBookmark}
+                disabled={toggleBookmark.isPending}
               />
             </div>
 

--- a/src/app/(main)/community/_ui/CommunityContent.tsx
+++ b/src/app/(main)/community/_ui/CommunityContent.tsx
@@ -10,7 +10,8 @@ import {
   SearchButton,
   Separator,
 } from '@/shared/ui'
-import { PostCard, communityQueries, toCommunityPreviewProps } from '@/entities/community'
+import { communityQueries, toCommunityPreviewProps } from '@/entities/community'
+import { ConnectedPostCard } from '@/features/community'
 
 const CommunityContent = () => {
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery(
@@ -53,7 +54,7 @@ const CommunityContent = () => {
             {posts.map((post, index) => (
               <Fragment key={post.postId}>
                 {index > 0 && <Separator className="bg-border-light" />}
-                <PostCard
+                <ConnectedPostCard
                   {...toCommunityPreviewProps(post)}
                   // ponytail: 목록 API에 댓글 미리보기 없음 — 상세(commentPreview) 생기면 교체. 댓글 있는 글만.
                   commentPreview={

--- a/src/app/(main)/community/drafts/_ui/DraftsContent.tsx
+++ b/src/app/(main)/community/drafts/_ui/DraftsContent.tsx
@@ -4,7 +4,8 @@ import { Fragment, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { useQuery } from '@tanstack/react-query'
 import { Container, DeleteConfirmModal, NavigationBar, Separator } from '@/shared/ui'
-import { PostCard, communityQueries, toCommunityPreviewProps } from '@/entities/community'
+import { communityQueries, toCommunityPreviewProps } from '@/entities/community'
+import { ConnectedPostCard } from '@/features/community'
 import { useDeleteCommunityPost } from '@/features/community'
 
 /** 임시저장 목록 — 카드를 누르면 수정 화면에서 이어서 작성한다 */
@@ -37,7 +38,7 @@ const DraftsContent = () => {
               {drafts.map((draft, index) => (
                 <Fragment key={draft.postId}>
                   {index > 0 && <Separator className="bg-border-light" />}
-                  <PostCard
+                  <ConnectedPostCard
                     {...toCommunityPreviewProps(draft)}
                     // 임시저장 글은 상세가 없으므로 수정 화면으로 바로 보낸다
                     detailHref={`/community/${draft.postId}/edit`}

--- a/src/app/(main)/community/drafts/_ui/DraftsContent.tsx
+++ b/src/app/(main)/community/drafts/_ui/DraftsContent.tsx
@@ -5,8 +5,7 @@ import { useRouter } from 'next/navigation'
 import { useQuery } from '@tanstack/react-query'
 import { Container, DeleteConfirmModal, NavigationBar, Separator } from '@/shared/ui'
 import { communityQueries, toCommunityPreviewProps } from '@/entities/community'
-import { ConnectedPostCard } from '@/features/community'
-import { useDeleteCommunityPost } from '@/features/community'
+import { ConnectedPostCard, useDeleteCommunityPost } from '@/features/community'
 
 /** 임시저장 목록 — 카드를 누르면 수정 화면에서 이어서 작성한다 */
 const DraftsContent = () => {

--- a/src/app/(main)/home/_ui/PostList.tsx
+++ b/src/app/(main)/home/_ui/PostList.tsx
@@ -1,5 +1,6 @@
 import { Fragment } from 'react'
-import { PostCard, toCommunityPreviewProps } from '@/entities/community'
+import { toCommunityPreviewProps } from '@/entities/community'
+import { ConnectedPostCard } from '@/features/community'
 import type { CommunityPostCard } from '@/shared/types'
 
 interface PostListProps {
@@ -26,7 +27,7 @@ const PostList = ({ posts, emptyText = '게시글이 없습니다.', onEdit, onD
     <div className="flex flex-col gap-5 tab:mx-auto tab:max-w-[59.25rem] tab:gap-8 tab:rounded-lg tab:border tab:border-neutral-300 tab:p-3">
       {posts.map((post, index) => (
         <Fragment key={post.postId}>
-          <PostCard
+          <ConnectedPostCard
             {...toCommunityPreviewProps(post)}
             onEdit={onEdit && (() => onEdit(post.postId))}
             onDelete={onDelete && (() => onDelete(post.postId))}

--- a/src/entities/community/api/community.api.ts
+++ b/src/entities/community/api/community.api.ts
@@ -39,6 +39,8 @@ interface RawCommunityPostCard {
   likeCount: number
   commentCount: number
   saveCount: number
+  isLiked: boolean
+  isSaved: boolean
   createdAt: string
 }
 
@@ -95,6 +97,8 @@ const mapCard = (raw: RawCommunityPostCard): CommunityPostCard => ({
   likeCount: raw.likeCount,
   commentCount: raw.commentCount,
   saveCount: raw.saveCount,
+  isLiked: raw.isLiked,
+  isSaved: raw.isSaved,
   createdAt: raw.createdAt,
 })
 
@@ -170,7 +174,8 @@ export const getMyBookmarkedPosts = async (
     `${API_VERSION}/community/posts/me/bookmarks?${query.toString()}`,
   )
   const page = unwrap(response, '저장한 게시글 목록 조회에 실패했습니다.')
-  return { ...page, items: page.items.map(mapCard) }
+  // 저장 목록 응답의 isSaved가 false로 내려와도 이 엔드포인트 결과는 전부 내가 저장한 글이다.
+  return { ...page, items: page.items.map((raw) => ({ ...mapCard(raw), isSaved: true })) }
 }
 
 /** 내가 임시저장(draft) 한 게시글 목록 — 본인에게만 노출, 최신순 */

--- a/src/entities/community/api/community.queries.ts
+++ b/src/entities/community/api/community.queries.ts
@@ -57,9 +57,11 @@ export const communityQueries = {
       staleTime: STALE_TIME.DEFAULT,
     }),
 
+  myBookmarksAll: () => [...communityQueries.all(), 'myBookmarks'] as const,
+
   myBookmarks: (pageSize = 15) =>
     createInfiniteQuery({
-      queryKey: [...communityQueries.all(), 'myBookmarks', pageSize],
+      queryKey: [...communityQueries.myBookmarksAll(), pageSize],
       queryFn: (page) => getMyBookmarkedPosts({ page, pageSize }),
       staleTime: STALE_TIME.DEFAULT,
     }),

--- a/src/entities/community/model/communityPreview.ts
+++ b/src/entities/community/model/communityPreview.ts
@@ -7,16 +7,20 @@ interface CommunityPreviewAuthor {
 }
 
 interface CommunityPreviewProps {
+  postId: string
   author: CommunityPreviewAuthor
   createdAt: string
   text: string
   images?: string[]
   likeCount: number
   commentCount: number
+  isLiked: boolean
+  isSaved: boolean
   detailHref?: string
 }
 
 const toCommunityPreviewProps = (post: CommunityPostCard): CommunityPreviewProps => ({
+  postId: post.postId,
   author: {
     id: post.authorId,
     nickname: post.authorNickname,
@@ -27,6 +31,8 @@ const toCommunityPreviewProps = (post: CommunityPostCard): CommunityPreviewProps
   images: post.photoUrls,
   likeCount: post.likeCount,
   commentCount: post.commentCount,
+  isLiked: post.isLiked,
+  isSaved: post.isSaved,
   detailHref: `/community/${post.postId}`,
 })
 

--- a/src/entities/community/ui/CommunityBox.tsx
+++ b/src/entities/community/ui/CommunityBox.tsx
@@ -11,6 +11,9 @@ import { CommunityPostProfile } from './CommunityPostProfile'
 type CommunityBoxAuthor = CommunityPreviewAuthor
 
 interface CommunityBoxProps extends CommunityPreviewProps {
+  /** 좋아요·북마크 토글 — features의 ConnectedCommunityBox에서 주입 */
+  onToggleLike?: () => void
+  onToggleSave?: () => void
   className?: string
 }
 
@@ -25,7 +28,11 @@ const CommunityBox = ({
   images = [],
   likeCount,
   commentCount,
+  isLiked,
+  isSaved,
   detailHref,
+  onToggleLike,
+  onToggleSave,
   className,
 }: CommunityBoxProps) => {
   const primaryImage = images[0]
@@ -84,7 +91,14 @@ const CommunityBox = ({
         )}
       </div>
 
-      <CommunityPostActions likeCount={likeCount} commentCount={commentCount} />
+      <CommunityPostActions
+        likeCount={likeCount}
+        commentCount={commentCount}
+        liked={isLiked}
+        saved={isSaved}
+        onToggleLike={onToggleLike}
+        onToggleSave={onToggleSave}
+      />
     </article>
   )
 }

--- a/src/entities/community/ui/CommunityPostActions.tsx
+++ b/src/entities/community/ui/CommunityPostActions.tsx
@@ -1,38 +1,45 @@
 'use client'
 
-import { useState } from 'react'
 import { FavoriteIcon, PixelBookmarkIcon, PixelMessageIcon } from '@/shared/assets/icons'
 import { BOOKMARK_ACTIVE, PostActionButton } from '@/shared/ui'
 
 interface CommunityPostActionsProps {
   likeCount: number
   commentCount: number
+  liked: boolean
+  saved: boolean
+  /** 미전달 시 버튼은 표시만 되고 동작하지 않는다 (features 래퍼에서 주입) */
+  onToggleLike?: () => void
+  onToggleSave?: () => void
 }
 
-const CommunityPostActions = ({ likeCount, commentCount }: CommunityPostActionsProps) => {
-  // ponytail: API 미연결 — mutation 연결 전까지 공통 로컬 상태로 색과 카운트만 반영한다.
-  const [liked, setLiked] = useState(false)
-  const [bookmarked, setBookmarked] = useState(false)
-
+const CommunityPostActions = ({
+  likeCount,
+  commentCount,
+  liked,
+  saved,
+  onToggleLike,
+  onToggleSave,
+}: CommunityPostActionsProps) => {
   return (
     <div className="flex items-center gap-2">
       <PostActionButton
         icon={FavoriteIcon}
-        count={likeCount + (liked ? 1 : 0)}
+        count={likeCount}
         iconClassName="size-8"
         ariaLabel="좋아요"
         active={liked}
         iconStatus={liked ? 'fill' : 'default'}
-        onClick={() => setLiked((current) => !current)}
+        onClick={onToggleLike}
       />
       <PostActionButton icon={PixelMessageIcon} count={commentCount} iconClassName="size-8" />
       <PostActionButton
         icon={PixelBookmarkIcon}
         iconClassName="size-8"
         ariaLabel="북마크"
-        active={bookmarked}
+        active={saved}
         activeClassName={BOOKMARK_ACTIVE}
-        onClick={() => setBookmarked((current) => !current)}
+        onClick={onToggleSave}
       />
     </div>
   )

--- a/src/entities/community/ui/PostCard.tsx
+++ b/src/entities/community/ui/PostCard.tsx
@@ -19,6 +19,9 @@ interface PostCardProps extends CommunityPreviewProps {
   /** 내 글일 때만 전달 — ⋯ 메뉴가 수정/삭제로 동작 (미전달 시 메뉴 미노출) */
   onEdit?: () => void
   onDelete?: () => void
+  /** 좋아요·북마크 토글 — features의 ConnectedPostCard에서 주입 */
+  onToggleLike?: () => void
+  onToggleSave?: () => void
   className?: string
 }
 
@@ -35,12 +38,16 @@ const PostCard = ({
   images = [],
   likeCount,
   commentCount,
+  isLiked,
+  isSaved,
   detailHref,
   profileType,
   showMore,
   commentPreview,
   onEdit,
   onDelete,
+  onToggleLike,
+  onToggleSave,
   className,
 }: PostCardProps) => {
   const hasImages = images.length > 0
@@ -119,7 +126,14 @@ const PostCard = ({
         {/* 액션 + 댓글 미리보기 — 아이콘↔댓글 4px gap */}
         <div className="flex flex-col gap-1">
           {/* 액션: 좋아요 · 댓글 · 북마크 (픽셀 아이콘) */}
-          <CommunityPostActions likeCount={likeCount} commentCount={commentCount} />
+          <CommunityPostActions
+            likeCount={likeCount}
+            commentCount={commentCount}
+            liked={isLiked}
+            saved={isSaved}
+            onToggleLike={onToggleLike}
+            onToggleSave={onToggleSave}
+          />
 
           {/* 댓글 미리보기 (Figma community-profile 2596-231732) — 작성자 + 본문 1줄 + [더보기] */}
           {commentPreview && (

--- a/src/features/adoption/api/adoption.mutations.ts
+++ b/src/features/adoption/api/adoption.mutations.ts
@@ -7,6 +7,7 @@ import {
   type QueryKey,
 } from '@tanstack/react-query'
 import { adoptionQueries } from '@/entities/adoption'
+import { patchCachedItem } from '@/shared/lib/patchCachedItem'
 import type {
   AdoptionFavoriteResponse,
   AdoptionPetCard,
@@ -35,33 +36,15 @@ const isFavoritablePet = (value: unknown): value is FavoritablePet =>
   'isFavorited' in value &&
   'favoriteCount' in value
 
-/**
- * adoption 캐시 안의 특정 펫만 갈아끼운다.
- * 캐시에 들어있는 형태는 세 가지뿐이다 — 무한 목록(InfiniteData<PaginationResponse>), 배열(popular), 단일 상세.
- */
+/** adoption 캐시 안의 특정 펫만 갈아끼운다. */
 const patchAdoptionCache = (
   data: unknown,
   petId: string,
   patch: (pet: FavoritablePet) => FavoritablePet,
-): unknown => {
-  const applyToPet = (value: unknown) =>
-    isFavoritablePet(value) && value.petId === petId ? patch(value) : value
-
-  if (Array.isArray(data)) return data.map(applyToPet)
-  if (typeof data !== 'object' || data === null) return data
-
-  if ('pages' in data && Array.isArray(data.pages)) {
-    return {
-      ...data,
-      pages: data.pages.map((page: unknown) =>
-        typeof page === 'object' && page !== null && 'items' in page && Array.isArray(page.items)
-          ? { ...page, items: page.items.map(applyToPet) }
-          : page,
-      ),
-    }
-  }
-  return applyToPet(data)
-}
+): unknown =>
+  patchCachedItem(data, (value) =>
+    isFavoritablePet(value) && value.petId === petId ? patch(value) : value,
+  )
 
 type FavoritePages = InfiniteData<PaginationResponse<AdoptionPetCard>, number>
 

--- a/src/features/community/api/community.mutations.ts
+++ b/src/features/community/api/community.mutations.ts
@@ -2,69 +2,8 @@
 
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { communityQueries } from '@/entities/community'
-import type {
-  CreateCommunityPostRequest,
-  UpdateCommunityPostRequest,
-  CreateCommunityCommentRequest,
-  UpdateCommunityCommentRequest,
-  CommunityPostDetail,
-} from '@/shared/types'
-import {
-  createCommunityPost,
-  updateCommunityPost,
-  deleteCommunityPost,
-  likeCommunityPost,
-  unlikeCommunityPost,
-  createCommunityComment,
-  updateCommunityComment,
-  deleteCommunityComment,
-  bookmarkCommunityPost,
-  unbookmarkCommunityPost,
-} from './community.api'
-
-/**
- * 게시글 좋아요 토글 — 상세 캐시를 낙관적으로 갱신(즉시 반응), 실패 시 롤백.
- * mutate 인자는 "토글 직전의 isLiked" 값.
- */
-export const useToggleCommunityPostLike = (postId: string) => {
-  const qc = useQueryClient()
-  const detailKey = communityQueries.detail(postId).queryKey
-  return useMutation({
-    mutationFn: (isLiked: boolean) =>
-      isLiked ? unlikeCommunityPost(postId) : likeCommunityPost(postId),
-    onMutate: async (isLiked: boolean) => {
-      await qc.cancelQueries({ queryKey: detailKey })
-      const prev = qc.getQueryData<CommunityPostDetail>(detailKey)
-      if (prev) {
-        qc.setQueryData<CommunityPostDetail>(detailKey, {
-          ...prev,
-          isLiked: !isLiked,
-          likeCount: Math.max(0, prev.likeCount + (isLiked ? -1 : 1)),
-        })
-      }
-      return { prev }
-    },
-    onError: (_err, _isLiked, ctx) => {
-      if (ctx?.prev) qc.setQueryData(detailKey, ctx.prev)
-    },
-    onSettled: () => {
-      void qc.invalidateQueries({ queryKey: detailKey })
-      void qc.invalidateQueries({ queryKey: [...communityQueries.all(), 'posts'] })
-    },
-  })
-}
-
-/** 댓글 작성 (parentCommentId 있으면 답글) — 댓글 목록 + 상세(댓글 수) 갱신 */
-export const useCreateCommunityComment = (postId: string) => {
-  const qc = useQueryClient()
-  return useMutation({
-    mutationFn: (data: CreateCommunityCommentRequest) => createCommunityComment(postId, data),
-    onSuccess: () => {
-      void qc.invalidateQueries({ queryKey: [...communityQueries.all(), 'comments', postId] })
-      void qc.invalidateQueries({ queryKey: communityQueries.detail(postId).queryKey })
-    },
-  })
-}
+import type { CreateCommunityPostRequest, UpdateCommunityPostRequest } from '@/shared/types'
+import { createCommunityPost, updateCommunityPost, deleteCommunityPost } from './community.api'
 
 export const useCreateCommunityPost = () => {
   const qc = useQueryClient()
@@ -90,46 +29,6 @@ export const useDeleteCommunityPost = () => {
   const qc = useQueryClient()
   return useMutation({
     mutationFn: (postId: string) => deleteCommunityPost(postId),
-    onSuccess: () => {
-      void qc.invalidateQueries({ queryKey: communityQueries.all() })
-    },
-  })
-}
-
-export const useUpdateCommunityComment = (commentId: string) => {
-  const qc = useQueryClient()
-  return useMutation({
-    mutationFn: (data: UpdateCommunityCommentRequest) => updateCommunityComment(commentId, data),
-    onSuccess: () => {
-      void qc.invalidateQueries({ queryKey: communityQueries.all() })
-    },
-  })
-}
-
-export const useDeleteCommunityComment = () => {
-  const qc = useQueryClient()
-  return useMutation({
-    mutationFn: (commentId: string) => deleteCommunityComment(commentId),
-    onSuccess: () => {
-      void qc.invalidateQueries({ queryKey: communityQueries.all() })
-    },
-  })
-}
-
-export const useBookmarkCommunityPost = () => {
-  const qc = useQueryClient()
-  return useMutation({
-    mutationFn: (postId: string) => bookmarkCommunityPost(postId),
-    onSuccess: () => {
-      void qc.invalidateQueries({ queryKey: communityQueries.all() })
-    },
-  })
-}
-
-export const useUnbookmarkCommunityPost = () => {
-  const qc = useQueryClient()
-  return useMutation({
-    mutationFn: (postId: string) => unbookmarkCommunityPost(postId),
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: communityQueries.all() })
     },

--- a/src/features/community/api/communityComment.mutations.ts
+++ b/src/features/community/api/communityComment.mutations.ts
@@ -1,0 +1,42 @@
+'use client'
+
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { communityQueries } from '@/entities/community'
+import type { CreateCommunityCommentRequest, UpdateCommunityCommentRequest } from '@/shared/types'
+import {
+  createCommunityComment,
+  updateCommunityComment,
+  deleteCommunityComment,
+} from './community.api'
+
+/** 댓글 작성 (parentCommentId 있으면 답글) — 댓글 목록 + 상세(댓글 수) 갱신 */
+export const useCreateCommunityComment = (postId: string) => {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (data: CreateCommunityCommentRequest) => createCommunityComment(postId, data),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: [...communityQueries.all(), 'comments', postId] })
+      void qc.invalidateQueries({ queryKey: communityQueries.detail(postId).queryKey })
+    },
+  })
+}
+
+export const useUpdateCommunityComment = (commentId: string) => {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (data: UpdateCommunityCommentRequest) => updateCommunityComment(commentId, data),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: communityQueries.all() })
+    },
+  })
+}
+
+export const useDeleteCommunityComment = () => {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (commentId: string) => deleteCommunityComment(commentId),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: communityQueries.all() })
+    },
+  })
+}

--- a/src/features/community/api/communityReaction.mutations.ts
+++ b/src/features/community/api/communityReaction.mutations.ts
@@ -1,0 +1,130 @@
+'use client'
+
+import { useMutation, useQueryClient, type QueryKey } from '@tanstack/react-query'
+import { communityQueries } from '@/entities/community'
+import { patchCachedItem } from '@/shared/lib/patchCachedItem'
+import {
+  likeCommunityPost,
+  unlikeCommunityPost,
+  bookmarkCommunityPost,
+  unbookmarkCommunityPost,
+} from './community.api'
+
+/** 리액션 패치에 필요한 공통 필드 — 목록 카드와 상세가 함께 가진다 */
+interface ReactablePost {
+  postId: string
+  isLiked: boolean
+  likeCount: number
+  isSaved: boolean
+  saveCount: number
+}
+
+const REACTION_FIELDS = ['postId', 'isLiked', 'likeCount', 'isSaved', 'saveCount'] as const
+
+const isReactablePost = (value: unknown): value is ReactablePost =>
+  typeof value === 'object' && value !== null && REACTION_FIELDS.every((field) => field in value)
+
+/** community 캐시 안의 특정 게시글만 갈아끼운다. */
+const patchCommunityPost = (
+  data: unknown,
+  postId: string,
+  patch: (post: ReactablePost) => ReactablePost,
+): unknown =>
+  patchCachedItem(data, (value) =>
+    isReactablePost(value) && value.postId === postId ? patch(value) : value,
+  )
+
+interface OptimisticReactionOptions {
+  postId: string
+  /** 토글 직전 상태 — true면 해제 요청 */
+  active: boolean
+  mutationFn: (active: boolean) => Promise<unknown>
+  patch: (post: ReactablePost, nextActive: boolean) => ReactablePost
+  /** 낙관적 패치만으로 부족해 실제 재조회가 필요한 쿼리 (예: 저장목록에서 항목 제거) */
+  refetchKey?: QueryKey
+}
+
+/**
+ * 좋아요/북마크 공용 낙관적 토글.
+ *
+ * 목록(posts/myPosts/drafts/myBookmarks)과 상세가 같은 게시글을 각각 들고 있어,
+ * community 전체를 스코프로 잡고 해당 postId만 갈아끼운다.
+ * onSettled는 refetchType 'none' — 재요청 없이 "다음 마운트 때 최신화" 표시만 남긴다.
+ * active는 로컬 state가 아니라 호출부가 넘긴 캐시 값이 그대로 흐른다.
+ */
+const useOptimisticReaction = ({
+  postId,
+  active,
+  mutationFn,
+  patch,
+  refetchKey,
+}: OptimisticReactionOptions) => {
+  const qc = useQueryClient()
+  const scope = { queryKey: communityQueries.all() }
+
+  const { mutate, isPending } = useMutation({
+    mutationFn,
+    onMutate: async (currentActive: boolean) => {
+      // 진행 중인 refetch가 낙관적 패치를 덮어쓰지 않도록 먼저 취소.
+      // 단 최초 로딩(데이터 없음)까지 끊으면 재요청 없이 pending으로 남으므로 제외한다.
+      await qc.cancelQueries({ ...scope, predicate: (query) => query.state.data !== undefined })
+      const snapshot = qc.getQueriesData(scope)
+      qc.setQueriesData(scope, (data) =>
+        patchCommunityPost(data, postId, (post) => patch(post, !currentActive)),
+      )
+      return { snapshot }
+    },
+    onError: (_error, _currentActive, context) => {
+      context?.snapshot.forEach(([queryKey, data]) => qc.setQueryData(queryKey, data))
+    },
+    onSettled: () => {
+      void qc.invalidateQueries({ ...scope, refetchType: 'none' })
+      if (refetchKey) void qc.invalidateQueries({ queryKey: refetchKey })
+    },
+  })
+
+  return {
+    isPending,
+    toggle: () => {
+      if (isPending) return
+      mutate(active)
+    },
+  }
+}
+
+/** 카드/상세 공용 좋아요 토글 — isLiked는 서버 상태(목록·상세 캐시)를 그대로 쓴다. */
+export const useToggleCommunityPostLike = (postId: string, isLiked: boolean) => {
+  const { isPending, toggle } = useOptimisticReaction({
+    postId,
+    active: isLiked,
+    mutationFn: (liked) => (liked ? unlikeCommunityPost(postId) : likeCommunityPost(postId)),
+    patch: (post, nextLiked) => ({
+      ...post,
+      isLiked: nextLiked,
+      likeCount: Math.max(0, post.likeCount + (nextLiked ? 1 : -1)),
+    }),
+  })
+
+  return { isPending, toggleLike: toggle }
+}
+
+/**
+ * 카드/상세 공용 북마크 토글 — isSaved는 서버 상태(목록·상세 캐시)를 그대로 쓴다.
+ * 저장목록은 "저장한 글만" 담는 목록이라 해제된 항목이 빠지도록 그 쿼리만 재조회한다.
+ */
+export const useToggleCommunityPostBookmark = (postId: string, isSaved: boolean) => {
+  const { isPending, toggle } = useOptimisticReaction({
+    postId,
+    active: isSaved,
+    mutationFn: (saved) =>
+      saved ? unbookmarkCommunityPost(postId) : bookmarkCommunityPost(postId),
+    patch: (post, nextSaved) => ({
+      ...post,
+      isSaved: nextSaved,
+      saveCount: Math.max(0, post.saveCount + (nextSaved ? 1 : -1)),
+    }),
+    refetchKey: communityQueries.myBookmarksAll(),
+  })
+
+  return { isPending, toggleBookmark: toggle }
+}

--- a/src/features/community/index.ts
+++ b/src/features/community/index.ts
@@ -1,2 +1,17 @@
-export * from './api/community.mutations'
+export {
+  useCreateCommunityPost,
+  useUpdateCommunityPost,
+  useDeleteCommunityPost,
+} from './api/community.mutations'
+export {
+  useCreateCommunityComment,
+  useUpdateCommunityComment,
+  useDeleteCommunityComment,
+} from './api/communityComment.mutations'
+// 좋아요·북마크는 토글 훅만 공개한다 (개별 등록/해제 훅을 노출하면 호출부마다 분기가 복제된다)
+export {
+  useToggleCommunityPostLike,
+  useToggleCommunityPostBookmark,
+} from './api/communityReaction.mutations'
+export { ConnectedCommunityBox, ConnectedPostCard } from './ui/ConnectedPostCard'
 export { useSubmitCommunityPostForm } from './lib/useSubmitCommunityPostForm'

--- a/src/features/community/ui/ConnectedPostCard.tsx
+++ b/src/features/community/ui/ConnectedPostCard.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import type { ComponentProps } from 'react'
+import { CommunityBox, PostCard } from '@/entities/community'
+import {
+  useToggleCommunityPostBookmark,
+  useToggleCommunityPostLike,
+} from '../api/communityReaction.mutations'
+
+type InjectedActions = 'onToggleLike' | 'onToggleSave'
+
+/** entities 카드가 표시만 하는 좋아요·북마크를 mutation에 연결한다. */
+const useCardReactions = (postId: string, isLiked: boolean, isSaved: boolean) => {
+  const { toggleLike } = useToggleCommunityPostLike(postId, isLiked)
+  const { toggleBookmark } = useToggleCommunityPostBookmark(postId, isSaved)
+
+  return { onToggleLike: toggleLike, onToggleSave: toggleBookmark }
+}
+
+/**
+ * entities의 프레젠테이셔널 카드에 카드 액션 mutation을 연결한 features 레이어 래퍼.
+ * (entities → features 역방향 import 금지이므로 연결은 이 래퍼에서 수행)
+ */
+const ConnectedPostCard = (props: Omit<ComponentProps<typeof PostCard>, InjectedActions>) => {
+  const reactions = useCardReactions(props.postId, props.isLiked, props.isSaved)
+
+  return <PostCard {...props} {...reactions} />
+}
+
+const ConnectedCommunityBox = (
+  props: Omit<ComponentProps<typeof CommunityBox>, InjectedActions>,
+) => {
+  const reactions = useCardReactions(props.postId, props.isLiked, props.isSaved)
+
+  return <CommunityBox {...props} {...reactions} />
+}
+
+export { ConnectedCommunityBox, ConnectedPostCard }

--- a/src/shared/lib/patchCachedItem.ts
+++ b/src/shared/lib/patchCachedItem.ts
@@ -1,0 +1,21 @@
+/**
+ * 쿼리 캐시에 담긴 항목을 캐시 형태와 무관하게 갈아끼운다.
+ * 캐시에 들어있는 형태는 네 가지 — 무한 목록(pages), 페이지 응답(items), 배열, 단일 객체.
+ *
+ * apply는 "항목 하나"를 받아 교체 대상이면 새 값을, 아니면 받은 값을 그대로 돌려준다.
+ * 대상 판별(타입 가드 + id 비교)은 호출부 책임이다.
+ */
+const patchCachedItem = (data: unknown, apply: (value: unknown) => unknown): unknown => {
+  if (Array.isArray(data)) return data.map(apply)
+  if (typeof data !== 'object' || data === null) return data
+
+  if ('pages' in data && Array.isArray(data.pages)) {
+    return { ...data, pages: data.pages.map((page) => patchCachedItem(page, apply)) }
+  }
+  if ('items' in data && Array.isArray(data.items)) {
+    return { ...data, items: data.items.map(apply) }
+  }
+  return apply(data)
+}
+
+export { patchCachedItem }

--- a/src/shared/mocks/community.ts
+++ b/src/shared/mocks/community.ts
@@ -15,6 +15,8 @@ const POST_BASE: Omit<CommunityPostCard, 'postId'> = {
   likeCount: 10,
   commentCount: 10,
   saveCount: 2,
+  isLiked: false,
+  isSaved: false,
   createdAt: '20시간',
 }
 

--- a/src/shared/mocks/myHome.ts
+++ b/src/shared/mocks/myHome.ts
@@ -62,6 +62,8 @@ const MY_HOME_POST_BASE: Omit<CommunityPostCard, 'postId'> = {
   likeCount: 10,
   commentCount: 10,
   saveCount: 2,
+  isLiked: false,
+  isSaved: false,
   createdAt: '20시간',
 }
 

--- a/src/shared/types/CommunityTypes.ts
+++ b/src/shared/types/CommunityTypes.ts
@@ -31,6 +31,8 @@ export interface CommunityPostCard {
   likeCount: number
   commentCount: number
   saveCount: number
+  isLiked: boolean
+  isSaved: boolean
   createdAt: string
 }
 

--- a/src/widgets/community-showcase/ui/CommunityShowcase.tsx
+++ b/src/widgets/community-showcase/ui/CommunityShowcase.tsx
@@ -2,7 +2,8 @@
 
 import { useInfiniteQuery } from '@tanstack/react-query'
 import { ShowcaseSection } from '@/shared/ui'
-import { CommunityBox, communityQueries, toCommunityPreviewProps } from '@/entities/community'
+import { communityQueries, toCommunityPreviewProps } from '@/entities/community'
+import { ConnectedCommunityBox } from '@/features/community'
 import { MOCK_MY_HOME_POSTS } from '@/shared/mocks/myHome'
 
 const CARD_COUNT = 3
@@ -26,7 +27,7 @@ const CommunityShowcase = () => {
       {/* 한 DOM 목록을 브레이크포인트별 그리드로 재배치한다. */}
       <div className="grid grid-cols-[20.0625rem] justify-center gap-y-2 tab:grid-cols-[repeat(2,20.0625rem)] tab:justify-between pc:grid-cols-[repeat(3,25.4375rem)] pc:gap-y-0">
         {posts.map((post, index) => (
-          <CommunityBox
+          <ConnectedCommunityBox
             key={post.detailHref ?? index}
             {...post}
             className={index === 2 ? 'hidden pc:flex' : undefined}

--- a/src/widgets/community-showcase/ui/CommunityShowcase.tsx
+++ b/src/widgets/community-showcase/ui/CommunityShowcase.tsx
@@ -2,7 +2,7 @@
 
 import { useInfiniteQuery } from '@tanstack/react-query'
 import { ShowcaseSection } from '@/shared/ui'
-import { communityQueries, toCommunityPreviewProps } from '@/entities/community'
+import { CommunityBox, communityQueries, toCommunityPreviewProps } from '@/entities/community'
 import { ConnectedCommunityBox } from '@/features/community'
 import { MOCK_MY_HOME_POSTS } from '@/shared/mocks/myHome'
 
@@ -17,17 +17,20 @@ const CommunityShowcase = () => {
   const fetched = (data?.pages[0]?.items ?? []).slice(0, CARD_COUNT).map(toCommunityPreviewProps)
 
   // 데이터 없으면(로딩/실패/빈 목록) 목업으로 스켈레톤 유지
-  const posts =
-    fetched.length > 0
-      ? fetched
-      : MOCK_MY_HOME_POSTS.slice(0, CARD_COUNT).map(toCommunityPreviewProps)
+  const isMock = fetched.length === 0
+  const posts = isMock
+    ? MOCK_MY_HOME_POSTS.slice(0, CARD_COUNT).map(toCommunityPreviewProps)
+    : fetched
+
+  // 목업 postId는 실제로 없는 값이라 토글을 연결하면 존재하지 않는 글에 요청이 나간다
+  const Card = isMock ? CommunityBox : ConnectedCommunityBox
 
   return (
     <ShowcaseSection title="동물 자랑하기" linkText="커뮤니티 바로가기" linkHref="/community">
       {/* 한 DOM 목록을 브레이크포인트별 그리드로 재배치한다. */}
       <div className="grid grid-cols-[20.0625rem] justify-center gap-y-2 tab:grid-cols-[repeat(2,20.0625rem)] tab:justify-between pc:grid-cols-[repeat(3,25.4375rem)] pc:gap-y-0">
         {posts.map((post, index) => (
-          <ConnectedCommunityBox
+          <Card
             key={post.detailHref ?? index}
             {...post}
             className={index === 2 ? 'hidden pc:flex' : undefined}


### PR DESCRIPTION
Closes #227

## 변경 사항

- `CommunityPostCard`의 `isLiked`/`isSaved`를 서버 응답에서 매핑하고 카드까지 전달. 목록 카드의 좋아요가 로컬 `useState(false)`로만 동작해 이미 좋아요한 글도 빈 하트로 보이던 문제를 해결. 홈·커뮤니티·저장목록·임시저장·쇼케이스가 모두 `toCommunityPreviewProps`를 거치므로 매퍼 한 곳으로 전 화면에 반영된다
- 좋아요·북마크를 낙관적 캐시 패치로 통일. 토글마다 `communityQueries.all()`을 전체 무효화하던 북마크도 요청 1건으로 줄었다. 저장목록은 "저장한 글만" 담는 목록이라 해제된 항목이 빠져야 하므로 `myBookmarksAll()` 프리픽스를 추가해 그 쿼리만 재조회한다
- 상세 페이지가 `useToggleCommunityPostBookmark`를 쓰도록 변경. 훅이 이미 있는데 등록/해제 분기를 복붙하고 있었다
- 캐시 순회를 `shared/lib/patchCachedItem`으로 공용화. features끼리 import가 불가해 adoption과 community에 같은 함수가 복제돼 있었다. 무한목록/페이지응답/배열/단일 네 형태를 한 번에 처리하며, adoption에 없던 `items` 분기도 함께 해소된다
- `community.mutations.ts`를 게시글/댓글/리액션 3파일로 분리. 좋아요·북마크는 `useOptimisticReaction` 하나를 공유하고 `mutationFn`과 `patch`만 주입한다
- `features/community`는 토글 훅만 공개. `useBookmarkCommunityPost`/`useUnbookmarkCommunityPost`를 비공개로 돌려 개별 등록/해제 훅 오용을 구조적으로 차단
- 좋아요까지 주입하게 된 `BookmarkablePostCard`를 `ConnectedPostCard`로 리네임

## 확인 방법

1. 이미 좋아요한 글이 목록에서 채워진 하트로 보이는지 확인
2. 목록에서 하트 토글 → 네트워크에 mutation 1건만 발생하고 목록 전체 재요청이 없어야 한다
3. 목록에서 토글한 상태로 상세에 진입 → 하트 상태와 카운트가 그대로 유지되어야 한다
4. 저장목록 탭에서 북마크 해제 → 항목이 목록에서 사라져야 한다
5. 네트워크 차단 후 토글 → 낙관적 반영이 원래 상태로 롤백되어야 한다
6. 목록 최초 로딩 중에 하트 클릭 → 로딩이 pending에 고착되지 않아야 한다

## 검증 범위

- `pnpm type-check` 통과
- `pnpm lint`는 `ApplicationForm.tsx:79`의 기존 에러 1건이 남아 있으며 이번 변경 파일이 아니다
- 런타임 검증은 하지 않았다

## 참고

- 관심 토글(#226)에서 정리한 낙관적 캐시 패치 방식을 커뮤니티 리액션에 그대로 적용했다
- feed 좋아요(`useToggleVideoLike`)는 훅만 있고 UI 미연결 상태로, 이번 범위에 포함하지 않았다