### PR TITLE
fix(community): 목록 카드 댓글 미리보기 연결과 게시글 상세 진입 영역 확대

### DIFF
--- a/src/app/(main)/community/_ui/CommunityContent.tsx
+++ b/src/app/(main)/community/_ui/CommunityContent.tsx
@@ -55,18 +55,7 @@ const CommunityContent = () => {
             {posts.map((post, index) => (
               <Fragment key={post.postId}>
                 {index > 0 && <Separator className="bg-border-light" />}
-                <ConnectedPostCard
-                  {...toCommunityPreviewProps(post)}
-                  // ponytail: 목록 API에 댓글 미리보기 없음 — 상세(commentPreview) 생기면 교체. 댓글 있는 글만.
-                  commentPreview={
-                    post.commentCount > 0
-                      ? {
-                          nickname: '댓글러',
-                          body: '미리보기 댓글입니다. 한줄만 보여줍니다. 두줄이상 넘어가면 쩜쩜쩜 보여줍니다.',
-                        }
-                      : undefined
-                  }
-                />
+                <ConnectedPostCard {...toCommunityPreviewProps(post)} />
               </Fragment>
             ))}
           </div>

--- a/src/entities/community/api/community.api.ts
+++ b/src/entities/community/api/community.api.ts
@@ -42,6 +42,7 @@ interface RawCommunityPostCard {
   isLiked: boolean
   isSaved: boolean
   createdAt: string
+  commentPreview?: RawCommunityComment[]
 }
 
 interface RawCommunityComment {
@@ -100,6 +101,7 @@ const mapCard = (raw: RawCommunityPostCard): CommunityPostCard => ({
   isLiked: raw.isLiked,
   isSaved: raw.isSaved,
   createdAt: raw.createdAt,
+  commentPreview: raw.commentPreview?.map(mapComment),
 })
 
 const mapComment = (raw: RawCommunityComment): CommunityComment => ({

--- a/src/entities/community/model/communityPreview.ts
+++ b/src/entities/community/model/communityPreview.ts
@@ -17,6 +17,7 @@ interface CommunityPreviewProps {
   isLiked: boolean
   isSaved: boolean
   detailHref?: string
+  commentPreview?: { nickname: string; body: string }
 }
 
 const toCommunityPreviewProps = (post: CommunityPostCard): CommunityPreviewProps => ({
@@ -34,6 +35,10 @@ const toCommunityPreviewProps = (post: CommunityPostCard): CommunityPreviewProps
   isLiked: post.isLiked,
   isSaved: post.isSaved,
   detailHref: `/community/${post.postId}`,
+  commentPreview: post.commentPreview?.[0] && {
+    nickname: post.commentPreview[0].authorNickname,
+    body: post.commentPreview[0].body,
+  },
 })
 
 export { toCommunityPreviewProps }

--- a/src/entities/community/ui/CommunityBox.tsx
+++ b/src/entities/community/ui/CommunityBox.tsx
@@ -98,6 +98,7 @@ const CommunityBox = ({
         saved={isSaved}
         onToggleLike={onToggleLike}
         onToggleSave={onToggleSave}
+        detailHref={detailHref}
       />
     </article>
   )

--- a/src/entities/community/ui/CommunityPostActions.tsx
+++ b/src/entities/community/ui/CommunityPostActions.tsx
@@ -11,6 +11,8 @@ interface CommunityPostActionsProps {
   /** 미전달 시 버튼은 표시만 되고 동작하지 않는다 (features 래퍼에서 주입) */
   onToggleLike?: () => void
   onToggleSave?: () => void
+  /** 있으면 댓글 아이콘이 게시글 상세 링크가 된다 */
+  detailHref?: string
 }
 
 const CommunityPostActions = ({
@@ -20,6 +22,7 @@ const CommunityPostActions = ({
   saved,
   onToggleLike,
   onToggleSave,
+  detailHref,
 }: CommunityPostActionsProps) => {
   return (
     <div className="flex items-center gap-2">
@@ -32,7 +35,13 @@ const CommunityPostActions = ({
         iconStatus={liked ? 'fill' : 'default'}
         onClick={onToggleLike}
       />
-      <PostActionButton icon={PixelMessageIcon} count={commentCount} iconClassName="size-8" />
+      <PostActionButton
+        icon={PixelMessageIcon}
+        count={commentCount}
+        iconClassName="size-8"
+        ariaLabel="댓글 보기"
+        href={detailHref}
+      />
       <PostActionButton
         icon={PixelBookmarkIcon}
         iconClassName="size-8"

--- a/src/entities/community/ui/PostCard.tsx
+++ b/src/entities/community/ui/PostCard.tsx
@@ -25,6 +25,40 @@ interface PostCardProps extends CommunityPreviewProps {
   className?: string
 }
 
+/** 이미지 가로 스크롤 — detailHref 있으면 행 전체(빈 영역 포함)가 상세 진입 링크 */
+const ImagesRow = ({
+  images,
+  detailHref,
+  className,
+}: {
+  images: string[]
+  detailHref?: string
+  className?: string
+}) => {
+  const row = (
+    <div className={cn('flex gap-3 overflow-x-auto', className)}>
+      {images.map((src, index) => (
+        <div
+          key={index}
+          className="relative h-[13.1875rem] w-[17.5625rem] shrink-0 overflow-hidden rounded-lg bg-neutral-700 tab:h-60 tab:w-80"
+        >
+          {src && (
+            <Image src={src} alt={`게시글 이미지 ${index + 1}`} fill className="object-cover" />
+          )}
+        </div>
+      ))}
+    </div>
+  )
+
+  return detailHref ? (
+    <Link href={detailHref} className="block">
+      {row}
+    </Link>
+  ) : (
+    row
+  )
+}
+
 /**
  * 커뮤니티 게시글 카드 (Figma node 1054-28522 · community box -게시글)
  * - 헤더: 아바타 + [이름·작성시각] / 본문 미리보기 + 더보기(⋯)
@@ -104,23 +138,11 @@ const PostCard = ({
       <div className="flex flex-col gap-2">
         {/* 이미지 (가로 스크롤) — 저장피드(profileType)는 상단패딩 제거 */}
         {hasImages && (
-          <div className={cn('flex gap-3 overflow-x-auto pt-3 pc:pt-3', profileType && 'pt-0')}>
-            {images.map((src, index) => (
-              <div
-                key={index}
-                className="relative h-[13.1875rem] w-[17.5625rem] shrink-0 overflow-hidden rounded-lg bg-neutral-700 tab:h-60 tab:w-80"
-              >
-                {src && (
-                  <Image
-                    src={src}
-                    alt={`게시글 이미지 ${index + 1}`}
-                    fill
-                    className="object-cover"
-                  />
-                )}
-              </div>
-            ))}
-          </div>
+          <ImagesRow
+            images={images}
+            detailHref={detailHref}
+            className={cn('pt-3 pc:pt-3', profileType && 'pt-0')}
+          />
         )}
 
         {/* 액션 + 댓글 미리보기 — 아이콘↔댓글 4px gap */}
@@ -133,6 +155,7 @@ const PostCard = ({
             saved={isSaved}
             onToggleLike={onToggleLike}
             onToggleSave={onToggleSave}
+            detailHref={detailHref}
           />
 
           {/* 댓글 미리보기 (Figma community-profile 2596-231732) — 작성자 + 본문 1줄 + [더보기] */}

--- a/src/shared/types/CommunityTypes.ts
+++ b/src/shared/types/CommunityTypes.ts
@@ -34,6 +34,8 @@ export interface CommunityPostCard {
   isLiked: boolean
   isSaved: boolean
   createdAt: string
+  /** 카드에 노출할 최신 댓글 (없으면 빈 배열) */
+  commentPreview?: CommunityComment[]
 }
 
 /** 커뮤니티 댓글 */

--- a/src/shared/ui/PostActionButton.tsx
+++ b/src/shared/ui/PostActionButton.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import { cn } from '@/shared/lib/cn'
 import { FAVORITE_ACTIVE, FAVORITE_INACTIVE } from './FavoriteToggle'
 
@@ -23,6 +24,8 @@ interface PostActionButtonProps {
   ariaLabel?: string
   /** 있으면 버튼으로 렌더(클릭 가능), 없으면 표시전용 */
   onClick?: () => void
+  /** 있으면 링크로 렌더 (댓글 아이콘 → 게시글 상세) */
+  href?: string
   disabled?: boolean
 }
 
@@ -35,6 +38,7 @@ const PostActionButton = ({
   iconStatus,
   ariaLabel,
   onClick,
+  href,
   disabled,
 }: PostActionButtonProps) => {
   const inner = (
@@ -53,6 +57,14 @@ const PostActionButton = ({
       )}
     </>
   )
+
+  if (href) {
+    return (
+      <Link href={href} aria-label={ariaLabel} className="flex items-center gap-1">
+        {inner}
+      </Link>
+    )
+  }
 
   if (onClick) {
     return (


### PR DESCRIPTION
Closes #249

## 변경 사항

**댓글 미리보기 연결** (`d0dea28`)
- 스웨거 `CommunityPostCardResponseDto`에 `commentPreview`가 이미 있는데 프론트 타입에서 누락돼 `mapCard`가 응답을 버리고 있었다. `RawCommunityPostCard` / `CommunityPostCard` 양쪽에 필드를 추가하고 기존 `mapComment`로 매핑.
- `toCommunityPreviewProps`에서 최신 댓글 1건을 `{ nickname, body }`로 변환해 `PostCard`에 전달.
- `CommunityContent`에 박혀 있던 하드코딩 더미(`'댓글러'` / `'미리보기 댓글입니다…'`) 제거. "목록 API에 댓글 미리보기 없음"이라는 주석이 스웨거보다 오래된 상태였다.
- `commentPreview`는 optional. 응답에 안 실려오면 미노출이고 기존 mock도 그대로 통과한다.

**상세 진입 영역 확대** (`d67c1af`)
- 기존에는 프로필 클러스터(아바타+닉네임+본문)만 링크라 사진 영역과 그 오른쪽 여백이 죽은 영역이었다. 이미지 행을 `ImagesRow`로 분리하고 `detailHref`가 있으면 행 전체를 `<Link>`로 감쌌다.
- `PostActionButton`에 `href`를 추가해 댓글 아이콘도 상세로 이동. 좋아요·북마크는 기존 `onClick` 토글 그대로.
- `PostCard`, `CommunityBox` 양쪽에서 `detailHref`를 넘기므로 커뮤니티 목록·홈 쇼케이스·북마크·임시저장 전부 적용된다.

카드 전체를 stretched-link로 덮는 방식은 액션 버튼마다 z-index를 발라야 해서 택하지 않았다.

## 확인 방법

1. `/community` 진입
2. 댓글 있는 글의 미리보기에 실제 작성자·본문이 뜨는지 (더미 문구 없음)
3. 사진 영역 / 사진 오른쪽 여백 / 댓글 아이콘 각각 클릭 → `/community/{postId}` 진입
4. 좋아요·북마크는 페이지 이동 없이 토글만 되는지
5. 홈 쇼케이스, 북마크, 임시저장 목록에서도 동일 동작

`pnpm type-check`, `pnpm lint` 통과.