### PR TITLE
fix(home): 팔로우 버튼을 실제 팔로우/언팔로우 API에 연결

### DIFF
--- a/src/app/(main)/home/_lib/toMyProfileCardProps.ts
+++ b/src/app/(main)/home/_lib/toMyProfileCardProps.ts
@@ -38,7 +38,9 @@ export const toMyProfileCardProps = (profile: MyProfile): MyProfileCardProps => 
         district: profile.businessLocation?.district ?? '',
         address: profile.businessLocation?.address,
       },
+      // 내 홈은 팔로우/즐겨찾기 액션이 없어 자기 자신 기준 false 로 채운다
       isFavorited: false,
+      isFollowing: false,
     },
   }
 }

--- a/src/app/(main)/home/_ui/ProfileCard.tsx
+++ b/src/app/(main)/home/_ui/ProfileCard.tsx
@@ -19,7 +19,7 @@ import {
 import { cn } from '@/shared/lib/cn'
 import { LocationOnIcon } from '@/shared/assets/icons'
 import { profileQueries } from '@/entities/profile'
-import { useUnfollowUser, useRemoveFollower } from '@/features/profile'
+import { useFollowUser, useUnfollowUser, useRemoveFollower } from '@/features/profile'
 import type {
   AdopterPublicProfile,
   BreederPublicProfile,
@@ -139,28 +139,46 @@ const MessageButton = () => (
   </Button>
 )
 
+interface VisitorActionsProps {
+  /** 팔로우 대상 — 입양자는 userId, 브리더는 breederId (백엔드 팔로우 대상은 양쪽 모두 허용) */
+  targetId: string
+  isFollowing: boolean
+}
+
 // 시안의 팔로우는 point 색 BaseButton(최대 258).
 // 공통 FollowButton 은 팔로워 모달용 muted pill 이라 여기서는 쓰지 않는다
-const FollowActionButton = () => (
-  <Button variant="primary" className={cn(ACTION_SIZE, 'pc:max-w-[16.125rem]')}>
-    팔로우
-  </Button>
-)
+const FollowActionButton = ({ targetId, isFollowing }: VisitorActionsProps) => {
+  const follow = useFollowUser()
+  const unfollow = useUnfollowUser()
+  const isPending = follow.isPending || unfollow.isPending
+
+  return (
+    <Button
+      variant={isFollowing ? 'outline' : 'primary'}
+      disabled={isPending}
+      onClick={() => (isFollowing ? unfollow : follow).mutate(targetId)}
+      className={cn(ACTION_SIZE, 'pc:max-w-[16.125rem]')}
+    >
+      {isFollowing ? '팔로잉' : '팔로우'}
+    </Button>
+  )
+}
 
 // 팔로우가 앞, 메시지가 뒤 — 입양자·브리더 홈 동일
-const VisitorActions = () => (
+const VisitorActions = (props: VisitorActionsProps) => (
   <>
-    <FollowActionButton />
+    <FollowActionButton {...props} />
     <MessageButton />
   </>
 )
 
+// 내 홈 액션은 props 를 쓰지 않는다 (같은 자리에서 렌더되므로 시그니처만 맞춤)
 const ACTION_MAP = {
   mine: MineActions,
   'mine-breeder': MineActions,
   breeder: VisitorActions,
   other: VisitorActions,
-} satisfies Record<ProfileMode, ComponentType>
+} satisfies Record<ProfileMode, ComponentType<VisitorActionsProps>>
 
 /* ── ProfileCard ── */
 
@@ -173,6 +191,7 @@ const ProfileCard = ({ profile, mode = 'mine' }: ProfileCardProps) => {
   const breederProfile = 'businessLocation' in profile ? profile : null
   const isBreederProfile = breederProfile !== null
   const profileUserId = breederProfile?.breederId ?? (profile as AdopterPublicProfile).userId
+  const isFollowing = breederProfile?.isFollowing ?? (profile as AdopterPublicProfile).isFollowing
 
   // 친구 목록 — 모달이 열릴 때만 조회
   const followersQuery = useInfiniteQuery(profileQueries.followers(profileUserId, followOpen))
@@ -230,7 +249,7 @@ const ProfileCard = ({ profile, mode = 'mine' }: ProfileCardProps) => {
         </div>
         {/* 하단: 모드별 버튼 (풀폭, gap-10, h-40) */}
         <div className="flex w-full items-start gap-2.5">
-          <Actions />
+          <Actions targetId={profileUserId} isFollowing={isFollowing} />
         </div>
       </div>
 
@@ -288,7 +307,7 @@ const ProfileCard = ({ profile, mode = 'mine' }: ProfileCardProps) => {
               mode === 'breeder' ? 'max-w-[48rem]' : 'max-w-[43rem] px-5',
             )}
           >
-            <Actions />
+            <Actions targetId={profileUserId} isFollowing={isFollowing} />
           </div>
         </div>
       </div>

--- a/src/features/profile/api/profile.mutations.ts
+++ b/src/features/profile/api/profile.mutations.ts
@@ -1,6 +1,7 @@
 'use client'
 
-import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient, type QueryClient } from '@tanstack/react-query'
+import { breederQueries } from '@/entities/breeder'
 import { profileQueries } from '@/entities/profile'
 import type { UpdateMyProfileRequest } from '@/shared/types'
 import { updateMyProfile, followUser, unfollowUser, removeFollower } from './profile.api'
@@ -15,12 +16,22 @@ export const useUpdateMyProfile = () => {
   })
 }
 
+/**
+ * 팔로우 관계가 바뀌면 프로필 루트뿐 아니라 브리더 루트도 지운다 —
+ * 브리더홈의 isFollowing/followerCount 는 breederQueries 쪽 캐시에 있다.
+ */
+const invalidateFollowCaches = (qc: QueryClient) =>
+  Promise.all([
+    qc.invalidateQueries({ queryKey: profileQueries.all() }),
+    qc.invalidateQueries({ queryKey: breederQueries.all() }),
+  ])
+
 export const useFollowUser = () => {
   const qc = useQueryClient()
   return useMutation({
     mutationFn: (userId: string) => followUser(userId),
     onSuccess: () => {
-      void qc.invalidateQueries({ queryKey: profileQueries.all() })
+      void invalidateFollowCaches(qc)
     },
   })
 }
@@ -30,7 +41,7 @@ export const useUnfollowUser = () => {
   return useMutation({
     mutationFn: (userId: string) => unfollowUser(userId),
     onSuccess: () => {
-      void qc.invalidateQueries({ queryKey: profileQueries.all() })
+      void invalidateFollowCaches(qc)
     },
   })
 }

--- a/src/shared/types/BreederTypes.ts
+++ b/src/shared/types/BreederTypes.ts
@@ -165,7 +165,6 @@ export interface BreederPublicProfile {
   longDescription?: string
   bpm: number
   followerCount: number
-  /** 내가 팔로우하는 수 (브리더는 항상 0) */
   followingCount?: number
   level: BreederLevel
   plan: 'basic' | 'pro'
@@ -175,6 +174,8 @@ export interface BreederPublicProfile {
     address?: string
   }
   isFavorited: boolean
+  /** 로그인 사용자가 이 브리더를 팔로우 중인지 (비로그인/본인 조회는 false) */
+  isFollowing: boolean
 }
 
 /** 브리더 프로필 수정 요청 — Partial<BreederProfileInfoDto> 기반 */


### PR DESCRIPTION
## 연관 이슈

close #255

---

## 작업 유형

- [ ] feat: 새 기능
- [x] fix: 버그 수정
- [ ] refactor: 리팩토링
- [ ] style: UI/스타일 변경
- [ ] chore: 빌드·설정·의존성
- [ ] docs: 문서

---

## 작업 내용

`ProfileCard` 의 팔로우 버튼이 `onClick` 없는 정적 버튼이라 유저홈·브리더홈 어디서도 팔로우가 되지 않았습니다.

- `FollowActionButton` 을 `useFollowUser` / `useUnfollowUser` 에 연결, `isFollowing` 에 따라 **팔로우(primary) ↔ 팔로잉(outline)** 토글하고 요청 중에는 비활성화
- `BreederPublicProfile` 에 `isFollowing` 추가 — 백엔드가 브리더 공개 프로필에 이 필드를 내려주기 시작 (backend `858e3cd`, dev 반영됨)
- 팔로우 뮤테이션 무효화 범위에 `breederQueries` 추가 — 브리더홈의 `isFollowing`/`followerCount` 는 `profileQueries` 가 아니라 `breederQueries` 캐시에 있어, 기존 무효화만으로는 버튼 상태가 갱신되지 않습니다

### 백엔드 동반 변경 (`858e3cd`, dev 반영 완료)
- 팔로우 대상 검증이 입양자만 허용해 브리더 팔로우가 400 이던 것을 브리더까지 확장
- `Breeder.stats` 에 `followerCount`/`followingCount` 신설
- ⚠️ 브리더 홈의 팔로워 수가 그동안 **즐겨찾기 수**를 표시하고 있었고, 이제 실제 팔로워 수라 기존 브리더는 0부터 시작합니다

---

## 범위 밖

메시지 버튼은 손대지 않았습니다. `POST /v2/chat/rooms` 계약이 `breederId` 필수라 입양자 홈(`mode="other"`)에서는 방을 만들 수 없습니다 — 참여자 일반화는 별도 논의 대상입니다.

---

## 스크린샷

<!-- 팔로우 → 팔로잉 토글 -->

---

## 체크리스트

- [x] 타입 에러 없음 (`tsc --noEmit`)
- [x] 린트 통과 (`eslint`)
- [x] 셀프 리뷰 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)