### PR TITLE
fix(home): 기준폭 사이 구간에서 깨지던 홈·명예의 전당 레이아웃 정리

### DIFF
--- a/src/app/(main)/hall-of-fame/_ui/HallOfFameContent.tsx
+++ b/src/app/(main)/hall-of-fame/_ui/HallOfFameContent.tsx
@@ -96,7 +96,7 @@ const HallOfFameContent = () => {
                   화살표는 마지막 줄 끝에 붙여 흐르게 둔다 (세로 가운데 띄우면 어색) */}
               <Link
                 href="/hall-of-fame/participate"
-                className="text-right text-xs leading-[1.5] font-semibold text-neutral-850 tab:text-left pc:w-[9.0625rem]"
+                className="text-right text-xs leading-[1.5] font-semibold text-[#c75a00] tab:text-left pc:w-[9.0625rem]"
               >
                 이번주 명예의 전당{' '}
                 <span className="block tab:inline pc:block">

--- a/src/app/(main)/hall-of-fame/_ui/HallOfFameContent.tsx
+++ b/src/app/(main)/hall-of-fame/_ui/HallOfFameContent.tsx
@@ -109,7 +109,7 @@ const HallOfFameContent = () => {
             <HallOfFamePodium
               entries={podiumEntries}
               onEntryClick={setSelectedEntry}
-              className="pc:h-[26rem] pc:w-[65rem]"
+              className="pc:h-[26rem] pc:min-w-0 pc:shrink pc:flex-1"
             />
           </div>
         </Container>

--- a/src/app/(main)/hall-of-fame/_ui/HallOfFameContent.tsx
+++ b/src/app/(main)/hall-of-fame/_ui/HallOfFameContent.tsx
@@ -75,6 +75,10 @@ const HallOfFameContent = () => {
     voteEntry.mutate(entryId)
   }
 
+  // 서버가 같은 상태(콘테스트 없음)를 /current는 200+null, /entries는 400으로 다르게 응답한다.
+  // 후보 목록 실패를 그대로 에러로 보여주면 "불러오지 못했습니다"라는 거짓 문구가 뜬다
+  const hasNoContest = currentContest === null
+
   const votedEntryId =
     currentContest?.myVotedEntryId ?? entries.find((entry) => entry.hasVoted)?.id ?? null
   const hasContestVote = votedEntryId !== null
@@ -123,11 +127,13 @@ const HallOfFameContent = () => {
 
           <ListState
             isPending={areEntriesPending}
-            isError={areEntriesError}
+            isError={areEntriesError && !hasNoContest}
             isEmpty={entries.length === 0}
             loadingText="투표 후보를 불러오는 중입니다."
             errorText="투표 후보를 불러오지 못했습니다."
-            emptyText="아직 등록된 투표 후보가 없습니다."
+            emptyText={
+              hasNoContest ? '진행 중인 콘테스트가 없습니다.' : '아직 등록된 투표 후보가 없습니다.'
+            }
           >
             <>
               <div className="grid grid-cols-2 gap-4 tab:grid-cols-3 tab:gap-5 pc:grid-cols-4">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,7 +6,9 @@
 @theme {
   --breakpoint-mo: 375px;
   --breakpoint-tab: 768px;
-  --breakpoint-pc: 1440px;
+  /* 셸 상한(max-w-[90rem], 1440)과 같은 값이면 스크롤바 폭 때문에 1440 모니터에서 pc:가 끝내 안 켜진다.
+     디자인 기준은 1440 그대로 두고 진입점만 노트북 폭으로 내린다 */
+  --breakpoint-pc: 1280px;
 
   /* typography — Body 스케일 (line-height 150% 포함). weight는 font-* 유틸로: font-normal/medium/semibold */
   --text-body-sm: 0.75rem; /* 12 */

--- a/src/entities/community/ui/CommunityBox.tsx
+++ b/src/entities/community/ui/CommunityBox.tsx
@@ -58,7 +58,8 @@ const CommunityBox = ({
   return (
     <article
       className={cn(
-        'flex h-[20.5625rem] w-[20.0625rem] flex-col items-start overflow-hidden rounded-lg border border-neutral-300 bg-white p-3 pc:h-[23.5rem] pc:w-[25.4375rem]',
+        // 카드 폭이 그리드를 채우므로 높이도 고정값이 아닌 비율로 — 디자인 기준(tab 321x329 / pc 407x376)
+        'flex aspect-[321/329] w-full flex-col items-start overflow-hidden rounded-lg border border-neutral-300 bg-white p-3 pc:aspect-[407/376]',
         // Figma hover/press (923-18992): 배경 #f6f6f6 + drop shadow
         'transition-[background-color,box-shadow] hover:bg-neutral-50 hover:shadow-[0_7px_7px_0_rgba(55,55,55,0.1)] active:bg-neutral-50 active:shadow-[0_7px_7px_0_rgba(55,55,55,0.1)]',
         className,

--- a/src/widgets/adoption-showcase/ui/AdoptionShowcase.tsx
+++ b/src/widgets/adoption-showcase/ui/AdoptionShowcase.tsx
@@ -23,8 +23,10 @@ const AdoptionShowcase = () => {
 
   return (
     <ShowcaseSection title="분양중인 동물" linkText="탐색 바로가기" linkHref="/explore">
-      {/* 모바일 2열 / 태블릿·PC 4열 (탭 164px, PC 282px 카드) */}
-      <div className="grid grid-cols-[repeat(2,10.25rem)] justify-between gap-x-0 gap-y-5 tab:grid-cols-[repeat(4,10.25rem)] tab:gap-y-0 pc:grid-cols-4 pc:gap-[3.125rem]">
+      {/* 모바일 2열 / 태블릿·PC 4열. 전 구간 고정폭이 아니라 비율 컬럼 —
+          고정 164px + justify-between이면 기준폭(375/768)을 벗어나는 순간
+          남는 폭이 전부 카드 사이 간격으로 벌어졌다 */}
+      <div className="grid grid-cols-2 gap-x-[0.9375rem] gap-y-5 tab:grid-cols-4 tab:gap-x-5 tab:gap-y-0 pc:gap-x-[3.125rem]">
         {listings.map((listing) => (
           <FavoriteAdoptionShowcaseCard key={listing.listingId} listing={listing} />
         ))}

--- a/src/widgets/community-showcase/ui/CommunityShowcase.tsx
+++ b/src/widgets/community-showcase/ui/CommunityShowcase.tsx
@@ -30,7 +30,7 @@ const CommunityShowcase = () => {
   return (
     <ShowcaseSection title="동물 자랑하기" linkText="커뮤니티 바로가기" linkHref="/community">
       {/* 한 DOM 목록을 브레이크포인트별 그리드로 재배치한다. */}
-      <div className="grid grid-cols-[20.0625rem] justify-center gap-y-2 tab:grid-cols-[repeat(2,20.0625rem)] tab:justify-between pc:grid-cols-[repeat(3,25.4375rem)] pc:gap-y-0">
+      <div className="grid grid-cols-1 gap-y-2 tab:grid-cols-2 tab:gap-x-[1.875rem] pc:grid-cols-3 pc:gap-y-0">
         {posts.map((post, index) => (
           <Card
             key={post.detailHref ?? index}

--- a/src/widgets/hall-of-fame/ui/HallOfFamePodium.tsx
+++ b/src/widgets/hall-of-fame/ui/HallOfFamePodium.tsx
@@ -219,7 +219,7 @@ const HallOfFamePodium = ({ entries, onEntryClick, className }: HallOfFamePodium
   return (
     <div
       className={cn(
-        'relative flex h-[13.8125rem] w-full shrink-0 items-center overflow-hidden rounded-xl bg-secondary-200 px-4 py-8 tab:h-[16.8rem] tab:items-start tab:justify-center tab:p-8 pc:h-[26.425rem] pc:w-[66.0625rem]',
+        'relative flex h-[13.8125rem] w-full shrink-0 items-center overflow-hidden rounded-xl bg-secondary-200 px-4 py-8 tab:h-[16.8rem] tab:items-start tab:justify-center tab:p-8 pc:h-[26.425rem] pc:min-w-0 pc:shrink pc:flex-1',
         className,
       )}
     >


### PR DESCRIPTION
Closes #259

## Changes
- `--breakpoint-pc` 1440 -> 1280. 셸 상한 `max-w-[90rem]`(1440)과 값이 같아, 스크롤바 폭 때문에 1440 모니터에서 `pc:` 스타일이 끝내 적용되지 않던 문제
- 홈 쇼케이스 그리드를 고정폭 컬럼에서 비율 컬럼으로 전환. `CommunityBox`는 고정 높이 대신 `aspect` 사용 (폭이 늘면 높이도 따라가야 함)
- 명예의 전당 시상대 pc 고정폭 제거 — 1280에서 177px 오버플로. 홈 위젯과 명예의 전당 페이지 양쪽 적용
- 콘테스트 참여 유도 링크와 화살표 색상 `#c75a00` (디자인 토큰에 없어 arbitrary value 사용)
- 진행 중인 콘테스트가 없을 때 "불러오지 못했습니다" 대신 "진행 중인 콘테스트가 없습니다" 표시

## 백엔드 연계
`/contest/current`는 콘테스트가 없을 때 200 + `data: null`을 주는데 `/contest/entries`는 400을 반환해, 프론트에서 조회 실패로 잡히고 있었다. 백엔드는 `pawpong_backend@6f66dec`에서 빈 목록 응답으로 수정 완료. 이 PR의 빈 상태 처리는 서버 수정 전후 모두 동일하게 동작한다.

## How to test
1. 브라우저 폭 696 / 1096 / 1280 / 1440 / 1600에서 `/` — 쇼케이스 카드 사이가 벌어지지 않고 폭에 맞춰 늘어나는지
2. 1280에서 `/`, `/hall-of-fame` — 시상대가 가로로 넘치지 않는지
3. 기준폭 768 / 1440에서 카드 크기가 디자인 값과 일치하는지 (분양 카드 282 / 커뮤니티 카드 407x376)
4. `/hall-of-fame` — 참여 유도 링크와 화살표 색상, 콘테스트가 없을 때 빈 상태 문구