### PR TITLE
fix(home): 1440 초과 레이아웃 이탈과 분양중인 동물 목데이터, 상단바 피그마 정렬

### DIFF
--- a/src/app/(main)/hall-of-fame/_ui/HallOfFameContent.tsx
+++ b/src/app/(main)/hall-of-fame/_ui/HallOfFameContent.tsx
@@ -57,7 +57,10 @@ const HallOfFameContent = () => {
 
   const entries = useMemo(() => flattenPages(entriesData), [entriesData])
   const winners =
-    hallOfFameData?.pages[0]?.items.slice(0, PODIUM_COUNT).map((item) => item.winner) ?? []
+    // [refactored] 같은 파일에서 이미 쓰는 flattenPages로 통일
+    flattenPages(hallOfFameData)
+      .slice(0, PODIUM_COUNT)
+      .map((item) => item.winner)
   const currentRanking = currentContest?.ranking.slice(0, PODIUM_COUNT) ?? []
   const podiumEntries: (ContestEntry | undefined)[] = Array.from(
     { length: PODIUM_COUNT },

--- a/src/shared/config/layout.ts
+++ b/src/shared/config/layout.ts
@@ -1,4 +1,7 @@
-/** 페이지 셸의 반응형 최대 너비. 내부 여백은 각 영역의 디자인에 맞게 별도로 지정한다. */
-const PAGE_WIDTH_CLASS = 'mx-auto w-full'
+/**
+ * 페이지 셸의 반응형 최대 너비. 내부 여백은 각 영역의 디자인에 맞게 별도로 지정한다.
+ * pc 디자인 기준이 1440이라 그 이상에서는 좌우 여백만 늘어나도록 가둔다.
+ */
+const PAGE_WIDTH_CLASS = 'mx-auto w-full max-w-[90rem]'
 
 export { PAGE_WIDTH_CLASS }

--- a/src/widgets/adoption-showcase/ui/AdoptionShowcase.tsx
+++ b/src/widgets/adoption-showcase/ui/AdoptionShowcase.tsx
@@ -1,13 +1,25 @@
+'use client'
+
+import { useInfiniteQuery } from '@tanstack/react-query'
+import { adoptionQueries } from '@/entities/adoption'
 import { ShowcaseSection } from '@/shared/ui'
+import { flattenPages } from '@/shared/lib/infiniteList'
+import { mapAdoptionCard } from '@/shared/lib/mapAdoptionCard'
 import { createMockListings } from '@/shared/mocks/adoption'
 import { FavoriteAdoptionShowcaseCard } from '@/features/adoption'
 
 const CARD_COUNT = 4
 
-// ponytail: 분양 목록 API(AdoptionPetCard)가 카드 타입(AdoptionListingCard)과 아직 불일치 —
-// explore도 동일하게 이 카드엔 목데이터 사용. 타입 정합되면 adoptionQueries.list로 교체.
 const AdoptionShowcase = () => {
-  const listings = createMockListings().slice(0, CARD_COUNT)
+  // 홈 섹션은 비필수 — 실패해도 페이지는 렌더되어야 하므로 바운더리로 던지지 않음
+  const { data } = useInfiniteQuery({
+    ...adoptionQueries.list('latest', undefined, 'available', undefined, CARD_COUNT),
+    throwOnError: false,
+  })
+  const pets = flattenPages(data).slice(0, CARD_COUNT).map(mapAdoptionCard)
+
+  // ponytail SSL 인증서 복구 전 홈 UI 확인용 폴백 (명예의 동물과 동일)
+  const listings = pets.length > 0 ? pets : createMockListings().slice(0, CARD_COUNT)
 
   return (
     <ShowcaseSection title="분양중인 동물" linkText="탐색 바로가기" linkHref="/explore">

--- a/src/widgets/community-showcase/ui/CommunityShowcase.tsx
+++ b/src/widgets/community-showcase/ui/CommunityShowcase.tsx
@@ -5,6 +5,7 @@ import { ShowcaseSection } from '@/shared/ui'
 import { CommunityBox, communityQueries, toCommunityPreviewProps } from '@/entities/community'
 import { ConnectedCommunityBox } from '@/features/community'
 import { MOCK_MY_HOME_POSTS } from '@/shared/mocks/myHome'
+import { flattenPages } from '@/shared/lib/infiniteList'
 
 const CARD_COUNT = 3
 
@@ -14,7 +15,8 @@ const CommunityShowcase = () => {
     ...communityQueries.posts('latest', undefined, undefined, CARD_COUNT),
     throwOnError: false,
   })
-  const fetched = (data?.pages[0]?.items ?? []).slice(0, CARD_COUNT).map(toCommunityPreviewProps)
+  // [refactored] 손수 pages[0] 까던 것 → 기존 flattenPages 헬퍼로 통일
+  const fetched = flattenPages(data).slice(0, CARD_COUNT).map(toCommunityPreviewProps)
 
   // 데이터 없으면(로딩/실패/빈 목록) 목업으로 스켈레톤 유지
   const isMock = fetched.length === 0

--- a/src/widgets/gnb/ui/Gnb.tsx
+++ b/src/widgets/gnb/ui/Gnb.tsx
@@ -17,15 +17,16 @@ const Gnb = () => {
 
   return (
     <>
+      {/* 높이·좌우 여백은 Figma 740-66523 디바이스 프레임 기준
+          (mo-375 h48/px16 · tab-768 py8/px48 · pc-1440 h64/py8/px80) */}
       <header
         data-gnb
-        className="sticky top-0 z-50 flex w-full items-center justify-center bg-white py-0 pc:py-[0.5rem]"
+        className="sticky top-0 z-50 flex h-12 w-full items-center justify-center bg-white tab:py-2 pc:h-16"
       >
         <div
           className={cn(
             PAGE_WIDTH_CLASS,
-            'flex items-center justify-between px-4 tab:px-[3rem]',
-            isChat ? 'pc:px-20' : 'pc:px-[6.25rem]',
+            'flex items-center justify-between px-4 tab:px-12 pc:px-20',
           )}
         >
           <LogoButton />
@@ -43,7 +44,8 @@ const Gnb = () => {
               className="flex size-12 items-center justify-center"
               aria-label="메뉴 열기"
             >
-              <MenuIcon className="size-6" />
+              {/* Figma icon/menu — colors/icon/interactive/main color/Primary (#ad651d) */}
+              <MenuIcon className="size-6 text-primary-500" />
             </button>
           </div>
         </div>

--- a/src/widgets/gnb/ui/LogoButton.tsx
+++ b/src/widgets/gnb/ui/LogoButton.tsx
@@ -18,8 +18,15 @@ const LogoButton = () => {
 
   return (
     <Link href="/" aria-label="홈으로 이동" onClick={handleClick}>
-      {/* Figma 로고 (742:67105) — 96x32 워드마크 */}
-      <Image src="/logo.svg" alt="Pawpong" width={96} height={32} priority />
+      {/* Figma 로고 (742:67105) — mo 28px / tab+ 32px 높이, 폭은 비율 유지 */}
+      <Image
+        src="/logo.svg"
+        alt="Pawpong"
+        width={96}
+        height={32}
+        priority
+        className="h-7 w-auto tab:h-8"
+      />
     </Link>
   )
 }

--- a/src/widgets/gnb/ui/NavBar.tsx
+++ b/src/widgets/gnb/ui/NavBar.tsx
@@ -23,7 +23,7 @@ const NavBar = ({ className, chatTone = false }: NavBarProps) => {
   }
 
   return (
-    <nav className={cn('flex items-center gap-[1.25rem]', className)}>
+    <nav className={cn('flex items-center gap-4', className)}>
       {/* 아이콘·목적지는 BottomNav와 shared/config/mainNav 공유 (Figma NavBar 1596-97648) */}
       {HEADER_NAV.map(({ href, label, Icon, isActive }) => (
         <Link
@@ -31,15 +31,15 @@ const NavBar = ({ className, chatTone = false }: NavBarProps) => {
           href={href}
           onClick={(e) => handleLinkClick(e, href)}
           className={cn(
-            'flex items-center text-[1rem] whitespace-nowrap transition-colors',
+            'flex items-center gap-[0.125rem] text-sm leading-[1.5] whitespace-nowrap transition-colors',
             chatTone
               ? 'font-medium text-primary-300'
               : isActive(pathname)
                 ? 'font-semibold text-neutral-850'
-                : 'font-medium text-neutral-500',
+                : 'font-medium text-secondary-500',
           )}
         >
-          <Icon className="size-8" />
+          <Icon className="size-[1.875rem]" />
           {label}
         </Link>
       ))}

--- a/src/widgets/gnb/ui/NavBar.tsx
+++ b/src/widgets/gnb/ui/NavBar.tsx
@@ -31,7 +31,7 @@ const NavBar = ({ className, chatTone = false }: NavBarProps) => {
           href={href}
           onClick={(e) => handleLinkClick(e, href)}
           className={cn(
-            'flex items-center gap-[0.125rem] text-sm leading-[1.5] whitespace-nowrap transition-colors',
+            'flex items-center gap-0.5 text-sm leading-[1.5] whitespace-nowrap transition-colors',
             chatTone
               ? 'font-medium text-primary-300'
               : isActive(pathname)
@@ -39,7 +39,7 @@ const NavBar = ({ className, chatTone = false }: NavBarProps) => {
                 : 'font-medium text-secondary-500',
           )}
         >
-          <Icon className="size-[1.875rem]" />
+          <Icon className="size-7.5" />
           {label}
         </Link>
       ))}

--- a/src/widgets/hall-of-fame/ui/HallOfFame.tsx
+++ b/src/widgets/hall-of-fame/ui/HallOfFame.tsx
@@ -6,6 +6,7 @@ import { contestQueries } from '@/entities/contest'
 import { MOCK_RANKING_ENTRIES } from '@/shared/mocks/hallOfFame'
 import type { ContestEntry } from '@/shared/types'
 import { Container, DetailLink, ImageDetailModal } from '@/shared/ui'
+import { flattenPages } from '@/shared/lib/infiniteList'
 import { HallOfFamePodium } from './HallOfFamePodium'
 
 const CARD_COUNT = 3
@@ -17,7 +18,10 @@ const HallOfFame = () => {
     ...contestQueries.hallOfFame(CARD_COUNT),
     throwOnError: false,
   })
-  const winners = (data?.pages[0]?.items ?? []).slice(0, CARD_COUNT).map((item) => item.winner)
+  // [refactored] 손수 pages[0] 까던 것 → 기존 flattenPages 헬퍼로 통일
+  const winners = flattenPages(data)
+    .slice(0, CARD_COUNT)
+    .map((item) => item.winner)
 
   // ponytail SSL 인증서 복구 전 홈 UI 확인용 폴백
   const cards: (ContestEntry | undefined)[] = winners.length > 0 ? winners : MOCK_RANKING_ENTRIES


### PR DESCRIPTION
Closes #251

## 변경 사항

**1440 초과 레이아웃 상한** (`c388ebf`)

`PAGE_WIDTH_CLASS`가 `mx-auto w-full`이라 상한이 없었다. `mx-auto`가 있어도 `w-full`이면 늘 뷰포트 전체를 먹어서 가운데 정렬이 발동할 일이 없다. 그 안에서 각 위젯은 pc 고정폭을 쓰기 때문에(명예의 동물: 좌측 컬럼 204px + 시상대 1057px = 약 1297px) 1440을 넘기면 그 덩어리가 좌측에 붙고 오른쪽에 빈 공간만 남았다.

`max-w-[90rem]`(1440) 한 줄 추가. 이 상수를 `Container`(→ `ShowcaseSection` 경유로 명예의 동물·분양중인 동물·커뮤니티·카테고리 전부), `Gnb`, `TabBar`, `BottomNav`가 공유하므로 한 곳만 막으면 끝난다. `Banner`(Swiper `centeredSlides`)와 `SearchSection`(`items-center`)은 원래 자기가 가운데 정렬하고 있어 손대지 않았다.

**분양중인 동물 실 API 연결** (`b8a471b`)

"분양 목록 API가 카드 타입과 불일치"라는 주석이 붙어 목데이터를 쓰고 있었는데, `shared/lib/mapAdoptionCard.ts`가 이미 `AdoptionPetCard → AdoptionListingCard` 변환을 하고 explore·북마크·브리더홈·입양상세가 전부 실 API를 쓰는 상태였다. 홈 쇼케이스만 그 시점에 멈춰 있었다.

`adoptionQueries.list('latest', undefined, 'available', undefined, 4)` + `mapAdoptionCard`로 연결. `throwOnError: false`는 홈 섹션 비필수 정책 그대로. 목업은 명예의 동물과 같은 방식으로 응답이 빌 때만 폴백한다.

참고로 이름상 이 섹션용인 `/home/available-pets`는 쓸 수 없다. DTO에 `gender`, `status`, `isPopular`, `isFavorited`가 없어서 성별 아이콘·분양상태 배지·인기 배지·하트 토글을 채울 수 없다. `GET /adoption`의 `AdoptionPetResponseDto`에는 넷 다 있다.

**flattenPages 통일** (`8b3d5ab`)

`data?.pages[0]?.items ?? []`를 손수 까던 3곳을 기존 `flattenPages` 헬퍼로 바꿨다. 이미 12개 파일이 쓰는 방식이고, `HallOfFameContent`는 같은 파일에서 `flattenPages`를 import해 쓰면서 이 한 줄만 손수 까고 있었다. 남은 `pages[0]` 두 곳은 용도가 달라 두었다(`adoption/[id]/page.tsx`는 의도적으로 첫 페이지만, `adoption.mutations.ts`는 `items`가 아니라 `pagination.totalItems`).

**상단바 피그마 정렬** (`0a1c93d`) — Figma 740-66523

| 항목 | 이전 | 변경 |
|---|---|---|
| 헤더 높이 | 없음 | `h-12`(mo 48) / `pc:h-16`(64) |
| 세로 여백 | pc만 8px | `tab:py-2` 추가 |
| 좌우 여백 | 16 / 48 / 100 | 16 / 48 / **80** (`pc:px-20`) |
| 로고 | 96x32 고정 | `h-7 tab:h-8` (mo 28 / tab+ 32) |
| nav 항목 간격 | 20px | 16px |
| 아이콘-라벨 간격 | 0 | 2px |
| nav 아이콘 | 32px | 30px |
| nav 라벨 | 16px | 14px medium |
| nav 기본 색 | `neutral-500` | `secondary-500` (#f6c65d) |
| 햄버거 색 | 상속(검정) | `primary-500` (#ad651d) |

pc 좌우 여백이 100px이고 채팅 페이지만 80px로 예외 처리돼 있었는데, 피그마가 전부 80이라 그 분기를 없앴다. pc 여백 80 + 셸 상한 1440 = 콘텐츠 1280으로 피그마 내부 프레임의 `max-w-1280`과 정확히 맞아 별도 클래스는 넣지 않았다.

## 확인 방법

1. 홈에서 브라우저 폭을 2000px까지 늘려 셸이 1440에 고정되고 좌우 여백만 늘어나는지
2. 1440 이하에서 기존과 동일하게 보이는지
3. 분양중인 동물 카드에 실제 분양글이 뜨고 하트·인기 배지·분양상태가 정상인지
4. 상단바를 375 / 768 / 1440에서 각각 피그마와 대조

## 리뷰 시 확인 부탁

- **pc 로그인/회원가입 버튼**: 피그마 pc 프레임에 로고 + nav + 햄버거만 있고 auth 버튼이 없다. 지우면 로그아웃 진입점이 햄버거 메뉴에만 남아서 임의로 지우지 않고 유지했다. 별도 프레임인지 실제로 빠지는지 확인 필요.
- **nav active 색**: 프레임이 전부 Default라 활성 상태가 없다. 기존 동작(`neutral-850` semibold) 유지하고 비활성만 `secondary-500`으로 바꿨다.
- **마이홈 아이콘 원**: `bg-current`라 이제 골드로 뜬다. 피그마는 회색 원(#ededed)인데, 이 아이콘은 `MAIN_NAV`에서 BottomNav와 공유하고 원 색이 활성 표시 역할을 해서 건드리지 않았다.

`pnpm type-check`, `pnpm lint` 통과.