### PR TITLE
fix(home): 즐겨찾는 브리더 카드 별 상태를 서버 값과 낙관적 갱신으로 전환

### DIFF
--- a/src/app/(main)/home/_ui/FavoriteBreedersContent.tsx
+++ b/src/app/(main)/home/_ui/FavoriteBreedersContent.tsx
@@ -18,8 +18,7 @@ const toBreederCardModel = (breeder: FavoriteBreederCard): FavoriteBreeder => ({
   location: breeder.breederLocation,
   date: breeder.addedAt,
   level: breeder.level,
-  // 이 목록 자체가 즐겨찾기한 브리더라 항상 등록 상태
-  isFavorited: true,
+  isFavorited: breeder.isFavorited,
 })
 
 const FavoriteBreedersContent = () => {

--- a/src/features/adopter/api/adopter.mutations.ts
+++ b/src/features/adopter/api/adopter.mutations.ts
@@ -1,6 +1,11 @@
 'use client'
 
-import { useMutation, useQueryClient, type QueryClient } from '@tanstack/react-query'
+import {
+  useMutation,
+  useQueryClient,
+  type InfiniteData,
+  type QueryClient,
+} from '@tanstack/react-query'
 import { adopterQueries } from '@/entities/adopter'
 import { breederQueries } from '@/entities/breeder'
 import { communityQueries } from '@/entities/community'
@@ -14,6 +19,8 @@ import {
 } from './adopter.api'
 import type {
   AdopterProfileUpdateRequest,
+  FavoriteBreederCard,
+  PaginationResponse,
   ReviewCreateRequest,
   WithdrawReason,
 } from '@/shared/types'
@@ -62,10 +69,34 @@ export const useAddFavorite = () => {
   })
 }
 
+/**
+ * 즐겨찾는 브리더 목록 캐시에서 해당 카드를 즉시 제거한다.
+ * 목록은 등록된 브리더만 반환해(isFavorited 항상 true) 재조회 전까지 카드가 채워진 별로 남는다.
+ */
+const dropFromFavoriteList = (qc: QueryClient, breederId: string) =>
+  qc.setQueriesData<InfiniteData<PaginationResponse<FavoriteBreederCard>>>(
+    { queryKey: [...profileQueries.all(), 'favoriteBreeders'] },
+    (data) =>
+      data && {
+        ...data,
+        pages: data.pages.map((page) => ({
+          ...page,
+          items: page.items.filter((breeder) => breeder.breederId !== breederId),
+        })),
+      },
+  )
+
 export const useRemoveFavorite = () => {
   const qc = useQueryClient()
   return useMutation({
     mutationFn: (breederId: string) => removeFavorite(breederId),
+    onMutate: (breederId) => {
+      dropFromFavoriteList(qc, breederId)
+    },
+    // ponytail: 롤백 스냅샷 대신 재조회로 되돌린다 (실패는 드물고 서버가 정답)
+    onError: () => {
+      void qc.invalidateQueries({ queryKey: profileQueries.favoriteBreeders().queryKey })
+    },
     onSuccess: () => {
       void invalidateFavoriteCaches(qc)
     },

--- a/src/shared/types/ProfileTypes.ts
+++ b/src/shared/types/ProfileTypes.ts
@@ -57,6 +57,7 @@ export interface FavoriteBreederCard {
   bpm: number
   level: BreederLevel
   addedAt: string
+  isFavorited: boolean
 }
 
 /**


### PR DESCRIPTION
## 연관 이슈

close #253

---

## 작업 유형

- [ ] feat: 새 기능
- [x] fix: 버그 수정
- [ ] refactor: 리팩토링
- [ ] style: UI/스타일 변경
- [ ] chore: 빌드·설정·의존성
- [ ] docs: 문서

---

## 작업 내용

PR #252 코드리뷰 지적 [2/3] 후속.

`FavoriteBreedersContent` 가 카드의 `isFavorited` 를 `true` 로 하드코딩해, 즐겨찾기 해제 후 목록이 재조회될 때까지 별이 채워진 채 남는 구간이 있었습니다.

- 백엔드가 `GET /v2/profile/me/favorite-breeders` 응답에 `isFavorited` 를 추가 (backend `5c03a63`, dev 배포됨) → 하드코딩을 서버 값으로 교체
- `useRemoveFavorite` 에 `onMutate` 추가 — 해제 즉시 즐겨찾기 목록 캐시(무한스크롤 페이지 전체)에서 해당 카드를 제거
- 실패 시엔 스냅샷 복원 대신 해당 목록만 `invalidateQueries` 로 되돌림 (서버가 정답, 실패 빈도 낮음)

> 배포 순서: 백엔드 dev 반영이 선행되어야 합니다 (이미 푸시 완료).

---

## 스크린샷

UI 레이아웃 변경 없음 — 별 아이콘 상태/타이밍만 변경.

---

## 체크리스트

- [x] 타입 에러 없음 (`tsc --noEmit`)
- [x] 린트 통과 (`eslint`)
- [x] 셀프 리뷰 완료
