### PR TITLE
refactor(adoption): 입양 신청서 공통 컴포넌트 적용과 온보딩 조사 판별 서버 전환

### DIFF
--- a/src/app/(main)/adoption/[id]/apply/_lib/constants.ts
+++ b/src/app/(main)/adoption/[id]/apply/_lib/constants.ts
@@ -1,0 +1,58 @@
+import type { FieldPath } from 'react-hook-form'
+import { ADOPTION_SURVEY_QUESTIONS } from '@/shared/config/adoptionSurvey'
+import type { ApplicationFormValues, ApplicationTextField } from './schema'
+
+// [refactored] 신청서 문구를 한곳에 모음 — 텍스트 필드가 상수 배열(조사)과 JSX 인라인(입양계획·가족구성원)으로
+// 나뉘어 있어 같은 성격의 값이 두 군데서 관리되던 것을 통일한다.
+
+export const APPLY_TITLE = '입양 신청'
+
+/** 신청서 텍스트 필드 (title/placeholder만 다른 같은 모양) */
+interface ApplicationTextFieldConfig {
+  name: ApplicationTextField
+  title: string
+  placeholder: string
+}
+
+export const ADOPTION_PLAN_FIELD: ApplicationTextFieldConfig = {
+  name: 'adoptionPlan',
+  title: '입양 계획을 간단히 작성해 주세요',
+  placeholder: '생활패턴, 주거환경, 입양 시기 등을 입력해주세요',
+}
+
+export const FAMILY_MEMBERS_FIELD: ApplicationTextFieldConfig = {
+  name: 'familyMembers',
+  title: '함께 거주하는 가족 구성원을 입력해주세요',
+  placeholder: '예) 배우자 1명, 자녀 1명, 부모님 1명',
+}
+
+/** 조사 건너뛴 입양자에게만 노출하는 문항(선택) — 온보딩 SurveyStep과 동일 문항 */
+export const SURVEY_FIELDS: ApplicationTextFieldConfig[] = [
+  { name: 'selfIntroduction', ...ADOPTION_SURVEY_QUESTIONS.selfIntroduction },
+  { name: 'timeAwayFromHome', ...ADOPTION_SURVEY_QUESTIONS.timeAwayFromHome },
+  { name: 'livingSpaceDescription', ...ADOPTION_SURVEY_QUESTIONS.livingSpaceDescription },
+]
+
+export const CONSENT_CHECKS_TITLE = '입양준비 확인을 위한 필수 항목을 체크해주세요'
+
+export const CONSENT_CHECKS: { name: FieldPath<ApplicationFormValues>; label: string }[] = [
+  { name: 'privacyConsent', label: '개인정보 수집 및 이용에 동의합니다.' },
+  {
+    name: 'canProvideBasicCare',
+    label: '정기 예방 접종/ 건강검진/ 훈련 등 기본 케어가 가능합니다.',
+  },
+  {
+    name: 'canAffordMedicalExpenses',
+    label: '예상치 못한 질병/ 사고 치료비를 감당할 수 있습니다.',
+  },
+]
+
+export const ALL_FAMILY_CONSENT_LABEL = '모든 가족 구성원이 입양에 동의했습니다.'
+
+export const PET_FIELD_TITLE = '입양하는 동물'
+
+export const EXIT_CONFIRM_TITLE = '입양 신청을 그만두시나요?'
+
+export const CONSULT_CONFIRM_TITLE = '브리더와 더 자세한 입양 상담이\n이루어집니다.'
+
+export const SUBMIT_ERROR_FALLBACK = '입양 신청에 실패했습니다.'

--- a/src/app/(main)/adoption/[id]/apply/_lib/schema.ts
+++ b/src/app/(main)/adoption/[id]/apply/_lib/schema.ts
@@ -15,6 +15,14 @@ export const applicationSchema = z.object({
 
 export type ApplicationFormValues = z.infer<typeof applicationSchema>
 
+// [refactored] 스키마 파생 타입이라 스키마 옆이 제자리 (_ui/FormFields 에서 이동)
+// 문자열 필드 키만 추림 — 필드 추가/삭제 시 자동 반영(drift 방지)
+export type ApplicationTextField = {
+  [K in keyof ApplicationFormValues]-?: NonNullable<ApplicationFormValues[K]> extends string
+    ? K
+    : never
+}[keyof ApplicationFormValues]
+
 export const getAgeText = (birthDate: string): string => {
   const match = birthDate.match(/(\d{4})년\s*(\d{1,2})월/)
   if (!match) return birthDate

--- a/src/app/(main)/adoption/[id]/apply/_lib/useApplicationForm.ts
+++ b/src/app/(main)/adoption/[id]/apply/_lib/useApplicationForm.ts
@@ -2,15 +2,19 @@
 
 import { useRef, useState } from 'react'
 import { useForm } from 'react-hook-form'
+import { useQuery } from '@tanstack/react-query'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useRouter } from 'next/navigation'
 import { useCreateApplication } from '@/features/application'
+import { adopterQueries } from '@/entities/adopter'
 import { useExitGuard } from '@/shared/lib/useExitGuard'
-import { clearSurveySkipped } from '@/shared/lib/surveySkip'
+import { useToast } from '@/shared/lib/useToast'
+import { normalizeApiError } from '@/shared/api'
 import { GENDER_LABEL } from '@/shared/types'
 import type { AdoptionDetailDto } from '@/shared/types'
 import { applicationSchema, getAgeText, type ApplicationFormValues } from './schema'
 import { toCreateApplicationRequest } from './applicationRequest'
+import { SUBMIT_ERROR_FALLBACK } from './constants'
 
 const useApplicationForm = (detail: AdoptionDetailDto) => {
   const router = useRouter()
@@ -77,18 +81,30 @@ const useApplicationForm = (detail: AdoptionDetailDto) => {
     handleCloseClick()
   }
 
+  // 신청 실패(중복 신청 409 / 분양 불가 400 / 브리더·펫 없음 404)를 알리는 토스트.
+  // 전역 MutationCache 는 5xx 를 Sentry 로 보낼 뿐이라 4xx 는 화면에서 직접 처리해야 한다.
+  const toast = useToast()
+
   const confirmConsult = () => {
     const data = pendingData.current
     if (!data) return
     createApplication(toCreateApplicationRequest(detail, data), {
       onSuccess: () => {
-        // 조사 항목까지 신청서로 제출됐으므로 건너뜀 플래그 해제
-        clearSurveySkipped()
         setShowConsultConfirm(false)
         router.push(`/adoption/${detail.listingId}`)
       },
+      onError: (error) => {
+        // 모달을 닫아 폼으로 돌려보낸다 (입력값은 유지) — 서버 문구를 그대로 노출
+        setShowConsultConfirm(false)
+        toast.error(normalizeApiError(error, SUBMIT_ERROR_FALLBACK).message)
+      },
     })
   }
+
+  // 온보딩에서 '다음에 작성하기'로 조사 양식을 건너뛴 입양자에게만 조사 항목을 노출.
+  // 서버가 답변이 하나도 없으면 counselDefaultProfile 을 null 로 내려준다 (건너뜀 판별의 유일한 근거).
+  const { data: adopterProfile } = useQuery(adopterQueries.profile())
+  const needsSurvey = adopterProfile?.counselDefaultProfile === null
 
   const petSummary = `${detail.name} . ${GENDER_LABEL[detail.gender]} . ${getAgeText(detail.birthDate)}`
 
@@ -109,6 +125,8 @@ const useApplicationForm = (detail: AdoptionDetailDto) => {
     cancelConsult,
     giveUpFromConsult,
     petSummary,
+    needsSurvey,
+    toast,
   }
 }
 

--- a/src/app/(main)/adoption/[id]/apply/_ui/ApplicationForm.tsx
+++ b/src/app/(main)/adoption/[id]/apply/_ui/ApplicationForm.tsx
@@ -1,14 +1,21 @@
 'use client'
 
-import { useSyncExternalStore } from 'react'
-import type { FieldPath } from 'react-hook-form'
-import { CloseIcon, PawIcon } from '@/shared/assets/icons'
-import { Container, CtaModal, ExitConfirmModal } from '@/shared/ui'
-import { isSurveySkipped } from '@/shared/lib/surveySkip'
+import { AlertCircleIcon, PawIcon } from '@/shared/assets/icons'
+import { AlertMessage, Container, CtaModal, ExitConfirmModal, NavigationBar } from '@/shared/ui'
 import type { AdoptionDetailDto } from '@/shared/types'
-import { ADOPTION_SURVEY_QUESTIONS } from '@/shared/config/adoptionSurvey'
 import { useApplicationForm } from '../_lib/useApplicationForm'
-import type { ApplicationFormValues } from '../_lib/schema'
+import {
+  ADOPTION_PLAN_FIELD,
+  APPLY_TITLE,
+  ALL_FAMILY_CONSENT_LABEL,
+  CONSENT_CHECKS,
+  CONSENT_CHECKS_TITLE,
+  CONSULT_CONFIRM_TITLE,
+  EXIT_CONFIRM_TITLE,
+  FAMILY_MEMBERS_FIELD,
+  PET_FIELD_TITLE,
+  SURVEY_FIELDS,
+} from '../_lib/constants'
 import { PetInfoCard } from './PetInfoCard'
 import {
   LabeledField,
@@ -16,45 +23,10 @@ import {
   ReadonlyInput,
   CheckboxField,
   FooterCtaBar,
-  type ApplicationTextField,
 } from './FormFields'
 
 interface ApplicationFormProps {
   detail: AdoptionDetailDto
-}
-
-// [refactored] 반복되던 체크박스 3개를 배열+map으로 전환
-const CONSENT_CHECKS: { name: FieldPath<ApplicationFormValues>; label: string }[] = [
-  { name: 'privacyConsent', label: '개인정보 수집 및 이용에 동의합니다.' },
-  {
-    name: 'canProvideBasicCare',
-    label: '정기 예방 접종/ 건강검진/ 훈련 등 기본 케어가 가능합니다.',
-  },
-  {
-    name: 'canAffordMedicalExpenses',
-    label: '예상치 못한 질병/ 사고 치료비를 감당할 수 있습니다.',
-  },
-]
-
-// [refactored] 조사 건너뛴 입양자용 문항(선택) — title/placeholder만 다른 복붙을 배열+map으로
-const SURVEY_FIELDS: { name: ApplicationTextField; title: string; placeholder: string }[] = [
-  {
-    name: 'selfIntroduction',
-    ...ADOPTION_SURVEY_QUESTIONS.selfIntroduction,
-  },
-  {
-    name: 'timeAwayFromHome',
-    ...ADOPTION_SURVEY_QUESTIONS.timeAwayFromHome,
-  },
-  {
-    name: 'livingSpaceDescription',
-    ...ADOPTION_SURVEY_QUESTIONS.livingSpaceDescription,
-  },
-]
-
-const subscribeToSurveySkip = (onStoreChange: () => void) => {
-  window.addEventListener('storage', onStoreChange)
-  return () => window.removeEventListener('storage', onStoreChange)
 }
 
 const ApplicationForm = ({ detail }: ApplicationFormProps) => {
@@ -75,29 +47,17 @@ const ApplicationForm = ({ detail }: ApplicationFormProps) => {
     cancelConsult,
     giveUpFromConsult,
     petSummary,
+    needsSurvey,
+    toast,
   } = useApplicationForm(detail)
-
-  // 온보딩에서 조사 양식을 건너뛴 입양자에게만 조사 항목을 노출 (localStorage → 클라이언트에서만 읽음)
-  const needsSurvey = useSyncExternalStore(subscribeToSurveySkip, isSurveySkipped, () => false)
 
   return (
     <div>
       {/* ═══ 상단 고정 영역 — GNB(sticky top-0) 아래에 서브헤더 + 동물 정보 카드를 함께 sticky ═══ */}
       {/* top 값 = GNB 높이(모바일 48px / 탭+ ≈56px) 기준 오프셋 */}
       <div className="sticky top-12 z-40 tab:top-14">
-        {/* 서브헤더 (Figma 1654-161687) — 패딩 mo: 4·16 / tab: 4·48 / pc: 8·80 */}
-        <div className="flex flex-col items-center bg-white px-4 py-1 tab:px-12 pc:px-20 pc:py-2">
-          <div className="flex w-full items-center">
-            <button type="button" onClick={handleCloseClick} aria-label="닫기">
-              <CloseIcon className="size-6 text-neutral-700" />
-            </button>
-            <div className="flex flex-1 items-center justify-center p-0.5">
-              <p className="text-base leading-normal font-semibold text-neutral-850">입양 신청</p>
-            </div>
-          </div>
-        </div>
-
-        {/* 동물 정보 카드 */}
+        {/* [refactored] 인라인 서브헤더 JSX → 공통 NavigationBar (Figma 976:25817 close 변형) */}
+        <NavigationBar title={APPLY_TITLE} icon="close" onBack={handleCloseClick} />
         <PetInfoCard detail={detail} />
       </div>
 
@@ -112,49 +72,17 @@ const ApplicationForm = ({ detail }: ApplicationFormProps) => {
 
       {/* ═══ 폼 영역 (Figma 1237-41470) — 모바일: 박스 없음 / 탭+: point-50 카드(#fffff1 p40 rounded12 max-w880) ═══ */}
       <form onSubmit={handleSubmit(onSubmit)}>
-        <Container className="px-[1rem] pb-12">
+        {/* 하단 여백 48px — CTA 바가 fixed 라 바 높이(mo 80 / tab+ 64)를 더해야 실제로 48px 남는다 */}
+        <Container className="px-[1rem] pb-32 tab:pb-28">
           <div className="mx-auto max-w-[55rem]">
             {/* 폼 박스 — 섹션 간 gap 40 */}
             <div className="flex flex-col gap-10 tab:rounded-xl tab:bg-point-50 tab:p-10">
-              {/* [refactored] 라벨+필드 래퍼를 LabeledField로 통일 */}
               {/* 입양하는 동물 (읽기 전용) */}
-              <LabeledField title="입양하는 동물">
+              <LabeledField title={PET_FIELD_TITLE}>
                 <ReadonlyInput value={petSummary} />
               </LabeledField>
 
-              {/* 입양 계획 */}
-              <CountedTextareaField
-                title="입양 계획을 간단히 작성해 주세요"
-                placeholder="생활패턴, 주거환경, 입양 시기 등을 입력해주세요"
-                name="adoptionPlan"
-                register={register}
-                watch={watch}
-              />
-
-              {/* 입양준비 확인 체크 */}
-              <LabeledField
-                title="입양준비 확인을 위한 필수 항목을 체크해주세요"
-                size="lg"
-                gap="gap-5"
-              >
-                {/* [refactored] CONSENT_CHECKS 배열을 map으로 렌더 */}
-                <div className="flex flex-col gap-3">
-                  {CONSENT_CHECKS.map(({ name, label }) => (
-                    <CheckboxField key={name} control={control} name={name} label={label} />
-                  ))}
-                </div>
-              </LabeledField>
-
-              {/* 가족 구성원 */}
-              <CountedTextareaField
-                title="함께 거주하는 가족 구성원을 입력해주세요"
-                placeholder="예) 배우자 1명, 자녀 1명, 부모님 1명"
-                name="familyMembers"
-                register={register}
-                watch={watch}
-              />
-
-              {/* 조사 건너뛴 입양자용 조사 항목 (선택) — 온보딩 SurveyStep과 동일 문항 */}
+              {/* 조사 건너뛴 입양자용 조사 항목 (선택) — 시안상 '입양 계획' 바로 위에 온다 */}
               {needsSurvey &&
                 SURVEY_FIELDS.map((field) => (
                   <CountedTextareaField
@@ -166,18 +94,43 @@ const ApplicationForm = ({ detail }: ApplicationFormProps) => {
                   />
                 ))}
 
+              {/* [refactored] 인라인이던 문구를 상수로 — 조사 항목과 같은 형태로 통일 */}
+              <CountedTextareaField {...ADOPTION_PLAN_FIELD} register={register} watch={watch} />
+
+              {/* 입양준비 확인 체크 */}
+              <LabeledField title={CONSENT_CHECKS_TITLE} size="lg" gap="gap-5">
+                <div className="flex flex-col gap-3">
+                  {CONSENT_CHECKS.map(({ name, label }) => (
+                    <CheckboxField key={name} control={control} name={name} label={label} />
+                  ))}
+                </div>
+              </LabeledField>
+
+              <CountedTextareaField {...FAMILY_MEMBERS_FIELD} register={register} watch={watch} />
+
               {/* 모든 가족 동의 */}
               <CheckboxField
                 control={control}
                 name="allFamilyConsent"
-                label="모든 가족 구성원이 입양에 동의했습니다."
+                label={ALL_FAMILY_CONSENT_LABEL}
               />
             </div>
           </div>
         </Container>
 
-        {/* ═══ 하단 CTA 바 (Figma 1654-161691/97/03) — [refactored] FooterCtaBar로 분리 ═══ */}
-        <FooterCtaBar onCancel={handleCloseClick} isValid={isValid} isPending={isPending} />
+        {/* ═══ 하단 CTA 바 (Figma 1654-161691/97/03) ═══ */}
+        <FooterCtaBar onCancel={handleCloseClick} isValid={isValid} isPending={isPending}>
+          {/* 신청 실패 토스트 — 위치(바 높이 기준)는 FooterCtaBar가 잡는다 */}
+          {toast.current && (
+            <AlertMessage
+              status="error"
+              size="responsive"
+              icon={AlertCircleIcon}
+              message={toast.current.message}
+              onClose={toast.hide}
+            />
+          )}
+        </FooterCtaBar>
       </form>
 
       {/* ═══ 나가기 확인 모달 (공통 ExitConfirmModal) ═══ */}
@@ -185,7 +138,7 @@ const ApplicationForm = ({ detail }: ApplicationFormProps) => {
         open={showGuard}
         onClose={cancelExit}
         onConfirm={confirmExit}
-        title="입양 신청을 그만두시나요?"
+        title={EXIT_CONFIRM_TITLE}
       />
 
       {/* ═══ 입양 상담 확인 모달 (Figma 1955-262642) — 제출 버튼 → 이 모달 → "상담하기"로 실제 신청 ═══ */}
@@ -193,7 +146,7 @@ const ApplicationForm = ({ detail }: ApplicationFormProps) => {
         open={showConsultConfirm}
         onOpenChange={(isOpen) => !isOpen && cancelConsult()}
         icon={<PawIcon className="size-8 text-neutral-700" />}
-        title={'브리더와 더 자세한 입양 상담이\n이루어집니다.'}
+        title={CONSULT_CONFIRM_TITLE}
         direction="row"
         actions={[
           { label: '그만두기', variant: 'outline', onClick: giveUpFromConsult },

--- a/src/app/(main)/adoption/[id]/apply/_ui/FormFields.tsx
+++ b/src/app/(main)/adoption/[id]/apply/_ui/FormFields.tsx
@@ -6,44 +6,14 @@ import {
   type UseFormRegister,
   type UseFormWatch,
 } from 'react-hook-form'
-import { Checkbox, TextareaField } from '@/shared/ui'
+import { Button, Checkbox, Input, TextLabel, TextareaField } from '@/shared/ui'
 import { cn } from '@/shared/lib/cn'
-import type { ApplicationFormValues } from '../_lib/schema'
+import type { ApplicationFormValues, ApplicationTextField } from '../_lib/schema'
 
 // [refactored] textarea 글자 수 제한(100)을 공통 컴포넌트 옆으로 이동 (ApplicationForm에서 옮겨옴)
 const TEXTAREA_MAX_LENGTH = 100
 
-// [refactored] 스키마에서 문자열 필드 키만 파생 — 필드 추가/삭제 시 자동 반영(drift 방지)
-export type ApplicationTextField = {
-  [K in keyof ApplicationFormValues]-?: NonNullable<ApplicationFormValues[K]> extends string
-    ? K
-    : never
-}[keyof ApplicationFormValues]
-
-// 라벨 + 필수/선택 뱃지 (Figma 1237-41470) — 라벨 md/bold 14(또는 lg 14→탭+ 16), 뱃지 md/medium 14 #6b6b6b
-const FieldLabel = ({
-  title,
-  size = 'md',
-  requirement = '필수',
-}: {
-  title: string
-  size?: 'md' | 'lg'
-  requirement?: '필수' | '선택'
-}) => (
-  <div className="flex items-center gap-1">
-    <span
-      className={cn(
-        'leading-[1.5] font-semibold text-neutral-850',
-        size === 'lg' ? 'text-sm tab:text-base' : 'text-sm',
-      )}
-    >
-      {title}
-    </span>
-    <span className="text-sm leading-[1.5] font-medium text-neutral-700">{requirement}</span>
-  </div>
-)
-
-// [refactored] 라벨 + 필드 래퍼 — ApplicationForm에서 4회 반복되던 `div(flex-col) + FieldLabel` 패턴 통합
+// [refactored] 라벨 + 필드 래퍼 — 라벨은 공통 TextLabel(Figma 926-25253 label-필수)에 위임
 const LabeledField = ({
   title,
   size = 'md',
@@ -58,7 +28,9 @@ const LabeledField = ({
   children: ReactNode
 }) => (
   <div className={cn('flex flex-col', gap)}>
-    <FieldLabel title={title} size={size} requirement={requirement} />
+    <TextLabel size="14" requirement={requirement} className={cn(size === 'lg' && 'tab:text-base')}>
+      {title}
+    </TextLabel>
     {children}
   </div>
 )
@@ -89,12 +61,8 @@ const CountedTextareaField = ({
   </LabeledField>
 )
 
-// 읽기 전용 입력 (입양하는 동물) — border #e4e4e4, h-45, rounded-8, p-12
-const ReadonlyInput = ({ value }: { value: string }) => (
-  <div className="flex h-[2.8125rem] items-center rounded-lg border border-neutral-150 bg-white p-3">
-    <p className="text-sm leading-[1.5] font-medium text-neutral-850">{value}</p>
-  </div>
-)
+// [refactored] 읽기 전용 입력(입양하는 동물) — 규격이 공통 Input과 같아 readOnly로 대체
+const ReadonlyInput = ({ value }: { value: string }) => <Input readOnly value={value} />
 
 // 체크박스 — 공통 Checkbox(기본 large 24px) + 라벨 lg/medium 14→탭+ 16
 const CheckboxField = ({
@@ -121,82 +89,58 @@ const CheckboxField = ({
   />
 )
 
-// [refactored] CancelButton/SubmitButton 공통 base 클래스 추출 (DRY)
-const CTA_BUTTON_BASE =
-  'flex items-center justify-center rounded-full font-semibold whitespace-nowrap'
-
-// 신청 취소 버튼 (아웃라인) — 라벨: mo·tab "신청 취소" / pc "신청 취소하기" (Figma 1654-161691/97/03)
-const CancelButton = ({ onClick, className }: { onClick: () => void; className?: string }) => (
-  <button
-    type="button"
-    onClick={onClick}
-    className={cn(CTA_BUTTON_BASE, 'border border-neutral-300 text-neutral-850', className)}
-  >
-    <span className="pc:hidden">신청 취소</span>
-    <span className="hidden pc:inline">신청 취소하기</span>
-  </button>
-)
-
-// 제출 버튼 (Figma bg/interactive/point-color/primary = point-500) — 라벨: mo "상담 신청하기" / tab "입양 상담" / pc "입양 상담하기", 크기만 className 주입
-const SubmitButton = ({
-  isValid,
-  isPending,
-  className,
-}: {
-  isValid: boolean
-  isPending: boolean
-  className?: string
-}) => (
-  <button
-    type="submit"
-    disabled={!isValid || isPending}
-    className={cn(
-      CTA_BUTTON_BASE,
-      'transition-colors',
-      isValid && !isPending ? 'bg-point-500 text-neutral-850' : 'bg-[#d4d4d4] text-[#5d5d5d]',
-      className,
-    )}
-  >
-    {isPending ? (
-      '제출 중...'
-    ) : (
-      <>
-        <span className="tab:hidden">상담 신청하기</span>
-        <span className="hidden tab:inline pc:hidden">입양 상담</span>
-        <span className="hidden pc:inline">입양 상담하기</span>
-      </>
-    )}
-  </button>
-)
-
-// [refactored] 하단 CTA 바 — 스페이서 + 버튼 그룹 레이아웃을 ApplicationForm에서 분리(SRP)
-// mo: gap10 px16 py16 / tab·pc: 우측 정렬 그룹(w-360 max-536, 버튼 h-40), px48/80 py12 (Figma 1654-161697)
+// [refactored] 하단 CTA 바 — 버튼 스타일은 공통 Button(variant outline/primary)에 위임하고
+// 크기·반응형 라벨만 이 시안(Figma 1654-161691/97/03) 규격으로 얹는다
 const FooterCtaBar = ({
   onCancel,
   isValid,
   isPending,
+  children,
 }: {
   onCancel: () => void
   isValid: boolean
   isPending: boolean
+  /** 바 위에 겹쳐 띄우는 요소 (실패 토스트) — 위치는 바가 자기 높이를 알고 잡는다 */
+  children?: ReactNode
 }) => (
   <div className="fixed inset-x-0 bottom-0 z-10 flex items-center gap-2.5 bg-white px-4 py-4 tab:justify-end tab:gap-5 tab:px-12 tab:py-3 pc:px-20">
+    {/* [refactored] bottom 값은 바 높이(mo 80 / tab+ 64)에서 나오므로 호출부가 아니라 여기서 관리 */}
+    {children && (
+      <div className="absolute inset-x-0 bottom-20 px-4 tab:bottom-16 tab:px-12 pc:px-20">
+        {children}
+      </div>
+    )}
     {/* 좌측 스페이서 (tab+) */}
     <div className="hidden h-[2.8125rem] flex-1 tab:block" />
     {/* 버튼 그룹 — mo: 전체폭 / tab+: 360px(max-536) */}
     <div className="flex flex-1 items-center gap-2.5 tab:max-w-[33.5rem] tab:flex-none tab:basis-[22.5rem] tab:gap-5">
-      <CancelButton
+      <Button
+        variant="outline"
+        size="lg"
         onClick={onCancel}
-        className="h-12 w-[7.3125rem] shrink-0 text-base tab:h-10 tab:w-auto tab:max-w-[16.125rem] tab:flex-1"
-      />
-      <SubmitButton
-        isValid={isValid}
-        isPending={isPending}
-        className="h-12 max-w-[18.5625rem] flex-1 text-base tab:h-10 tab:max-w-[16.125rem]"
-      />
+        className="w-[7.3125rem] shrink-0 whitespace-nowrap tab:h-10 tab:w-auto tab:max-w-[16.125rem] tab:flex-1"
+      >
+        <span className="pc:hidden">신청 취소</span>
+        <span className="hidden pc:inline">신청 취소하기</span>
+      </Button>
+      <Button
+        type="submit"
+        size="lg"
+        disabled={!isValid || isPending}
+        className="max-w-[18.5625rem] flex-1 whitespace-nowrap tab:h-10 tab:max-w-[16.125rem]"
+      >
+        {isPending ? (
+          '제출 중...'
+        ) : (
+          <>
+            <span className="tab:hidden">상담 신청하기</span>
+            <span className="hidden tab:inline pc:hidden">입양 상담</span>
+            <span className="hidden pc:inline">입양 상담하기</span>
+          </>
+        )}
+      </Button>
     </div>
   </div>
 )
 
-// [refactored] FieldLabel/CancelButton/SubmitButton은 내부 전용이 되어 export 제거 (FooterCtaBar로 통합)
 export { LabeledField, CountedTextareaField, ReadonlyInput, CheckboxField, FooterCtaBar }

--- a/src/app/(main)/adoption/[id]/apply/_ui/FormFields.tsx
+++ b/src/app/(main)/adoption/[id]/apply/_ui/FormFields.tsx
@@ -6,7 +6,7 @@ import {
   type UseFormRegister,
   type UseFormWatch,
 } from 'react-hook-form'
-import { Button, Checkbox, Input, TextLabel, TextareaField } from '@/shared/ui'
+import { Button, Checkbox, Container, Input, TextLabel, TextareaField } from '@/shared/ui'
 import { cn } from '@/shared/lib/cn'
 import type { ApplicationFormValues, ApplicationTextField } from '../_lib/schema'
 
@@ -106,9 +106,7 @@ const FooterCtaBar = ({
   <div className="fixed inset-x-0 bottom-0 z-10 flex items-center gap-2.5 bg-white px-4 py-4 tab:justify-end tab:gap-5 tab:px-12 tab:py-3 pc:px-20">
     {/* [refactored] bottom 값은 바 높이(mo 80 / tab+ 64)에서 나오므로 호출부가 아니라 여기서 관리 */}
     {children && (
-      <div className="absolute inset-x-0 bottom-20 px-4 tab:bottom-16 tab:px-12 pc:px-20">
-        {children}
-      </div>
+      <Container className="absolute inset-x-0 bottom-20 px-4 tab:bottom-16">{children}</Container>
     )}
     {/* 좌측 스페이서 (tab+) */}
     <div className="hidden h-[2.8125rem] flex-1 tab:block" />

--- a/src/app/(main)/adoption/[id]/apply/page.tsx
+++ b/src/app/(main)/adoption/[id]/apply/page.tsx
@@ -4,7 +4,6 @@ import { useParams } from 'next/navigation'
 import { useQuery } from '@tanstack/react-query'
 import { Container } from '@/shared/ui'
 import { adoptionQueries } from '@/entities/adoption'
-import { adopterQueries } from '@/entities/adopter'
 import { mapAdoptionDetail } from '../_lib/mapAdoptionDetail'
 import { ApplicationForm } from './_ui/ApplicationForm'
 
@@ -14,12 +13,8 @@ const AdoptionApplyPage = () => {
 
   // 신청서에는 브리더/펫 기본 정보만 필요 — 다른 분양건은 조회하지 않는다
   const { data, isLoading, isError } = useQuery(adoptionQueries.detail(petId))
-  // 조사 문항 노출 여부(counselDefaultProfile)가 첫 렌더에 확정돼야 폼 중간에 문항이
-  // 끼어들며 밀리지 않는다. 신청서 훅과 같은 queryKey라 요청은 한 번만 나가고,
-  // detail 과 병렬이라 체감 지연도 없다.
-  const { isLoading: isProfileLoading } = useQuery(adopterQueries.profile())
 
-  if (isLoading || isProfileLoading) {
+  if (isLoading) {
     return (
       <Container className="flex min-h-screen items-center justify-center py-10">
         <p className="text-sm text-neutral-700">불러오는 중...</p>

--- a/src/app/(main)/adoption/[id]/apply/page.tsx
+++ b/src/app/(main)/adoption/[id]/apply/page.tsx
@@ -4,6 +4,7 @@ import { useParams } from 'next/navigation'
 import { useQuery } from '@tanstack/react-query'
 import { Container } from '@/shared/ui'
 import { adoptionQueries } from '@/entities/adoption'
+import { adopterQueries } from '@/entities/adopter'
 import { mapAdoptionDetail } from '../_lib/mapAdoptionDetail'
 import { ApplicationForm } from './_ui/ApplicationForm'
 
@@ -13,8 +14,12 @@ const AdoptionApplyPage = () => {
 
   // 신청서에는 브리더/펫 기본 정보만 필요 — 다른 분양건은 조회하지 않는다
   const { data, isLoading, isError } = useQuery(adoptionQueries.detail(petId))
+  // 조사 문항 노출 여부(counselDefaultProfile)가 첫 렌더에 확정돼야 폼 중간에 문항이
+  // 끼어들며 밀리지 않는다. 신청서 훅과 같은 queryKey라 요청은 한 번만 나가고,
+  // detail 과 병렬이라 체감 지연도 없다.
+  const { isLoading: isProfileLoading } = useQuery(adopterQueries.profile())
 
-  if (isLoading) {
+  if (isLoading || isProfileLoading) {
     return (
       <Container className="flex min-h-screen items-center justify-center py-10">
         <p className="text-sm text-neutral-700">불러오는 중...</p>

--- a/src/app/(main)/profile/edit/_ui/ProfileEditContent.tsx
+++ b/src/app/(main)/profile/edit/_ui/ProfileEditContent.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useRef, useEffect, type ChangeEvent, type ComponentProps } from 'react'
+import { useState, useRef, type ChangeEvent, type ComponentProps } from 'react'
 import { useRouter } from 'next/navigation'
 import { useQuery } from '@tanstack/react-query'
 import { adopterQueries } from '@/entities/adopter'
@@ -11,6 +11,7 @@ import { useUpdateMyProfile } from '@/features/profile'
 import { useUploadSingleFile } from '@/features/upload'
 import { useLogout } from '@/features/auth'
 import { normalizeApiError } from '@/shared/api'
+import { useToast } from '@/shared/lib/useToast'
 import { WithdrawReason } from '@/shared/types'
 import {
   AlertMessage,
@@ -26,7 +27,6 @@ import {
 } from '@/shared/ui'
 import { AlertCircleIcon, CheckIcon } from '@/shared/assets/icons'
 
-const TOAST_DURATION_MS = 3000
 const NAME_MAX_LENGTH = 30
 const BIO_MAX_LENGTH = 200 // 서버 UpdateMyProfileRequestDto.bio maxLength
 
@@ -46,27 +46,6 @@ const LEAVE_DESCRIPTION = (
     복구되지 않습니다
   </>
 )
-
-// 토스트 표시 + 자동 닫힘 로직 분리 (SRP)
-// 성공(default)·실패(error) 두 종류를 같은 슬롯에서 표시한다.
-type ToastState = { message: string; status: 'default' | 'error' }
-
-const useToast = (duration = TOAST_DURATION_MS) => {
-  const [toast, setToast] = useState<ToastState | null>(null)
-
-  useEffect(() => {
-    if (!toast) return
-    const timer = setTimeout(() => setToast(null), duration)
-    return () => clearTimeout(timer)
-  }, [toast, duration])
-
-  return {
-    current: toast,
-    success: (message: string) => setToast({ message, status: 'default' }),
-    error: (message: string) => setToast({ message, status: 'error' }),
-    hide: () => setToast(null),
-  }
-}
 
 /** 프로필 편집 (Figma node 2145-191107) — GNB는 MainLayout 제공 */
 const ProfileEditContent = () => {

--- a/src/features/onboarding/model/useAdopterSignup.ts
+++ b/src/features/onboarding/model/useAdopterSignup.ts
@@ -10,7 +10,6 @@ import { buildAdopterRegistrationRequest } from './buildAdopterRegistrationReque
 import { useSignupCompletion } from './useSignupCompletion' // [refactored]
 import { SIGNUP_ERROR } from './signupErrors' // [refactored]
 import type { SurveyFormData } from './schema'
-import { clearSurveySkipped, markSurveySkipped } from '@/shared/lib/surveySkip'
 
 /**
  * 입양자 가입 완료 (POST /auth/register/adopter)
@@ -89,10 +88,7 @@ export const useAdopterSignup = () => {
 
     try {
       const tokens = await registerAdopter(request)
-      // 조사 미작성 표시는 가입이 실제로 끝난 뒤에만 남긴다
-      if (skipped) markSurveySkipped()
-      else clearSurveySkipped()
-
+      // 조사 작성 여부는 서버가 counselDefaultProfile 유무로 판별한다 (클라 플래그 불필요)
       await complete(tokens) // [refactored]
     } catch (err) {
       setError(err instanceof Error ? err.message : SIGNUP_ERROR.registerFailed)

--- a/src/shared/lib/surveySkip.ts
+++ b/src/shared/lib/surveySkip.ts
@@ -1,9 +1,0 @@
-// 온보딩에서 '다음에 작성하기'로 조사 양식을 건너뛴 입양자 표시 —
-// apply 신청서에서 조사 항목(자기소개/집 비우는 시간/공간)을 다시 노출하기 위한 플래그.
-// ponytail: 임시 로컬 플래그. 백엔드 프로필에 survey 완료 여부가 생기면 그 값으로 교체.
-const KEY = 'pawpong:survey-skipped'
-
-export const markSurveySkipped = () => localStorage.setItem(KEY, '1')
-export const isSurveySkipped = () =>
-  typeof window !== 'undefined' && localStorage.getItem(KEY) === '1'
-export const clearSurveySkipped = () => localStorage.removeItem(KEY)

--- a/src/shared/lib/useToast.ts
+++ b/src/shared/lib/useToast.ts
@@ -1,0 +1,28 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+const TOAST_DURATION_MS = 3000
+
+// 토스트 표시 + 자동 닫힘 로직 분리 (SRP)
+// 성공(default)·실패(error) 두 종류를 같은 슬롯에서 표시한다.
+type ToastState = { message: string; status: 'default' | 'error' }
+
+const useToast = (duration = TOAST_DURATION_MS) => {
+  const [toast, setToast] = useState<ToastState | null>(null)
+
+  useEffect(() => {
+    if (!toast) return
+    const timer = setTimeout(() => setToast(null), duration)
+    return () => clearTimeout(timer)
+  }, [toast, duration])
+
+  return {
+    current: toast,
+    success: (message: string) => setToast({ message, status: 'default' }),
+    error: (message: string) => setToast({ message, status: 'error' }),
+    hide: () => setToast(null),
+  }
+}
+
+export { useToast, TOAST_DURATION_MS, type ToastState }

--- a/src/shared/types/AdopterTypes.ts
+++ b/src/shared/types/AdopterTypes.ts
@@ -8,6 +8,18 @@ import type { PaginationResponse } from './ApiTypes'
 
 // ==================== 프로필 ====================
 
+/**
+ * 온보딩 조사 양식(상담 사전 정보) 답변.
+ * 서버가 답변이 하나도 없으면 프로필 응답에서 null 로 내려주므로, 이 값으로
+ * '다음에 작성하기'로 건너뛴 입양자인지 판별한다.
+ */
+export interface AdopterCounselProfile {
+  selfIntroduction?: string
+  dailyAbsenceHours?: string
+  livingSpaceDescription?: string
+  counselPrivacyAgreedAt?: string
+}
+
 export interface AdopterProfileDto {
   adopterId: string
   emailAddress: string
@@ -17,6 +29,8 @@ export interface AdopterProfileDto {
   accountStatus: string
   authProvider: AuthProvider
   marketingAgreed: boolean
+  /** 조사 양식을 건너뛴 경우 null */
+  counselDefaultProfile: AdopterCounselProfile | null
   createdAt: string
   updatedAt: string
 }


### PR DESCRIPTION
Closes #247

## 변경 사항

### 공통 컴포넌트/토큰 적용 (Figma 1237-41470)
손으로 조립돼 있던 요소를 공통 컴포넌트로 교체했습니다.

| 제거한 로컬 구현 | 대체 |
|---|---|
| `FieldLabel` (라벨+필수/선택 직접 조립) | `TextLabel` — Figma 926-25253 `label-필수` |
| `ReadonlyInput` (div로 흉내낸 입력창) | `Input` + `readOnly` — 규격 동일 |
| `CancelButton`/`SubmitButton` + `CTA_BUTTON_BASE` | `Button` `variant="outline"`/`"primary"` |
| `ApplyHeader` (인라인 서브헤더) | `NavigationBar` `icon="close"` |

disabled 하드코딩 색상 `#d4d4d4`/`#5d5d5d` → 토큰 `neutral-150`/`neutral-400`.

### 온보딩 조사 건너뜀 판별
localStorage 플래그(`pawpong:survey-skipped`)를 서버 값으로 교체했습니다.

백엔드 `AdopterProfileResultMapperService.toCounselDefaultProfile()`이 답변이 하나도 없으면 `null`을 반환하고, e2e(`adopter-counsel-profile.e2e-spec.ts`)에도 "조사 양식을 건너뛴 사용자는 null 이라 완료 여부를 구분할 수 있다"로 명시돼 있습니다.

조사 문항 위치도 시안대로 `입양 계획` 위로 옮겼습니다.

### 제출 실패 노출
`createApplication`에 `onError`가 없어 실패가 화면에 전혀 안 떴습니다. 전역 `MutationCache`는 5xx만 Sentry로 보내고 `mutations.retry: false`라, "상담하기"를 눌러도 모달이 그대로 떠 있고 아무 반응이 없었습니다.

```
409  해당 브리더에게 이미 대기 중인 상담 신청이 있습니다
400  현재 분양 신청이 불가능한 반려동물입니다
404  해당 브리더/반려동물을 찾을 수 없습니다
```

상담 모달을 닫고 서버 문구를 CTA 바 위 토스트로 띄웁니다. 입력값은 유지됩니다.

### 정리
- 문구를 `_lib/constants.ts`로 모아 조사 문항만 배열이던 비대칭 제거
- `ApplicationTextField`를 파생 원본인 `_lib/schema.ts`로 이동
- 토스트 위치(`bottom-[5rem]`)가 CTA 바 높이에서 나오므로 바가 직접 소유
- 하단 여백을 바 높이만큼 더해 실제로 48px 남게 조정
- `useToast`를 `shared/lib`로 공용화 (프로필 편집과 공유)

`ApplicationForm.tsx` 207 → 160줄.

## 확인 사항
- `NavigationBar` 기본값을 쓰면서 타이틀이 모바일 14px로 바뀝니다 (기존 16px 고정). `NavigationBar` 주석상 "medium(mo) 14 / large(tab+) 16"이 시스템 기준이라 기존 값이 손튜닝으로 보이는데, 신청서 시안(1654-161687)이 모바일도 16이면 `NavigationBar`에 사이즈 variant를 넣는 게 맞습니다.
- 신청 생성 경로(`create-adoption-application-v2.use-case.ts`)는 `counselDefaultProfile`을 채우지 않습니다. 기존 "제출했으니 플래그 해제" 로직은 근거 없는 클라이언트 가정이었고, 지금은 상담 사전 정보를 실제로 작성하기 전까지 문항이 계속 노출됩니다.

## 테스트
1. 조사 건너뛴 계정으로 `/adoption/{id}/apply` 진입 → `입양 계획` 위에 조사 3문항(선택) 노출
2. 조사 작성한 계정 → 문항 미노출
3. 같은 브리더에게 대기 중 신청이 있는 상태로 제출 → CTA 바 위 실패 토스트
4. 하단 여백이 CTA 바에 가리지 않고 48px 확보되는지 확인