### PR TITLE
feat(community): 게시글 작성 폼 피그마 레이아웃 반영

### DIFF
--- a/src/app/(main)/community/_ui/CommunityPostEditor.tsx
+++ b/src/app/(main)/community/_ui/CommunityPostEditor.tsx
@@ -3,15 +3,13 @@
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { useQuery } from '@tanstack/react-query'
-import { Container } from '@/shared/ui'
+import { Container, TextareaField, TextLabel } from '@/shared/ui'
 import { communityQueries } from '@/entities/community'
 import { profileQueries } from '@/entities/profile'
 import { useSubmitCommunityPostForm } from '@/features/community'
 import {
   usePostForm,
   PostFormHeader,
-  PostFormTextArea,
-  PostFormToolbar,
   PostFormCTA,
   ImageUploadArea,
   VisibilitySelect,
@@ -50,7 +48,6 @@ const PostForm = ({ postId, post }: PostFormProps) => {
     textareaRef,
     handleAddImages,
     handleRemoveImage,
-    handleEmojiSelect,
   } = usePostForm({ initialText: post?.body ?? '', initialImages: post?.photoUrls ?? [] })
 
   const [visibility, setVisibility] = useState<VisibilityType>(post?.visibility ?? 'public')
@@ -81,29 +78,43 @@ const PostForm = ({ postId, post }: PostFormProps) => {
     <div className="flex min-h-screen flex-col bg-white">
       <PostFormHeader title={formText.title} mobileTitle={formText.mobileTitle} />
 
-      <Container className="flex-1 pt-[0.719rem] pb-[7.5rem] tab:px-[6.25rem] tab:pt-[5.5rem]">
-        <div className="flex flex-col gap-[1.125rem] tab:flex-row tab:gap-0">
-          <div className="tab:w-[26.256rem] tab:shrink-0">
-            <ImageUploadArea images={images} onAdd={handleAddImages} onRemove={handleRemoveImage} />
-          </div>
-
-          <div className="flex flex-1 flex-col tab:ml-[2.5rem]">
-            <div className="flex flex-col gap-[0.375rem] tab:gap-[1.125rem]">
-              <PostFormTextArea
-                ref={textareaRef}
-                value={text}
-                onChange={setText}
-                placeholder="귀여운 동물을 자랑해보세요"
+      {/* Figma 1056-46147(PC) / 1056-46891(tab·mo): PC는 이미지 372 + 본문 2단(gap 100), 그 아래는 세로 스택 */}
+      <Container className="flex-1 py-5 pb-[7.5rem] pc:py-12">
+        {/* PC 콘텐츠 폭 1280 고정 (1440 - 좌우 80) */}
+        <div className="mx-auto w-full pc:max-w-320">
+          <div className="flex flex-col gap-[1.1875rem] pc:flex-row pc:gap-25">
+            <div className="flex flex-col gap-1 pc:w-93 pc:shrink-0 pc:gap-2">
+              <TextLabel size="14" requirement="선택">
+                이미지
+              </TextLabel>
+              <ImageUploadArea
+                size="post"
+                hideLabel
+                images={images}
+                onAdd={handleAddImages}
+                onRemove={handleRemoveImage}
               />
-              <PostFormToolbar onEmojiSelect={handleEmojiSelect} />
             </div>
 
-            <div className="mt-[1.125rem] tab:hidden">
-              <VisibilitySelect value={visibility} onChange={setVisibility} />
-            </div>
-
-            {error && <p className="mt-[0.75rem] text-sm text-red-500">{error}</p>}
+            {/* 본문 입력 높이: tab·mo 105(Textarea 기본) / PC 180 */}
+            <TextareaField
+              ref={textareaRef}
+              label="게시글"
+              required
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              placeholder="입력해보세요"
+              wrapperClassName="pc:flex-1"
+              className="pc:h-45"
+            />
           </div>
+
+          {/* 공개 설정 — tab·mo는 본문 아래 풀 너비, PC는 하단 CTA 바 왼쪽(Figma 1054-36832) */}
+          <div className="mt-3 pc:hidden">
+            <VisibilitySelect value={visibility} onChange={setVisibility} />
+          </div>
+
+          {error && <p className="mt-3 text-sm text-error-500">{error}</p>}
         </div>
       </Container>
 
@@ -115,7 +126,13 @@ const PostForm = ({ postId, post }: PostFormProps) => {
         isValid={canPublish}
         isSaveDraftValid={canSaveDraft}
         isSubmitting={isSubmitting}
-        leftSlot={<VisibilitySelect value={visibility} onChange={setVisibility} />}
+        leftSlot={
+          // Figma 1054-36832: 바 왼쪽 드롭다운 100px.
+          // 고정폭이면 '팔로워 공개'가 잘려 최소폭으로 두고 라벨만큼 늘어나게 한다
+          <div className="hidden min-w-25 pc:block">
+            <VisibilitySelect value={visibility} onChange={setVisibility} />
+          </div>
+        }
       />
     </div>
   )

--- a/src/app/(main)/hall-of-fame/participate/_ui/ContestEntryContent.tsx
+++ b/src/app/(main)/hall-of-fame/participate/_ui/ContestEntryContent.tsx
@@ -25,7 +25,7 @@ const ContestEntryContent = () => {
 
   return (
     <div className="flex min-h-screen flex-col bg-white">
-      <PostFormHeader title="명예의 전당 콘테스트 참여하기" />
+      <PostFormHeader title="명예의 전당 콘테스트 참여하기" className="tab:px-[6.25rem]" />
 
       <Container className="flex-1 pt-[0.719rem] pb-[7.5rem] tab:px-[6.25rem] tab:pt-[5.5rem]">
         <div className="flex flex-col gap-[1.125rem] tab:flex-row tab:gap-0">

--- a/src/widgets/post-form/ui/ImageUploadArea.tsx
+++ b/src/widgets/post-form/ui/ImageUploadArea.tsx
@@ -2,7 +2,8 @@
 
 import { useRef, useState } from 'react'
 import Image from 'next/image'
-import { ImageIcon, CloseIcon } from '@/shared/assets/icons'
+import { tv, type VariantProps } from 'tailwind-variants'
+import { CameraIcon, ImageIcon, CloseIcon } from '@/shared/assets/icons'
 import { ImageModal } from '@/shared/ui'
 import {
   Dialog,
@@ -15,7 +16,47 @@ import {
 
 const MAX_IMAGES = 10
 
-interface ImageUploadAreaProps {
+/**
+ * 업로드 타일 지오메트리.
+ * - default: 기존 화면(분양글 등장록·부모견·사육환경·명예의전당)이 쓰는 기존 규격
+ * - post: 커뮤니티 게시글 작성 (Figma 1056-46032 PC / 1056-46732 tab·mo) — mo·tab 100·radius4, PC 180·radius8
+ */
+const imageUploadVariants = tv({
+  slots: {
+    root: 'flex flex-col',
+    tiles: 'flex',
+    addButton: 'flex shrink-0 flex-col items-center',
+    addIcon: '',
+    addCounter: '',
+    preview: 'relative shrink-0 overflow-hidden',
+  },
+  variants: {
+    size: {
+      default: {
+        root: 'gap-[0.375rem] tab:gap-3',
+        tiles: 'gap-[0.375rem] tab:flex-wrap tab:gap-x-[1.438rem] tab:gap-y-3',
+        addButton:
+          'size-[3.793rem] rounded-[0.438rem] border border-[#cdcdcd] pt-[0.802rem] pr-[1.162rem] pb-[0.569rem] pl-[1.131rem] tab:h-[12.623rem] tab:w-[12.363rem] tab:justify-center tab:gap-[0.188rem] tab:rounded-[0.596rem] tab:border-fill-placeholder tab:p-0',
+        addIcon: 'size-[1.459rem] text-text-primary tab:size-[3.285rem]',
+        addCounter: 'text-[0.729rem] font-medium text-text-primary tab:text-[1.642rem]',
+        preview:
+          'size-[3.793rem] rounded-[0.438rem] border border-[#cdcdcd] bg-fill-placeholder tab:h-[12.623rem] tab:w-[12.363rem] tab:rounded-[0.596rem] tab:border-0',
+      },
+      post: {
+        root: 'gap-1 pc:gap-2',
+        tiles: 'flex-wrap gap-3',
+        addButton:
+          'size-25 justify-center gap-0.5 rounded border border-neutral-500 bg-white p-2 pc:size-45 pc:gap-2 pc:rounded-lg',
+        addIcon: 'size-8 text-neutral-700',
+        addCounter: 'text-sm leading-[1.5] font-semibold text-neutral-700 pc:text-base',
+        preview: 'size-25 rounded border border-neutral-500 pc:size-45 pc:rounded-lg',
+      },
+    },
+  },
+  defaultVariants: { size: 'default' },
+})
+
+interface ImageUploadAreaProps extends VariantProps<typeof imageUploadVariants> {
   images: string[]
   onAdd: (files: FileList) => void
   onRemove: (index: number) => void
@@ -36,7 +77,10 @@ const ImageUploadArea = ({
   onSetRepresentative,
   hideLabel = false,
   maxImages = MAX_IMAGES,
+  size,
 }: ImageUploadAreaProps) => {
+  const styles = imageUploadVariants({ size })
+  const AddIcon = size === 'post' ? CameraIcon : ImageIcon
   const inputRef = useRef<HTMLInputElement>(null)
   const [modalOpen, setModalOpen] = useState(false)
   const [modalIndex, setModalIndex] = useState(0)
@@ -79,7 +123,7 @@ const ImageUploadArea = ({
   const isRepresentative = (index: number) => hasRepresentative && representativeIndex === index
 
   return (
-    <div className="flex flex-col gap-[0.375rem] tab:gap-3">
+    <div className={styles.root()}>
       {!hideLabel && (
         <p className="text-body-s text-text-primary">
           <span className="font-bold">이미지</span>{' '}
@@ -90,15 +134,11 @@ const ImageUploadArea = ({
         </p>
       )}
 
-      <div className="flex gap-[0.375rem] tab:flex-wrap tab:gap-x-[1.438rem] tab:gap-y-3">
+      <div className={styles.tiles()}>
         {/* Upload Button */}
-        <button
-          type="button"
-          onClick={handleClick}
-          className="flex size-[3.793rem] shrink-0 flex-col items-center rounded-[0.438rem] border border-[#cdcdcd] pt-[0.802rem] pr-[1.162rem] pb-[0.569rem] pl-[1.131rem] tab:h-[12.623rem] tab:w-[12.363rem] tab:items-center tab:justify-center tab:gap-[0.188rem] tab:rounded-[0.596rem] tab:border-fill-placeholder tab:p-0"
-        >
-          <ImageIcon className="size-[1.459rem] text-text-primary tab:size-[3.285rem]" />
-          <span className="text-[0.729rem] font-medium text-text-primary tab:text-[1.642rem]">
+        <button type="button" onClick={handleClick} className={styles.addButton()}>
+          <AddIcon className={styles.addIcon()} />
+          <span className={styles.addCounter()}>
             {images.length}/{maxImages}
           </span>
         </button>
@@ -114,10 +154,7 @@ const ImageUploadArea = ({
 
         {/* Image Previews */}
         {images.map((src, index) => (
-          <div
-            key={src}
-            className="relative size-[3.793rem] shrink-0 overflow-hidden rounded-[0.438rem] border border-[#cdcdcd] bg-fill-placeholder tab:h-[12.623rem] tab:w-[12.363rem] tab:rounded-[0.596rem] tab:border-0"
-          >
+          <div key={src} className={styles.preview()}>
             <button
               type="button"
               className="size-full"
@@ -149,8 +186,8 @@ const ImageUploadArea = ({
               <CloseIcon className="size-2.5 text-white tab:size-3.5" />
             </button>
 
-            {/* 순번 — desktop only */}
-            {!hasRepresentative && (
+            {/* 순번 — desktop only. post 타일(100·180)에는 45px 배지가 과해 노출하지 않는다 */}
+            {!hasRepresentative && size !== 'post' && (
               <div className="pointer-events-none absolute top-0 left-0 hidden size-[2.822rem] items-center justify-center tab:flex">
                 <span className="text-[1.562rem] leading-[1.552rem] font-bold text-white">
                   {index + 1}

--- a/src/widgets/post-form/ui/PostFormCTA.tsx
+++ b/src/widgets/post-form/ui/PostFormCTA.tsx
@@ -13,7 +13,7 @@ interface PostFormCTAProps {
   isSaveDraftValid?: boolean
   /** 업로드/저장 진행 중 — 버튼 비활성화로 중복 제출 방지 */
   isSubmitting?: boolean
-  /** 왼쪽 슬롯 (예: visibility select) */
+  /** 바 왼쪽 슬롯 (Figma 1054-36832 — 공개범위 드롭다운) */
   leftSlot?: React.ReactNode
 }
 

--- a/src/widgets/post-form/ui/PostFormHeader.tsx
+++ b/src/widgets/post-form/ui/PostFormHeader.tsx
@@ -7,13 +7,15 @@ import { Container } from '@/shared/ui'
 interface PostFormHeaderProps {
   title: string
   mobileTitle?: string
+  /** 본문 여백이 Container 기본과 다른 화면에서 헤더를 맞추기 위한 오버라이드 */
+  className?: string
 }
 
-const PostFormHeader = ({ title, mobileTitle }: PostFormHeaderProps) => {
+const PostFormHeader = ({ title, mobileTitle, className }: PostFormHeaderProps) => {
   const router = useRouter()
 
   return (
-    <Container className="tab:px-[6.25rem]">
+    <Container className={className}>
       <header className="flex h-[3rem] items-center gap-[0.625rem] tab:h-[5.5rem] tab:justify-between tab:gap-0">
         <button type="button" onClick={() => router.back()} aria-label="닫기">
           <CloseIcon className="size-5 text-text-primary" />

--- a/src/widgets/post-form/ui/VisibilitySelect.tsx
+++ b/src/widgets/post-form/ui/VisibilitySelect.tsx
@@ -9,7 +9,7 @@ import {
 } from '@/shared/ui'
 
 const VISIBILITY_OPTIONS = [
-  { id: 'public', label: '전체공개' },
+  { id: 'public', label: '전체 공개' },
   { id: 'followers', label: '팔로워 공개' },
   { id: 'private', label: '나만보기' },
 ] as const
@@ -27,14 +27,15 @@ const VisibilitySelect = ({ value, onChange }: VisibilitySelectProps) => {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
+        {/* Figma 1058-47323: 풀 너비 h-45, p-12, radius 8 — Textarea와 같은 테두리 톤 */}
         <button
           type="button"
-          className="flex w-full items-center rounded-[0.375rem] border border-[#a8a8a8] px-[0.625rem] py-[0.5rem] tab:w-auto tab:border-fill-muted tab:py-[0.25rem]"
+          className="flex h-[2.8125rem] w-full items-center justify-between rounded-lg border border-neutral-300 bg-white p-3"
         >
-          <span className="flex-1 text-left text-sm font-medium text-text-primary">
+          <span className="flex-1 text-left text-sm leading-[1.5] font-medium whitespace-nowrap text-neutral-850">
             {activeLabel}
           </span>
-          <ChevronDownIcon className="size-6 text-[#C6C6C6]" />
+          <ChevronDownIcon className="size-6 text-neutral-500" />
         </button>
       </DropdownMenuTrigger>
 


### PR DESCRIPTION
Closes #233

## 변경사항
- `ImageUploadArea`를 `tv` slots 기반으로 정리하고 `post` 사이즈 variant 추가 (mo·tab 100/radius4, PC 180/radius8, 업로드 아이콘 카메라). 기존 화면(분양글·부모견·사육환경)은 `default` variant로 규격 유지
- 커뮤니티 글 작성 본문을 `PostFormTextArea` + `PostFormToolbar`에서 공용 `TextareaField`로 교체 — 라벨·필수 표시 포함, PC 높이 180
- 공개범위 드롭다운 배치 분리 — mo·tab은 본문 아래 풀 너비, PC는 하단 CTA 바 왼쪽(Figma 1054-36832). 상태는 하나를 공유해 값 어긋남 없음
- `VisibilitySelect` 트리거를 Textarea와 같은 테두리 톤으로 정리, 라벨 "전체공개" -> "전체 공개"
- `PostFormHeader`의 고정 여백(`tab:px-[6.25rem]`)을 `className` 오버라이드로 변경. 기존 규격이 필요한 `/hall-of-fame/participate`는 호출부에서 그대로 전달

## 확인 방법
1. `/community/write` PC(1440) — 이미지 372 + 본문 2단, 공개범위가 하단 바 왼쪽에 노출
2. 같은 화면 모바일·탭 — 세로 스택, 공개범위가 본문 아래 풀 너비
3. 공개범위를 팔로워 공개/나만보기로 바꿔 발행 -> 수정 진입 시 값이 유지되는지 확인
4. `/adoption/create` 이미지 업로드 타일이 기존과 동일한지 확인 (default variant 회귀 체크)
5. `/hall-of-fame/participate` 헤더 여백이 기존과 동일한지 확인