### PR TITLE
feat(breeder): 탐색 브리더 탭에 검색어 반영

### DIFF
--- a/src/app/(main)/adoption/[id]/_lib/mapAdoptionDetail.ts
+++ b/src/app/(main)/adoption/[id]/_lib/mapAdoptionDetail.ts
@@ -6,7 +6,7 @@ import type {
   ParentInfo,
   BreedingEnvironment,
 } from '@/shared/types'
-import { formatDate } from '@/shared/lib/formatDate'
+import { formatBirthDate } from '@/shared/lib/formatBirthDate'
 import { petTypeToCategory } from '@/shared/lib/petCategory'
 import { mapAdoptionCard } from '@/shared/lib/mapAdoptionCard'
 
@@ -44,7 +44,7 @@ export const mapAdoptionDetail = (
     role: p.relation === 'father' ? '아빠' : '엄마',
     name: p.name,
     imageUrl: p.photoUrl,
-    birthDate: formatDate(p.birthDate),
+    birthDate: formatBirthDate(p.birthDate),
   }))
 
   const breedingEnvironment: BreedingEnvironment = {
@@ -62,7 +62,7 @@ export const mapAdoptionDetail = (
     name: d.name,
     status: d.status,
     price: `${d.price.toLocaleString('ko-KR')}원`,
-    birthDate: formatDate(d.birthDate),
+    birthDate: formatBirthDate(d.birthDate),
     gender: d.gender,
     description: d.description,
     tags: d.tags ?? [],

--- a/src/app/(main)/adoption/[id]/_ui/OtherListingCard.tsx
+++ b/src/app/(main)/adoption/[id]/_ui/OtherListingCard.tsx
@@ -76,7 +76,7 @@ const DesktopOtherListingCard = ({
               <AdoptionStatusBadge status={listing.status} className="shrink-0" />
             </div>
             <p className="truncate text-[0.875rem] leading-[1.5] font-medium text-neutral-850">
-              {listing.ageText}
+              {listing.birthDateText}
             </p>
           </div>
           {listing.description && (

--- a/src/app/(main)/adoption/[id]/apply/_lib/schema.ts
+++ b/src/app/(main)/adoption/[id]/apply/_lib/schema.ts
@@ -22,14 +22,3 @@ export type ApplicationTextField = {
     ? K
     : never
 }[keyof ApplicationFormValues]
-
-export const getAgeText = (birthDate: string): string => {
-  const match = birthDate.match(/(\d{4})년\s*(\d{1,2})월/)
-  if (!match) return birthDate
-  const birthYear = parseInt(match[1], 10)
-  const birthMonth = parseInt(match[2], 10)
-  const now = new Date()
-  const monthsDiff = (now.getFullYear() - birthYear) * 12 + (now.getMonth() + 1 - birthMonth)
-  if (monthsDiff < 12) return `${monthsDiff}개월`
-  return `${Math.floor(monthsDiff / 12)}살`
-}

--- a/src/app/(main)/adoption/[id]/apply/_lib/useApplicationForm.ts
+++ b/src/app/(main)/adoption/[id]/apply/_lib/useApplicationForm.ts
@@ -12,7 +12,7 @@ import { useToast } from '@/shared/lib/useToast'
 import { normalizeApiError } from '@/shared/api'
 import { GENDER_LABEL } from '@/shared/types'
 import type { AdoptionDetailDto } from '@/shared/types'
-import { applicationSchema, getAgeText, type ApplicationFormValues } from './schema'
+import { applicationSchema, type ApplicationFormValues } from './schema'
 import { toCreateApplicationRequest } from './applicationRequest'
 import { SUBMIT_ERROR_FALLBACK } from './constants'
 
@@ -106,7 +106,7 @@ const useApplicationForm = (detail: AdoptionDetailDto) => {
   const { data: adopterProfile } = useQuery(adopterQueries.profile())
   const needsSurvey = adopterProfile?.counselDefaultProfile === null
 
-  const petSummary = `${detail.name} . ${GENDER_LABEL[detail.gender]} . ${getAgeText(detail.birthDate)}`
+  const petSummary = `${detail.name} . ${GENDER_LABEL[detail.gender]} . ${detail.birthDate}`
 
   return {
     register,

--- a/src/app/(main)/adoption/[id]/apply/_ui/PetInfoCard.tsx
+++ b/src/app/(main)/adoption/[id]/apply/_ui/PetInfoCard.tsx
@@ -5,7 +5,6 @@ import { PopularBadge } from '@/shared/ui'
 import type { AdoptionDetailDto } from '@/shared/types'
 import { GENDER_LABEL } from '@/shared/types'
 import { ADOPTION_CARD_STATUS } from '@/entities/adoption'
-import { getAgeText } from '../_lib/schema'
 
 interface PetInfoCardProps {
   detail: AdoptionDetailDto
@@ -15,7 +14,7 @@ interface PetInfoCardProps {
    골격은 브리더의 다른 분양건 카드(OtherListingCard)와 동일:
    이미지(좌, 가운데정렬) + 우측 정보 컬럼(flex-col justify-between self-stretch) + 하단 행 */
 const PetInfoCard = ({ detail }: PetInfoCardProps) => {
-  const title = `${detail.name} | ${GENDER_LABEL[detail.gender]} ${getAgeText(detail.birthDate)}`
+  const title = `${detail.name} | ${GENDER_LABEL[detail.gender]} ${detail.birthDate}`
 
   return (
     <div>

--- a/src/app/(main)/bookmarks/_ui/AdoptedListingCard.tsx
+++ b/src/app/(main)/bookmarks/_ui/AdoptedListingCard.tsx
@@ -107,7 +107,7 @@ const AdoptedListingCard = ({ listing }: AdoptedListingCardProps) => {
           <div className="flex flex-col gap-3">
             <div className="flex items-center gap-2">
               <p className="truncate text-xl leading-[1.5] font-bold text-neutral-850">
-                {`${listing.name} | ${GENDER_LABEL[listing.gender]} ${listing.ageText}`}
+                {`${listing.name} | ${GENDER_LABEL[listing.gender]} ${listing.birthDateText}`}
               </p>
               <AdoptionStatusBadge status={listing.status} className="shrink-0" />
             </div>

--- a/src/app/(main)/chat/_ui/PetInfoCard.tsx
+++ b/src/app/(main)/chat/_ui/PetInfoCard.tsx
@@ -2,6 +2,7 @@ import Image from 'next/image'
 import Link from 'next/link'
 import { PopularBadge } from '@/shared/ui'
 import { cn } from '@/shared/lib/cn'
+import { formatBirthDate } from '@/shared/lib/formatBirthDate'
 import { ArrowRightIcon } from '@/shared/assets'
 import { GENDER_LABEL, type AdoptionPetDetail } from '@/shared/types'
 import { ADOPTION_CARD_STATUS } from '@/entities/adoption'
@@ -12,7 +13,7 @@ interface PetInfoCardProps {
 }
 
 const PetInfoCard = ({ detail }: PetInfoCardProps) => {
-  const title = `${detail.breed} ${detail.name} | ${GENDER_LABEL[detail.gender]} ${detail.ageDescription}`
+  const title = `${detail.breed} ${detail.name} | ${GENDER_LABEL[detail.gender]} ${formatBirthDate(detail.birthDate)}`
   const statusLabel = ADOPTION_CARD_STATUS[detail.status].label
 
   return (

--- a/src/app/(main)/explore/_ui/BreederExploreContent.tsx
+++ b/src/app/(main)/explore/_ui/BreederExploreContent.tsx
@@ -43,17 +43,20 @@ const toBreederCardModel = (breeder: Breeder): FavoriteBreeder => ({
 interface BreederExploreContentProps {
   /** 상단 픽셀 카테고리 칩 선택값 — 입양 탭과 같은 필터를 공유한다 */
   category: AnimalCategory
+  /** 상단 검색바 검색어 — 입양 탭과 같은 URL 파라미터를 공유한다 */
+  keyword?: string
 }
 
 // 상단 카테고리/검색(픽셀 카테고리 + 큰 검색바)은 ExploreContent에서 공통 렌더.
 // 목록 레이아웃은 입양 탐색과 동일 — 제목+필터 칩 헤더 / 공용 그리드 / 무한스크롤.
-const BreederExploreContent = ({ category }: BreederExploreContentProps) => {
+const BreederExploreContent = ({ category, keyword }: BreederExploreContentProps) => {
   const [listFilter, setListFilter] = useState<ExploreListFilter>('all')
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isPending, isError } =
     useInfiniteQuery(
       breederQueries.explore({
         petType: toBreederPetType(category),
+        keyword,
         ...FILTER_TO_QUERY[listFilter],
       }),
     )

--- a/src/app/(main)/explore/_ui/ExploreContent.tsx
+++ b/src/app/(main)/explore/_ui/ExploreContent.tsx
@@ -194,7 +194,7 @@ const ExploreContent = () => {
       <div ref={sentinelRef} aria-hidden />
 
       {selectedType === 'breeder' ? (
-        <BreederExploreContent category={selectedCategory} />
+        <BreederExploreContent category={selectedCategory} keyword={keyword} />
       ) : (
         <>
           <Container className={EXPLORE_SECTION_CONTAINER}>

--- a/src/entities/adoption/ui/AdoptionCard.tsx
+++ b/src/entities/adoption/ui/AdoptionCard.tsx
@@ -115,7 +115,7 @@ const AdoptionCard = ({ listing, className, isFavorite, onToggle }: AdoptionCard
           <div className="flex min-w-0 flex-1 flex-col justify-between">
             {/* [refactored] 제목 공통 클래스 + 태블릿 사이즈 */}
             <p className={cn(CARD_TITLE_BASE, 'text-[1rem]')}>
-              {`${listing.name} | ${GENDER_LABEL[listing.gender]} ${listing.ageText}`}
+              {`${listing.name} | ${GENDER_LABEL[listing.gender]} ${listing.birthDateText}`}
             </p>
             <CardStats
               listing={listing}

--- a/src/entities/adoption/ui/AdoptionGridCard.tsx
+++ b/src/entities/adoption/ui/AdoptionGridCard.tsx
@@ -9,7 +9,7 @@ import { AdoptionStatusBadge } from './AdoptionStatusBadge'
 /** 이 카드가 실제로 그리는 필드만 (분양글 목록처럼 다른 응답 타입도 그대로 넘길 수 있게) */
 type AdoptionGridCardListing = Pick<
   AdoptionListingCard,
-  'listingId' | 'name' | 'gender' | 'ageText' | 'thumbnailUrl' | 'status'
+  'listingId' | 'name' | 'gender' | 'birthDateText' | 'thumbnailUrl' | 'status'
 > & { isPopular?: boolean }
 
 interface AdoptionGridCardProps {
@@ -85,7 +85,7 @@ const AdoptionGridCard = ({
         />
       </div>
       <p className="truncate text-xs leading-[1.5] font-medium text-neutral-850 tab:text-sm">
-        {listing.ageText}
+        {listing.birthDateText}
       </p>
     </MediaCard>
   )

--- a/src/shared/lib/formatBirthDate.ts
+++ b/src/shared/lib/formatBirthDate.ts
@@ -1,0 +1,15 @@
+/**
+ * ISO 날짜 문자열을 표시용 'YYYY년 MM월 DD일생' 으로 변환한다.
+ * - 백엔드는 생년월일을 자정(UTC) 기준으로 저장하므로 UTC 게터로 날짜가 밀리지 않게 처리
+ * - 파싱할 수 없는 값(이미 포맷된 문자열 등)은 그대로 돌려준다
+ */
+export const formatBirthDate = (value: string): string => {
+  if (!value) return value
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+
+  const y = date.getUTCFullYear()
+  const m = String(date.getUTCMonth() + 1).padStart(2, '0')
+  const d = String(date.getUTCDate()).padStart(2, '0')
+  return `${y}년 ${m}월 ${d}일생`
+}

--- a/src/shared/lib/mapAdoptionCard.ts
+++ b/src/shared/lib/mapAdoptionCard.ts
@@ -10,7 +10,7 @@ export const mapAdoptionCard = (c: AdoptionPetCard): AdoptionListingCard => ({
   listingId: c.petId,
   name: c.name,
   gender: c.gender,
-  ageText: c.ageDescription,
+  birthDateText: formatDate(c.birthDate),
   thumbnailUrl: c.primaryPhotoUrl || c.photoUrls?.[0] || FALLBACK_THUMBNAIL,
   status: c.status,
   category: petTypeToCategory(c.petType),

--- a/src/shared/lib/mapAdoptionCard.ts
+++ b/src/shared/lib/mapAdoptionCard.ts
@@ -1,5 +1,6 @@
 import type { AdoptionListingCard, AdoptionPetCard } from '@/shared/types'
 import { formatDate } from '@/shared/lib/formatDate'
+import { formatBirthDate } from '@/shared/lib/formatBirthDate'
 import { petTypeToCategory } from '@/shared/lib/petCategory'
 
 // AdoptionCard 는 <Image src> 를 무조건 렌더 — 사진 없는 분양글의 빈 URL 크래시 방어
@@ -10,7 +11,7 @@ export const mapAdoptionCard = (c: AdoptionPetCard): AdoptionListingCard => ({
   listingId: c.petId,
   name: c.name,
   gender: c.gender,
-  birthDateText: formatDate(c.birthDate),
+  birthDateText: formatBirthDate(c.birthDate),
   thumbnailUrl: c.primaryPhotoUrl || c.photoUrls?.[0] || FALLBACK_THUMBNAIL,
   status: c.status,
   category: petTypeToCategory(c.petType),

--- a/src/shared/mocks/adoption.ts
+++ b/src/shared/mocks/adoption.ts
@@ -4,7 +4,7 @@ export const MOCK_ADOPTION_LISTING: AdoptionListingCard = {
   listingId: '1',
   name: '레오파드 개코도마뱀 (만다린)',
   gender: 'female',
-  ageText: '6개월',
+  birthDateText: '2025.06.20',
   thumbnailUrl: '/images/mock-pet.jpg',
   status: 'available',
   category: 'lizard',

--- a/src/shared/types/AdoptionTypes.ts
+++ b/src/shared/types/AdoptionTypes.ts
@@ -31,7 +31,8 @@ export interface AdoptionListingCard {
   listingId: string
   name: string
   gender: 'male' | 'female'
-  ageText: string
+  /** 표시용 생년월일 (YYYY.MM.DD) — 나이 대신 태어난 날을 보여준다 */
+  birthDateText: string
   thumbnailUrl: string
   status: PetStatus
   category: AnimalCategory
@@ -203,6 +204,7 @@ export interface AdoptionPetCard {
   breed: string
   petType: CommunityPetType
   gender: PetGender
+  birthDate: string
   ageDescription: string
   price: number
   status: PetStatus

--- a/src/shared/types/AdoptionTypes.ts
+++ b/src/shared/types/AdoptionTypes.ts
@@ -31,7 +31,7 @@ export interface AdoptionListingCard {
   listingId: string
   name: string
   gender: 'male' | 'female'
-  /** 표시용 생년월일 (YYYY.MM.DD) — 나이 대신 태어난 날을 보여준다 */
+  /** 표시용 생년월일 (YYYY년 MM월 DD일생) — 나이 대신 태어난 날을 보여준다 */
   birthDateText: string
   thumbnailUrl: string
   status: PetStatus
@@ -205,7 +205,6 @@ export interface AdoptionPetCard {
   petType: CommunityPetType
   gender: PetGender
   birthDate: string
-  ageDescription: string
   price: number
   status: PetStatus
   primaryPhotoUrl: string

--- a/src/shared/types/BreederTypes.ts
+++ b/src/shared/types/BreederTypes.ts
@@ -222,6 +222,8 @@ export interface Breeder {
 
 export interface SearchBreederParams {
   petType?: 'dog' | 'cat'
+  /** 검색어 — 브리더명/품종/지역 부분 일치 */
+  keyword?: string
   dogSize?: string[]
   catFurLength?: string[]
   breeds?: string[]

--- a/src/shared/types/PetPostingTypes.ts
+++ b/src/shared/types/PetPostingTypes.ts
@@ -101,6 +101,7 @@ export interface MyPetPostingCard {
   breed: string
   petType: CommunityPetType
   gender: PetGender
+  birthDate: string
   ageDescription: string
   price: number
   status: PetStatus

--- a/src/shared/types/PetPostingTypes.ts
+++ b/src/shared/types/PetPostingTypes.ts
@@ -102,7 +102,6 @@ export interface MyPetPostingCard {
   petType: CommunityPetType
   gender: PetGender
   birthDate: string
-  ageDescription: string
   price: number
   status: PetStatus
   primaryPhotoUrl: string

--- a/src/widgets/my-pet-postings/model/mapMyPetPostingCard.ts
+++ b/src/widgets/my-pet-postings/model/mapMyPetPostingCard.ts
@@ -1,12 +1,13 @@
 import type { AdoptionGridCardListing } from '@/entities/adoption'
 import type { MyPetPostingCard } from '@/shared/types'
+import { formatDate } from '@/shared/lib/formatDate'
 
 /** 내 분양글 API 카드를 즐겨찾기 없는 공용 분양 카드 형태로 변환한다. */
 export const mapMyPetPostingCard = (posting: MyPetPostingCard): AdoptionGridCardListing => ({
   listingId: posting.petId,
   name: posting.name,
   gender: posting.gender,
-  ageText: posting.ageDescription,
+  birthDateText: formatDate(posting.birthDate),
   thumbnailUrl: posting.primaryPhotoUrl,
   status: posting.status,
 })

--- a/src/widgets/my-pet-postings/model/mapMyPetPostingCard.ts
+++ b/src/widgets/my-pet-postings/model/mapMyPetPostingCard.ts
@@ -1,13 +1,13 @@
 import type { AdoptionGridCardListing } from '@/entities/adoption'
 import type { MyPetPostingCard } from '@/shared/types'
-import { formatDate } from '@/shared/lib/formatDate'
+import { formatBirthDate } from '@/shared/lib/formatBirthDate'
 
 /** 내 분양글 API 카드를 즐겨찾기 없는 공용 분양 카드 형태로 변환한다. */
 export const mapMyPetPostingCard = (posting: MyPetPostingCard): AdoptionGridCardListing => ({
   listingId: posting.petId,
   name: posting.name,
   gender: posting.gender,
-  birthDateText: formatDate(posting.birthDate),
+  birthDateText: formatBirthDate(posting.birthDate),
   thumbnailUrl: posting.primaryPhotoUrl,
   status: posting.status,
 })

--- a/swagger.json
+++ b/swagger.json
@@ -53445,6 +53445,11 @@
               "cat"
             ]
           },
+          "keyword": {
+            "type": "string",
+            "description": "검색어 (브리더명, 품종, 지역 부분 일치)",
+            "example": "말티즈"
+          },
           "dogSize": {
             "type": "array",
             "description": "강아지 크기 필터 (dog 타입일 때만)",


### PR DESCRIPTION
Closes #275
백엔드: Pawpong/pawpong_backend#174 (선행 머지 필요)

## 변경
- `SearchBreederParams`에 `keyword` 추가
- `ExploreContent`가 URL의 `?keyword=`를 `BreederExploreContent`로 전달
- `breederQueries.explore`에 keyword를 실어 보냄 (params 객체가 queryKey에 포함돼 검색어가 바뀌면 재조회)
- swagger.json의 `SearchBreederRequestDto`에 keyword 반영

## 이유
검색바가 브리더 탭에서도 노출되고 URL에 keyword까지 남는데 목록은 그대로여서, 사용자에게는 검색이 먹지 않는 것처럼 보였다.

## 남은 것
`ExploreFilterBar`의 펼침 검색 input은 여전히 value/onSubmit 없이 붙어 있어 동작하지 않는다. `shared/ui/SearchButton`으로 교체하는 별도 작업 필요.