### PR TITLE
fix(home): 홈 상단바 타이틀과 탭 바·프로필 카드 레이아웃 정리

### DIFF
--- a/src/app/(main)/home/[userId]/_ui/BreederHomeContent.tsx
+++ b/src/app/(main)/home/[userId]/_ui/BreederHomeContent.tsx
@@ -59,7 +59,7 @@ const BreederHomeContent = ({ userId }: BreederHomeContentProps) => {
   return (
     <div className="flex w-full flex-col">
       <NavigationBar
-        title="Breeder"
+        title={`${profile.nickname}의 홈`}
         right={
           <FavoriteBreederIconButton
             breederId={profile.breederId}

--- a/src/app/(main)/home/[userId]/_ui/BreederHomeContent.tsx
+++ b/src/app/(main)/home/[userId]/_ui/BreederHomeContent.tsx
@@ -20,7 +20,6 @@ import { FavoriteBreederIconButton } from '../../_ui/FavoriteBreederIconButton'
 import { FavoriteAdoptionCard } from '@/features/adoption'
 import { HomeTabs, TabsContent } from '../../_ui/HomeTabs'
 import { PostList } from '../../_ui/PostList'
-import { FooterPlaceholder } from '../../_ui/FooterPlaceholder'
 import { BREEDER_HOME_TABS } from '../../_ui/constants'
 
 // 이 탭이 곧 분양글 목록 전체라 마이홈 프리뷰(6)보다 크게 받는다 (서버 상한 60)
@@ -70,7 +69,7 @@ const BreederHomeContent = ({ userId }: BreederHomeContentProps) => {
         }
       />
 
-      <Container className="pc:px-[10rem]">
+      <Container className="px-4 py-5 tab:py-10">
         <ProfileCard profile={profile} mode="breeder" />
       </Container>
 
@@ -132,8 +131,6 @@ const BreederHomeContent = ({ userId }: BreederHomeContentProps) => {
           </Container>
         </TabsContent>
       </HomeTabs>
-
-      <FooterPlaceholder />
     </div>
   )
 }

--- a/src/app/(main)/home/[userId]/_ui/UserHomeContent.tsx
+++ b/src/app/(main)/home/[userId]/_ui/UserHomeContent.tsx
@@ -7,7 +7,6 @@ import { adopterQueries } from '@/entities/adopter'
 import { communityQueries } from '@/entities/community'
 import { ProfileCard } from '../../_ui/ProfileCard'
 import { PostList } from '../../_ui/PostList'
-import { FooterPlaceholder } from '../../_ui/FooterPlaceholder'
 
 const HOME_POST_PAGE_SIZE = 30
 
@@ -34,7 +33,7 @@ const UserHomeContent = ({ userId }: UserHomeContentProps) => {
     <div className="flex w-full flex-col">
       <NavigationBar title={`${profile.nickname}의 홈`} />
 
-      <Container className="px-4 pt-5">
+      <Container className="px-4 py-5 tab:py-10">
         <ProfileCard profile={profile} mode="other" />
       </Container>
 
@@ -56,8 +55,6 @@ const UserHomeContent = ({ userId }: UserHomeContentProps) => {
           isFetchingNextPage={isFetchingNextPage}
         />
       </Container>
-
-      <FooterPlaceholder />
     </div>
   )
 }

--- a/src/app/(main)/home/[userId]/_ui/UserHomeContent.tsx
+++ b/src/app/(main)/home/[userId]/_ui/UserHomeContent.tsx
@@ -32,7 +32,7 @@ const UserHomeContent = ({ userId }: UserHomeContentProps) => {
 
   return (
     <div className="flex w-full flex-col">
-      <NavigationBar title={profile.nickname} />
+      <NavigationBar title={`${profile.nickname}의 홈`} />
 
       <Container className="px-4 pt-5">
         <ProfileCard profile={profile} mode="other" />

--- a/src/app/(main)/home/_ui/FooterPlaceholder.tsx
+++ b/src/app/(main)/home/_ui/FooterPlaceholder.tsx
@@ -1,5 +1,0 @@
-const FooterPlaceholder = () => {
-  return <div className="mt-8 h-[22.1rem] w-full bg-surface-placeholder" />
-}
-
-export { FooterPlaceholder }

--- a/src/shared/ui/TabBar.tsx
+++ b/src/shared/ui/TabBar.tsx
@@ -41,13 +41,13 @@ const TabBar = ({
 }: TabBarProps) => {
   return (
     <Tabs value={value} onValueChange={onValueChange} className={cn('w-full', className)}>
+      {/* 폭은 페이지 셸과 동일(PAGE_WIDTH_CLASS) — 하단 구분선도 1440에서 끊기도록 바 자체에 상한을 건다.
+          여백만 탭 바 디자인에 맞춤. Container를 쓰지 않는 이유: tab/pc는 Container와 같지만 모바일만 16px(Container는 20px). */}
       <div
-        className={cn('w-full border-b border-neutral-300 bg-white', barClassName)}
+        className={cn(PAGE_WIDTH_CLASS, 'border-b border-neutral-300 bg-white', barClassName)}
         style={barStyle}
       >
-        {/* 폭은 페이지 셸과 동일(PAGE_WIDTH_CLASS), 여백만 탭 바 디자인에 맞춤.
-            Container를 쓰지 않는 이유: tab/pc는 Container와 같지만 모바일만 16px(Container는 20px). */}
-        <div className={cn(PAGE_WIDTH_CLASS, 'px-4 pt-3 tab:px-12 tab:pt-4 pc:px-20')}>
+        <div className="px-4 pt-3 tab:px-12 tab:pt-4 pc:px-20">
           <TabsList variant="underline" aria-label={ariaLabel}>
             {items.map((item) => (
               <TabsTrigger


### PR DESCRIPTION
Closes #257

## Changes
- 브리더 홈 상단바 하드코딩 "Breeder" 제거 → `{닉네임}의 홈`, 입양자 홈도 동일 포맷
- 탭 바 하단 구분선/배경에 페이지 셸과 같은 1440(`PAGE_WIDTH_CLASS`) 상한 적용
  - `shared/ui/TabBar.tsx` 공통 수정이라 홈·탐색(/explore)·북마크(/bookmarks) 탭에 함께 반영
- 홈 하단 회색 더미 `FooterPlaceholder` 제거 (사용처 2곳 + 파일 삭제)
- 프로필 카드 래퍼를 브리더/입양자 동일하게 `Container` + `px-4 py-5 tab:py-10`으로 통일
  - 브리더 쪽 `pc:px-[10rem]` 제거

## How to test
1. `/home/{브리더ID}` — 상단바가 `{닉네임}의 홈`, 1577px 폭에서 탭 하단 구분선이 1440에서 끊기는지
2. `/home/{입양자ID}` — 동일 타이틀 포맷, 프로필 카드 좌우 여백이 브리더 홈과 일치
3. `/explore`, `/bookmarks` — 탭 바 sticky/구분선 정상
4. 두 홈 모두 하단 회색 박스 사라짐