### PR TITLE
feat(search): 홈·탐색·커뮤니티 검색바를 실제 검색에 연결

### DIFF
--- a/src/app/(main)/community/_ui/CommunityContent.tsx
+++ b/src/app/(main)/community/_ui/CommunityContent.tsx
@@ -6,6 +6,7 @@ import {
   Container,
   InfiniteScrollTrigger,
   InputUpload,
+  ListState,
   NavigationBar,
   SearchButton,
   Separator,
@@ -15,14 +16,16 @@ import { ConnectedPostCard } from '@/features/community'
 import { flattenPages } from '@/shared/lib/infiniteList'
 
 const CommunityContent = () => {
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery(
-    communityQueries.posts('latest'),
-  )
-  const posts = flattenPages(data)
-
-  // ponytail: 서버 검색 API 미구현 → 지금은 검색바 펼치기 UI만. keyword 파라미터 생기면 query 연결.
+  // 입력 중인 값과 실제 조회 조건을 분리한다 — 타이핑마다 재조회하지 않도록
   const [searchOpen, setSearchOpen] = useState(false)
   const [query, setQuery] = useState('')
+  const [appliedSearch, setAppliedSearch] = useState('')
+
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isPending, isError } =
+    useInfiniteQuery(
+      communityQueries.posts('latest', undefined, undefined, appliedSearch || undefined),
+    )
+  const posts = flattenPages(data)
 
   return (
     <div className="flex w-full flex-col">
@@ -40,8 +43,13 @@ const CommunityContent = () => {
           value={query}
           onChange={setQuery}
           onClick={() => setSearchOpen(true)}
-          // 비어 있을 때 포커스 잃으면 트리거로 복귀
-          onBlur={() => query.trim() === '' && setSearchOpen(false)}
+          onSubmit={() => setAppliedSearch(query.trim())}
+          // 비어 있을 때 포커스 잃으면 트리거로 복귀 (적용된 검색어도 함께 해제)
+          onBlur={() => {
+            if (query.trim() !== '') return
+            setSearchOpen(false)
+            setAppliedSearch('')
+          }}
           // 모바일은 풀폭, tab+는 최대 300px
           className="max-w-none tab:max-w-[18.75rem]"
         />
@@ -51,14 +59,25 @@ const CommunityContent = () => {
           pc는 Figma(2063-215749) 기준 948px 고정 폭 가운데 정렬 */}
       <Container className="px-4 pb-10 tab:pb-16">
         <div className="mx-auto w-full pc:max-w-[59.25rem]">
-          <div className="flex min-w-0 flex-col gap-5 tab:gap-8 tab:rounded-lg tab:border tab:border-neutral-300 tab:p-3">
-            {posts.map((post, index) => (
-              <Fragment key={post.postId}>
-                {index > 0 && <Separator className="bg-border-light" />}
-                <ConnectedPostCard {...toCommunityPreviewProps(post)} />
-              </Fragment>
-            ))}
-          </div>
+          <ListState
+            isPending={isPending}
+            isError={isError}
+            isEmpty={posts.length === 0}
+            loadingText="게시글을 불러오는 중입니다."
+            errorText="게시글을 불러오지 못했습니다."
+            emptyText={
+              appliedSearch ? `'${appliedSearch}' 검색 결과가 없습니다.` : '게시글이 없습니다.'
+            }
+          >
+            <div className="flex min-w-0 flex-col gap-5 tab:gap-8 tab:rounded-lg tab:border tab:border-neutral-300 tab:p-3">
+              {posts.map((post, index) => (
+                <Fragment key={post.postId}>
+                  {index > 0 && <Separator className="bg-border-light" />}
+                  <ConnectedPostCard {...toCommunityPreviewProps(post)} />
+                </Fragment>
+              ))}
+            </div>
+          </ListState>
 
           <InfiniteScrollTrigger
             onIntersect={fetchNextPage}

--- a/src/app/(main)/explore/_ui/ExploreContent.tsx
+++ b/src/app/(main)/explore/_ui/ExploreContent.tsx
@@ -46,6 +46,8 @@ const ExploreContent = () => {
   const selectedType: ExploreType = typeParam === 'breeder' ? 'breeder' : 'adoption'
   const [adoptionListFilter, setAdoptionListFilter] = useState<ExploreListFilter>('all')
 
+  const keyword = searchParams.get('keyword') ?? undefined
+
   const categoryParam = searchParams.get('category')
   const selectedCategory: AnimalCategory =
     categoryParam && ANIMAL_CATEGORIES.includes(categoryParam as AnimalCategory)
@@ -64,7 +66,7 @@ const ExploreContent = () => {
     isPending,
     isError,
   } = useInfiniteQuery({
-    ...adoptionQueries.list(sort, petType, status),
+    ...adoptionQueries.list(sort, petType, status, keyword),
     enabled: selectedType === 'adoption',
   })
 
@@ -98,6 +100,21 @@ const ExploreContent = () => {
         params.delete('category')
       } else {
         params.set('category', category)
+      }
+      const query = params.toString()
+      router.replace(`${pathname}${query ? `?${query}` : ''}`, { scroll: false })
+    },
+    [searchParams, router, pathname],
+  )
+
+  // 검색어는 카테고리·필터와 함께 URL에 실어 서버 조회 조건으로 합류시킨다
+  const handleSearch = useCallback(
+    (nextKeyword: string) => {
+      const params = new URLSearchParams(searchParams.toString())
+      if (nextKeyword) {
+        params.set('keyword', nextKeyword)
+      } else {
+        params.delete('keyword')
       }
       const query = params.toString()
       router.replace(`${pathname}${query ? `?${query}` : ''}`, { scroll: false })
@@ -167,7 +184,11 @@ const ExploreContent = () => {
       <div>
         <CategorySection selected={selectedCategory} onChange={handleCategoryChange} />
         {/* 검색바: 홈과 동일 — SearchSection 자체 패딩 20px(py-3 tab:py-5) / 80px(pc:px-20) */}
-        <SearchSection placeholder={SEARCH_PLACEHOLDERS[selectedType]} />
+        <SearchSection
+          placeholder={SEARCH_PLACEHOLDERS[selectedType]}
+          defaultValue={keyword}
+          onSubmit={handleSearch}
+        />
       </div>
       {/* 스크롤 트리거 sentinel (상단 영역 끝) */}
       <div ref={sentinelRef} aria-hidden />

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -5,14 +5,11 @@ import { CommunityShowcase } from '@/widgets/community-showcase'
 import { SearchSection } from '@/features/search'
 import { CategoryBrowse } from '@/features/category-browse'
 
-// 인기 검색어 (Figma 2752-261253) — API 연결 전 샘플
-const POPULAR_KEYWORDS = ['비숑', '푸들', '레오파드게코', '스코티시폴드', '말티즈']
-
 // 데스크탑 홈 순서: 검색 → 배너 → 브리더 CTA·카테고리 → 명예의 동물 → 분양중인 동물 → 커뮤니티 카드
 const HomePage = () => {
   return (
     <div>
-      <SearchSection popularKeywords={POPULAR_KEYWORDS} />
+      <SearchSection showPopularKeywords />
 
       <Banner />
 

--- a/src/entities/community/api/community.api.ts
+++ b/src/entities/community/api/community.api.ts
@@ -144,6 +144,7 @@ export const getCommunityPosts = async (
   if (params.petType) query.set('petType', params.petType)
   if (params.category) query.set('category', params.category)
   if (params.authorId) query.set('authorId', params.authorId)
+  if (params.search) query.set('search', params.search)
   if (params.sort) query.set('sort', params.sort)
   if (params.page) query.set('page', String(params.page))
   if (params.pageSize) query.set('pageSize', String(params.pageSize))

--- a/src/entities/community/api/community.queries.ts
+++ b/src/entities/community/api/community.queries.ts
@@ -15,11 +15,12 @@ export const communityQueries = {
     sort: CommunitySortType = 'latest',
     petType?: CommunityPetType,
     category?: string,
+    search?: string,
     pageSize = 15,
   ) =>
     createInfiniteQuery({
-      queryKey: [...communityQueries.all(), 'posts', sort, petType, category, pageSize],
-      queryFn: (page) => getCommunityPosts({ sort, petType, category, page, pageSize }),
+      queryKey: [...communityQueries.all(), 'posts', sort, petType, category, search, pageSize],
+      queryFn: (page) => getCommunityPosts({ sort, petType, category, search, page, pageSize }),
       staleTime: STALE_TIME.DEFAULT,
     }),
 

--- a/src/features/search/index.ts
+++ b/src/features/search/index.ts
@@ -1,1 +1,2 @@
 export { SearchSection } from './ui/SearchSection'
+export { PopularKeywords } from './ui/PopularKeywords'

--- a/src/features/search/ui/PopularKeywords.tsx
+++ b/src/features/search/ui/PopularKeywords.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import { useRouter } from 'next/navigation'
+import { popularKeywordQueries } from '@/entities/popular-keyword'
+
+/** 검색바 아래 인기 검색어 칩 (Figma 2752-261253) — 누르면 해당 키워드로 탐색한다 */
+const PopularKeywords = () => {
+  const router = useRouter()
+  // 홈의 보조 정보라 실패해도 페이지는 렌더되어야 한다
+  const { data } = useQuery({ ...popularKeywordQueries.list(), throwOnError: false })
+
+  const keywords = data ?? []
+  if (keywords.length === 0) return null
+
+  return (
+    <div className="flex min-w-0 items-center gap-3 overflow-hidden">
+      <span className="shrink-0 text-xs leading-[1.5] font-medium text-neutral-700 tab:text-sm">
+        인기 검색어
+      </span>
+      <div className="flex min-w-max items-center gap-1 tab:gap-2">
+        {keywords.map(({ keywordId, keyword }) => (
+          <button
+            key={keywordId}
+            type="button"
+            onClick={() => router.push(`/explore?keyword=${encodeURIComponent(keyword)}`)}
+            className="flex h-6 items-center rounded-full border border-primary-500 px-2 text-[0.625rem] leading-[1.5] font-medium whitespace-nowrap text-primary-500 tab:h-auto tab:py-0.5 tab:text-sm"
+          >
+            {keyword}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export { PopularKeywords }

--- a/src/features/search/ui/SearchSection.tsx
+++ b/src/features/search/ui/SearchSection.tsx
@@ -11,6 +11,10 @@ interface SearchSectionProps {
   withPadding?: boolean
   /** 검색바 아래 "인기 검색어" 라벨 (홈 전용, Figma 2752-261253) — 없으면 미노출 */
   popularKeywords?: string[]
+  /** 초기 검색어 — 탐색 페이지처럼 URL에 이미 검색어가 있는 경우 */
+  defaultValue?: string
+  /** 제출 시 동작. 미지정이면 SearchBar 기본값(탐색 페이지 이동) */
+  onSubmit?: (keyword: string) => void
 }
 
 const SearchSection = ({
@@ -18,6 +22,8 @@ const SearchSection = ({
   className,
   withPadding = true,
   popularKeywords,
+  defaultValue,
+  onSubmit,
 }: SearchSectionProps) => {
   return (
     <section
@@ -28,7 +34,7 @@ const SearchSection = ({
       )}
     >
       <div className="flex w-full max-w-[21.4375rem] flex-col gap-3 tab:max-w-[30.125rem] pc:max-w-[52.875rem]">
-        <SearchBar placeholder={placeholder} />
+        <SearchBar placeholder={placeholder} defaultValue={defaultValue} onSubmit={onSubmit} />
         {popularKeywords && popularKeywords.length > 0 && (
           <div className="flex min-w-0 items-center gap-3 overflow-hidden">
             <span className="shrink-0 text-xs leading-[1.5] font-medium text-neutral-700 tab:text-sm">

--- a/src/features/search/ui/SearchSection.tsx
+++ b/src/features/search/ui/SearchSection.tsx
@@ -1,5 +1,6 @@
 import { SearchBar } from '@/shared/ui'
 import { cn } from '@/shared/lib/cn'
+import { PopularKeywords } from './PopularKeywords'
 
 interface SearchSectionProps {
   placeholder?: {
@@ -9,8 +10,8 @@ interface SearchSectionProps {
   className?: string
   /** 독립 섹션이면 페이지 좌우 마진(px) 포함(홈), 이미 컨테이너 내부면 false(explore) */
   withPadding?: boolean
-  /** 검색바 아래 "인기 검색어" 라벨 (홈 전용, Figma 2752-261253) — 없으면 미노출 */
-  popularKeywords?: string[]
+  /** 검색바 아래 인기 검색어 칩 노출 (홈 전용, Figma 2752-261253) */
+  showPopularKeywords?: boolean
   /** 초기 검색어 — 탐색 페이지처럼 URL에 이미 검색어가 있는 경우 */
   defaultValue?: string
   /** 제출 시 동작. 미지정이면 SearchBar 기본값(탐색 페이지 이동) */
@@ -21,7 +22,7 @@ const SearchSection = ({
   placeholder,
   className,
   withPadding = true,
-  popularKeywords,
+  showPopularKeywords,
   defaultValue,
   onSubmit,
 }: SearchSectionProps) => {
@@ -35,23 +36,7 @@ const SearchSection = ({
     >
       <div className="flex w-full max-w-[21.4375rem] flex-col gap-3 tab:max-w-[30.125rem] pc:max-w-[52.875rem]">
         <SearchBar placeholder={placeholder} defaultValue={defaultValue} onSubmit={onSubmit} />
-        {popularKeywords && popularKeywords.length > 0 && (
-          <div className="flex min-w-0 items-center gap-3 overflow-hidden">
-            <span className="shrink-0 text-xs leading-[1.5] font-medium text-neutral-700 tab:text-sm">
-              인기 검색어
-            </span>
-            <div className="flex min-w-max items-center gap-1 tab:gap-2">
-              {popularKeywords.map((keyword) => (
-                <span
-                  key={keyword}
-                  className="flex h-6 items-center rounded-full border border-primary-500 px-2 text-[0.625rem] leading-[1.5] font-medium whitespace-nowrap text-primary-500 tab:h-auto tab:py-0.5 tab:text-sm"
-                >
-                  {keyword}
-                </span>
-              ))}
-            </div>
-          </div>
-        )}
+        {showPopularKeywords && <PopularKeywords />}
       </div>
     </section>
   )

--- a/src/shared/types/CommunityTypes.ts
+++ b/src/shared/types/CommunityTypes.ts
@@ -83,6 +83,8 @@ export interface CommunityPostListParams {
   petType?: CommunityPetType
   category?: string
   authorId?: string
+  /** 제목·본문 키워드 검색 (대소문자 무시). 다른 필터와 AND 결합된다 */
+  search?: string
   sort?: CommunitySortType
   page?: number
   pageSize?: number

--- a/src/shared/ui/SearchBar.tsx
+++ b/src/shared/ui/SearchBar.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useRouter } from 'next/navigation'
 import { cn } from '@/shared/lib/cn'
 import { useBreakpoint } from '@/shared/lib/useBreakpoint'
 import { SearchIcon } from './SearchIcon'
@@ -9,6 +10,10 @@ interface SearchBarProps {
     mobile: string
     desktop: string
   }
+  /** 초기 입력값 — 탐색 페이지처럼 URL에 검색어가 이미 있는 경우 */
+  defaultValue?: string
+  /** 제출 시 동작. 미지정이면 탐색 페이지로 이동한다 */
+  onSubmit?: (keyword: string) => void
   className?: string
 }
 
@@ -17,13 +22,36 @@ const DEFAULT_PLACEHOLDER = {
   desktop: '검색해서 원하는 아이 찾기',
 }
 
+const INPUT_NAME = 'keyword'
+
 // Figma: tab h48 / PC h56 / rounded8 / border #a6a6a6(포커스 #256EF4 — 모바일·탭 1px / PC 2px) / p12,
 // 입력 텍스트 #3E3E3E, placeholder Pretendard medium 16px #a6a6a6, 우측 32px 검색 아이콘
-export const SearchBar = ({ placeholder = DEFAULT_PLACEHOLDER, className }: SearchBarProps) => {
+export const SearchBar = ({
+  placeholder = DEFAULT_PLACEHOLDER,
+  defaultValue,
+  onSubmit,
+  className,
+}: SearchBarProps) => {
   const isTablet = useBreakpoint('tab')
+  const router = useRouter()
+
+  // 비제어 입력 + form submit — Enter와 아이콘 클릭이 같은 경로를 타고,
+  // 페이지마다 검색어 state를 따로 들 필요가 없다
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const keyword = new FormData(event.currentTarget).get(INPUT_NAME)?.toString().trim() ?? ''
+
+    if (onSubmit) {
+      onSubmit(keyword)
+      return
+    }
+    router.push(keyword ? `/explore?keyword=${encodeURIComponent(keyword)}` : '/explore')
+  }
 
   return (
-    <div
+    <form
+      role="search"
+      onSubmit={handleSubmit}
       className={cn(
         'flex h-12 w-full items-center justify-between gap-3 rounded-lg border border-neutral-500 bg-white p-3 focus-within:border-info-500 pc:h-14 pc:focus-within:border-2',
         className,
@@ -31,10 +59,14 @@ export const SearchBar = ({ placeholder = DEFAULT_PLACEHOLDER, className }: Sear
     >
       <input
         type="text"
+        name={INPUT_NAME}
+        defaultValue={defaultValue}
         placeholder={isTablet ? placeholder.desktop : placeholder.mobile}
         className="min-w-0 flex-1 bg-transparent text-base leading-[1.5] font-medium text-neutral-850 outline-none placeholder:text-neutral-500"
       />
-      <SearchIcon className="size-8 shrink-0 text-neutral-700" />
-    </div>
+      <button type="submit" aria-label="검색" className="shrink-0">
+        <SearchIcon className="size-8 text-neutral-700" />
+      </button>
+    </form>
   )
 }

--- a/src/widgets/community-showcase/ui/CommunityShowcase.tsx
+++ b/src/widgets/community-showcase/ui/CommunityShowcase.tsx
@@ -12,7 +12,7 @@ const CARD_COUNT = 3
 const CommunityShowcase = () => {
   // 홈은 부분 실패 허용 — throwOnError만 꺼서 실패 시 목업 유지 (커뮤니티 페이지는 기본 정책)
   const { data } = useInfiniteQuery({
-    ...communityQueries.posts('latest', undefined, undefined, CARD_COUNT),
+    ...communityQueries.posts('latest', undefined, undefined, undefined, CARD_COUNT),
     throwOnError: false,
   })
   // [refactored] 손수 pages[0] 까던 것 → 기존 flattenPages 헬퍼로 통일


### PR DESCRIPTION
Closes #265

## Changes
### 검색바 (`shared/ui/SearchBar.tsx`)
`<div>` + 맨 `<input>`이라 입력값이 아무 데도 가지 않던 것을 `<form>` + submit 구조로 변경했다. 비제어 입력 + `FormData`라 Enter와 아이콘 클릭이 같은 경로를 타고, 페이지마다 검색어 state를 따로 들 필요가 없다. 아이콘은 `<button type="submit">`으로 감쌌다.

기본 동작은 `/explore?keyword=`로 이동하고, `onSubmit`을 주면 재정의된다. 덕분에 홈은 서버 컴포넌트를 유지한 채 아무 변경 없이 동작한다.

### 탐색 (`explore`)
URL의 `keyword`를 읽어 `adoptionQueries.list`에 전달한다. 쿼리 팩토리는 이미 `keyword`를 받고 있었다. 검색어 제출은 카테고리 칩과 동일하게 URL 파라미터를 갱신하므로 카테고리·정렬 필터와 AND로 결합되고, 뒤로가기·새로고침·링크 공유가 그대로 동작한다.

### 커뮤니티 (`community`)
`CommunityPostListParams`, `getCommunityPosts`, `communityQueries.posts`에 `search`를 추가하고 `SearchButton`의 `onSubmit`을 연결했다. 입력값(`query`)과 실제 조회 조건(`appliedSearch`)을 분리해 타이핑마다 재조회하지 않는다. 검색 결과가 없을 때를 위해 `ListState`도 함께 붙였다.

### 인기 검색어
`page.tsx`에 하드코딩돼 있던 샘플 배열을 지우고 `popularKeywordQueries.list()`로 전환했다. 칩이 `<span>`이라 클릭할 수 없던 것을 `<button>`으로 바꿔 누르면 해당 키워드로 탐색한다. 홈의 보조 정보라 조회 실패 시 섹션만 빠지고 페이지는 정상 렌더된다.

## 주의
`communityQueries.posts`의 인자 순서가 `(sort, petType, category, search, pageSize)`로 바뀌었다. 기존 호출부인 `CommunityShowcase`의 `pageSize` 위치를 함께 보정했다.

## 백엔드
작업 없음. `GET /adoption?keyword=`, `GET /community/posts?search=`, `GET /popular-keyword` 모두 이미 제공되고 있었다.

## How to test
1. 홈 검색바에 키워드 입력 후 Enter — `/explore?keyword=...`로 이동하고 결과가 필터링되는지
2. 탐색 검색바에서 Enter — URL의 `keyword`가 갱신되고 목록이 바뀌는지. 카테고리 칩과 함께 걸리는지. 뒤로가기로 이전 검색어가 복원되는지
3. 커뮤니티 검색에서 Enter — 게시글이 검색어로 필터링되는지, 결과가 없을 때 "'키워드' 검색 결과가 없습니다."가 뜨는지
4. 홈 인기 검색어가 서버 값으로 뜨고, 칩을 누르면 해당 키워드로 검색되는지
5. `pnpm build`, `pnpm lint:fsd`(기존 13건 외 신규 위반 없음) 통과