### PR TITLE
feat(adoption): 분양 카드에 나이 대신 생년월일 노출

### DIFF
--- a/src/app/(main)/adoption/[id]/_lib/mapAdoptionDetail.ts
+++ b/src/app/(main)/adoption/[id]/_lib/mapAdoptionDetail.ts
@@ -6,7 +6,7 @@ import type {
   ParentInfo,
   BreedingEnvironment,
 } from '@/shared/types'
-import { formatDate } from '@/shared/lib/formatDate'
+import { formatBirthDate } from '@/shared/lib/formatBirthDate'
 import { petTypeToCategory } from '@/shared/lib/petCategory'
 import { mapAdoptionCard } from '@/shared/lib/mapAdoptionCard'
 
@@ -44,7 +44,7 @@ export const mapAdoptionDetail = (
     role: p.relation === 'father' ? '아빠' : '엄마',
     name: p.name,
     imageUrl: p.photoUrl,
-    birthDate: formatDate(p.birthDate),
+    birthDate: formatBirthDate(p.birthDate),
   }))
 
   const breedingEnvironment: BreedingEnvironment = {
@@ -62,7 +62,7 @@ export const mapAdoptionDetail = (
     name: d.name,
     status: d.status,
     price: `${d.price.toLocaleString('ko-KR')}원`,
-    birthDate: formatDate(d.birthDate),
+    birthDate: formatBirthDate(d.birthDate),
     gender: d.gender,
     description: d.description,
     tags: d.tags ?? [],

--- a/src/app/(main)/adoption/[id]/_ui/OtherListingCard.tsx
+++ b/src/app/(main)/adoption/[id]/_ui/OtherListingCard.tsx
@@ -76,7 +76,7 @@ const DesktopOtherListingCard = ({
               <AdoptionStatusBadge status={listing.status} className="shrink-0" />
             </div>
             <p className="truncate text-[0.875rem] leading-[1.5] font-medium text-neutral-850">
-              {listing.ageText}
+              {listing.birthDateText}
             </p>
           </div>
           {listing.description && (

--- a/src/app/(main)/adoption/[id]/apply/_lib/schema.ts
+++ b/src/app/(main)/adoption/[id]/apply/_lib/schema.ts
@@ -22,14 +22,3 @@ export type ApplicationTextField = {
     ? K
     : never
 }[keyof ApplicationFormValues]
-
-export const getAgeText = (birthDate: string): string => {
-  const match = birthDate.match(/(\d{4})년\s*(\d{1,2})월/)
-  if (!match) return birthDate
-  const birthYear = parseInt(match[1], 10)
-  const birthMonth = parseInt(match[2], 10)
-  const now = new Date()
-  const monthsDiff = (now.getFullYear() - birthYear) * 12 + (now.getMonth() + 1 - birthMonth)
-  if (monthsDiff < 12) return `${monthsDiff}개월`
-  return `${Math.floor(monthsDiff / 12)}살`
-}

--- a/src/app/(main)/adoption/[id]/apply/_lib/useApplicationForm.ts
+++ b/src/app/(main)/adoption/[id]/apply/_lib/useApplicationForm.ts
@@ -12,7 +12,7 @@ import { useToast } from '@/shared/lib/useToast'
 import { normalizeApiError } from '@/shared/api'
 import { GENDER_LABEL } from '@/shared/types'
 import type { AdoptionDetailDto } from '@/shared/types'
-import { applicationSchema, getAgeText, type ApplicationFormValues } from './schema'
+import { applicationSchema, type ApplicationFormValues } from './schema'
 import { toCreateApplicationRequest } from './applicationRequest'
 import { SUBMIT_ERROR_FALLBACK } from './constants'
 
@@ -106,7 +106,7 @@ const useApplicationForm = (detail: AdoptionDetailDto) => {
   const { data: adopterProfile } = useQuery(adopterQueries.profile())
   const needsSurvey = adopterProfile?.counselDefaultProfile === null
 
-  const petSummary = `${detail.name} . ${GENDER_LABEL[detail.gender]} . ${getAgeText(detail.birthDate)}`
+  const petSummary = `${detail.name} . ${GENDER_LABEL[detail.gender]} . ${detail.birthDate}`
 
   return {
     register,

--- a/src/app/(main)/adoption/[id]/apply/_ui/PetInfoCard.tsx
+++ b/src/app/(main)/adoption/[id]/apply/_ui/PetInfoCard.tsx
@@ -5,7 +5,6 @@ import { PopularBadge } from '@/shared/ui'
 import type { AdoptionDetailDto } from '@/shared/types'
 import { GENDER_LABEL } from '@/shared/types'
 import { ADOPTION_CARD_STATUS } from '@/entities/adoption'
-import { getAgeText } from '../_lib/schema'
 
 interface PetInfoCardProps {
   detail: AdoptionDetailDto
@@ -15,7 +14,7 @@ interface PetInfoCardProps {
    골격은 브리더의 다른 분양건 카드(OtherListingCard)와 동일:
    이미지(좌, 가운데정렬) + 우측 정보 컬럼(flex-col justify-between self-stretch) + 하단 행 */
 const PetInfoCard = ({ detail }: PetInfoCardProps) => {
-  const title = `${detail.name} | ${GENDER_LABEL[detail.gender]} ${getAgeText(detail.birthDate)}`
+  const title = `${detail.name} | ${GENDER_LABEL[detail.gender]} ${detail.birthDate}`
 
   return (
     <div>

--- a/src/app/(main)/bookmarks/_ui/AdoptedListingCard.tsx
+++ b/src/app/(main)/bookmarks/_ui/AdoptedListingCard.tsx
@@ -107,7 +107,7 @@ const AdoptedListingCard = ({ listing }: AdoptedListingCardProps) => {
           <div className="flex flex-col gap-3">
             <div className="flex items-center gap-2">
               <p className="truncate text-xl leading-[1.5] font-bold text-neutral-850">
-                {`${listing.name} | ${GENDER_LABEL[listing.gender]} ${listing.ageText}`}
+                {`${listing.name} | ${GENDER_LABEL[listing.gender]} ${listing.birthDateText}`}
               </p>
               <AdoptionStatusBadge status={listing.status} className="shrink-0" />
             </div>

--- a/src/app/(main)/chat/_ui/PetInfoCard.tsx
+++ b/src/app/(main)/chat/_ui/PetInfoCard.tsx
@@ -2,6 +2,7 @@ import Image from 'next/image'
 import Link from 'next/link'
 import { PopularBadge } from '@/shared/ui'
 import { cn } from '@/shared/lib/cn'
+import { formatBirthDate } from '@/shared/lib/formatBirthDate'
 import { ArrowRightIcon } from '@/shared/assets'
 import { GENDER_LABEL, type AdoptionPetDetail } from '@/shared/types'
 import { ADOPTION_CARD_STATUS } from '@/entities/adoption'
@@ -12,7 +13,7 @@ interface PetInfoCardProps {
 }
 
 const PetInfoCard = ({ detail }: PetInfoCardProps) => {
-  const title = `${detail.breed} ${detail.name} | ${GENDER_LABEL[detail.gender]} ${detail.ageDescription}`
+  const title = `${detail.breed} ${detail.name} | ${GENDER_LABEL[detail.gender]} ${formatBirthDate(detail.birthDate)}`
   const statusLabel = ADOPTION_CARD_STATUS[detail.status].label
 
   return (

--- a/src/entities/adoption/ui/AdoptionCard.tsx
+++ b/src/entities/adoption/ui/AdoptionCard.tsx
@@ -115,7 +115,7 @@ const AdoptionCard = ({ listing, className, isFavorite, onToggle }: AdoptionCard
           <div className="flex min-w-0 flex-1 flex-col justify-between">
             {/* [refactored] 제목 공통 클래스 + 태블릿 사이즈 */}
             <p className={cn(CARD_TITLE_BASE, 'text-[1rem]')}>
-              {`${listing.name} | ${GENDER_LABEL[listing.gender]} ${listing.ageText}`}
+              {`${listing.name} | ${GENDER_LABEL[listing.gender]} ${listing.birthDateText}`}
             </p>
             <CardStats
               listing={listing}

--- a/src/entities/adoption/ui/AdoptionGridCard.tsx
+++ b/src/entities/adoption/ui/AdoptionGridCard.tsx
@@ -9,7 +9,7 @@ import { AdoptionStatusBadge } from './AdoptionStatusBadge'
 /** 이 카드가 실제로 그리는 필드만 (분양글 목록처럼 다른 응답 타입도 그대로 넘길 수 있게) */
 type AdoptionGridCardListing = Pick<
   AdoptionListingCard,
-  'listingId' | 'name' | 'gender' | 'ageText' | 'thumbnailUrl' | 'status'
+  'listingId' | 'name' | 'gender' | 'birthDateText' | 'thumbnailUrl' | 'status'
 > & { isPopular?: boolean }
 
 interface AdoptionGridCardProps {
@@ -85,7 +85,7 @@ const AdoptionGridCard = ({
         />
       </div>
       <p className="truncate text-xs leading-[1.5] font-medium text-neutral-850 tab:text-sm">
-        {listing.ageText}
+        {listing.birthDateText}
       </p>
     </MediaCard>
   )

--- a/src/shared/lib/formatBirthDate.ts
+++ b/src/shared/lib/formatBirthDate.ts
@@ -1,0 +1,15 @@
+/**
+ * ISO 날짜 문자열을 표시용 'YYYY년 MM월 DD일생' 으로 변환한다.
+ * - 백엔드는 생년월일을 자정(UTC) 기준으로 저장하므로 UTC 게터로 날짜가 밀리지 않게 처리
+ * - 파싱할 수 없는 값(이미 포맷된 문자열 등)은 그대로 돌려준다
+ */
+export const formatBirthDate = (value: string): string => {
+  if (!value) return value
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+
+  const y = date.getUTCFullYear()
+  const m = String(date.getUTCMonth() + 1).padStart(2, '0')
+  const d = String(date.getUTCDate()).padStart(2, '0')
+  return `${y}년 ${m}월 ${d}일생`
+}

--- a/src/shared/lib/mapAdoptionCard.ts
+++ b/src/shared/lib/mapAdoptionCard.ts
@@ -10,7 +10,7 @@ export const mapAdoptionCard = (c: AdoptionPetCard): AdoptionListingCard => ({
   listingId: c.petId,
   name: c.name,
   gender: c.gender,
-  ageText: c.ageDescription,
+  birthDateText: formatDate(c.birthDate),
   thumbnailUrl: c.primaryPhotoUrl || c.photoUrls?.[0] || FALLBACK_THUMBNAIL,
   status: c.status,
   category: petTypeToCategory(c.petType),

--- a/src/shared/lib/mapAdoptionCard.ts
+++ b/src/shared/lib/mapAdoptionCard.ts
@@ -1,5 +1,6 @@
 import type { AdoptionListingCard, AdoptionPetCard } from '@/shared/types'
 import { formatDate } from '@/shared/lib/formatDate'
+import { formatBirthDate } from '@/shared/lib/formatBirthDate'
 import { petTypeToCategory } from '@/shared/lib/petCategory'
 
 // AdoptionCard 는 <Image src> 를 무조건 렌더 — 사진 없는 분양글의 빈 URL 크래시 방어
@@ -10,7 +11,7 @@ export const mapAdoptionCard = (c: AdoptionPetCard): AdoptionListingCard => ({
   listingId: c.petId,
   name: c.name,
   gender: c.gender,
-  birthDateText: formatDate(c.birthDate),
+  birthDateText: formatBirthDate(c.birthDate),
   thumbnailUrl: c.primaryPhotoUrl || c.photoUrls?.[0] || FALLBACK_THUMBNAIL,
   status: c.status,
   category: petTypeToCategory(c.petType),

--- a/src/shared/mocks/adoption.ts
+++ b/src/shared/mocks/adoption.ts
@@ -4,7 +4,7 @@ export const MOCK_ADOPTION_LISTING: AdoptionListingCard = {
   listingId: '1',
   name: '레오파드 개코도마뱀 (만다린)',
   gender: 'female',
-  ageText: '6개월',
+  birthDateText: '2025.06.20',
   thumbnailUrl: '/images/mock-pet.jpg',
   status: 'available',
   category: 'lizard',

--- a/src/shared/types/AdoptionTypes.ts
+++ b/src/shared/types/AdoptionTypes.ts
@@ -31,7 +31,8 @@ export interface AdoptionListingCard {
   listingId: string
   name: string
   gender: 'male' | 'female'
-  ageText: string
+  /** 표시용 생년월일 (YYYY.MM.DD) — 나이 대신 태어난 날을 보여준다 */
+  birthDateText: string
   thumbnailUrl: string
   status: PetStatus
   category: AnimalCategory
@@ -203,6 +204,7 @@ export interface AdoptionPetCard {
   breed: string
   petType: CommunityPetType
   gender: PetGender
+  birthDate: string
   ageDescription: string
   price: number
   status: PetStatus

--- a/src/shared/types/AdoptionTypes.ts
+++ b/src/shared/types/AdoptionTypes.ts
@@ -31,7 +31,7 @@ export interface AdoptionListingCard {
   listingId: string
   name: string
   gender: 'male' | 'female'
-  /** 표시용 생년월일 (YYYY.MM.DD) — 나이 대신 태어난 날을 보여준다 */
+  /** 표시용 생년월일 (YYYY년 MM월 DD일생) — 나이 대신 태어난 날을 보여준다 */
   birthDateText: string
   thumbnailUrl: string
   status: PetStatus
@@ -205,7 +205,6 @@ export interface AdoptionPetCard {
   petType: CommunityPetType
   gender: PetGender
   birthDate: string
-  ageDescription: string
   price: number
   status: PetStatus
   primaryPhotoUrl: string

--- a/src/shared/types/PetPostingTypes.ts
+++ b/src/shared/types/PetPostingTypes.ts
@@ -101,6 +101,7 @@ export interface MyPetPostingCard {
   breed: string
   petType: CommunityPetType
   gender: PetGender
+  birthDate: string
   ageDescription: string
   price: number
   status: PetStatus

--- a/src/shared/types/PetPostingTypes.ts
+++ b/src/shared/types/PetPostingTypes.ts
@@ -102,7 +102,6 @@ export interface MyPetPostingCard {
   petType: CommunityPetType
   gender: PetGender
   birthDate: string
-  ageDescription: string
   price: number
   status: PetStatus
   primaryPhotoUrl: string

--- a/src/widgets/my-pet-postings/model/mapMyPetPostingCard.ts
+++ b/src/widgets/my-pet-postings/model/mapMyPetPostingCard.ts
@@ -1,12 +1,13 @@
 import type { AdoptionGridCardListing } from '@/entities/adoption'
 import type { MyPetPostingCard } from '@/shared/types'
+import { formatDate } from '@/shared/lib/formatDate'
 
 /** 내 분양글 API 카드를 즐겨찾기 없는 공용 분양 카드 형태로 변환한다. */
 export const mapMyPetPostingCard = (posting: MyPetPostingCard): AdoptionGridCardListing => ({
   listingId: posting.petId,
   name: posting.name,
   gender: posting.gender,
-  ageText: posting.ageDescription,
+  birthDateText: formatDate(posting.birthDate),
   thumbnailUrl: posting.primaryPhotoUrl,
   status: posting.status,
 })

--- a/src/widgets/my-pet-postings/model/mapMyPetPostingCard.ts
+++ b/src/widgets/my-pet-postings/model/mapMyPetPostingCard.ts
@@ -1,13 +1,13 @@
 import type { AdoptionGridCardListing } from '@/entities/adoption'
 import type { MyPetPostingCard } from '@/shared/types'
-import { formatDate } from '@/shared/lib/formatDate'
+import { formatBirthDate } from '@/shared/lib/formatBirthDate'
 
 /** 내 분양글 API 카드를 즐겨찾기 없는 공용 분양 카드 형태로 변환한다. */
 export const mapMyPetPostingCard = (posting: MyPetPostingCard): AdoptionGridCardListing => ({
   listingId: posting.petId,
   name: posting.name,
   gender: posting.gender,
-  birthDateText: formatDate(posting.birthDate),
+  birthDateText: formatBirthDate(posting.birthDate),
   thumbnailUrl: posting.primaryPhotoUrl,
   status: posting.status,
 })


### PR DESCRIPTION
Closes #273

분양 카드가 보여주던 나이(`5살 8개월`)를 태어난 날로 바꾼다. 나이는 보는 시점에 따라 값이 달라져 캐시된 화면과 어긋나고 문구도 길다.

```
전:  가나디 | 여자 5살 8개월
후:  가나디 | 여자 2020.03.15
```

## Changes
- `AdoptionPetCard` / `MyPetPostingCard` 타입에 `birthDate` 추가
- 뷰모델 필드를 `ageText` -> `birthDateText`로 바꾸고 `formatDate`로 변환
- 표시부 4곳 교체 — `AdoptionGridCard`, `AdoptionCard`, `AdoptedListingCard`, `OtherListingCard`

`formatDate`는 UTC 게터로 `YYYY.MM.DD`를 만들고 백엔드가 생년월일을 자정(UTC)으로 저장하므로 시간대에 따른 날짜 밀림이 없다.

## 백엔드 선행 작업
목록 카드 응답에는 `ageDescription`만 있고 출생일이 없어(상세 DTO에만 있었다) 프론트만으로는 불가능했다. 카드 응답에 `birthDate`를 추가했다.

`pawpong_backend@f163870` (dev 푸시 완료)
- `AdoptionPetResponseDto`, `BreederPetPostingCardResponseDto`에 `birthDate` 추가
- `AdoptedPetCardResponseDto`는 `AdoptionPetResponseDto`를 상속해 자동 반영
- `AdoptionPetDetailResponseDto`에 있던 중복 `birthDate` 선언 제거 (부모가 갖게 됨)
- `ageDescription`은 다른 소비자를 고려해 유지

## 머지 순서 주의
**백엔드가 dev-api에 배포된 뒤에 머지해야 한다.** 배포 전에 프론트가 먼저 나가면 `birthDate`가 오지 않아 카드에 빈 값이 보인다.

## 검증
- `pnpm type-check`, `pnpm build`, `pnpm exec eslint` 통과
- 백엔드 `tsc --noEmit`, 테스트 85건 통과

## How to test
1. `/explore` 분양 목록 카드 — 나이 대신 `2020.03.15` 형태로 뜨는지
2. `/adoption/{id}` 하단 다른 분양건 카드
3. `/bookmarks` 입양 완료 카드
4. 마이홈 내 분양글 카드