### PR TITLE
fix(shared): 작성 유도 바를 주변 콘텐츠 폭에 맞춤

### DIFF
--- a/src/app/(main)/home/_ui/MyHomeContent.tsx
+++ b/src/app/(main)/home/_ui/MyHomeContent.tsx
@@ -98,14 +98,14 @@ const MyHomeContent = () => {
         onTabChange={setSelectedTab}
         stickyTop={gnbH + navH}
       >
-        {/* 브리더: 분양글 작성 바 / 일반: 게시글 작성 바 (공통 InputUpload, 상·하 보더 포함) */}
-        <InputUpload text={writeBar.text} href={writeBar.href} />
+        {/* 브리더: 분양글 작성 바 / 일반: 게시글 작성 바 (공통 InputUpload) */}
+        <InputUpload text={writeBar.text} href={writeBar.href} className="px-4" />
 
         {/* 분양 목록 탭 (브리더만) — 시안 3170-790275: 배너 -> 라벨+필터 -> 카드 4열 */}
         {isBreeder && (
           <TabsContent value="listings" className="mt-0">
             {/* 배너는 콘텐츠 Container 밖의 독립 밴드 (시안 3170-800323) — 홈 CTA 스트립과 같은 배치.
-                위쪽은 작성 바(InputUpload)의 보더와 붙지 않게 여백을 더 준다 */}
+                위쪽은 작성 바(InputUpload)와 붙지 않게 여백을 더 준다 */}
             <Container className="px-4 pt-10 pb-2">
               <CtaBanner text="분양 페이지 바로가기" href="/adoption" />
             </Container>

--- a/src/shared/ui/InputUpload.tsx
+++ b/src/shared/ui/InputUpload.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import { cn } from '@/shared/lib/cn'
+import { Container } from './Container'
 
 interface InputUploadProps {
   /** 안내 문구 (placeholder 역할) */
@@ -8,29 +9,26 @@ interface InputUploadProps {
   buttonText?: string
   /** 이동 경로 (바 전체가 링크) */
   href: string
+  /** 내용 행에 적용 — 좌우 여백을 주변 콘텐츠에 맞출 때 사용 */
   className?: string
 }
 
 /**
  * 게시글/분양글 작성 유도 바 (Figma node 818-110386 · InputUpload)
- * - 상·하 #cacaca 보더, 좌우 여백 mo16 / tab48 / pc80
+ * - 상·하 #cacaca 보더는 풀블리드, 내용은 Container 폭에 맞춘다 (주변 콘텐츠와 좌우 정렬)
  * - 모바일: 문구만, 탭·PC: 문구 + 작성하기 버튼
  */
 const InputUpload = ({ text, buttonText = '작성하기', href, className }: InputUploadProps) => {
   return (
-    <Link
-      href={href}
-      className={cn(
-        'flex items-center border-y border-neutral-300 bg-white px-4 py-2 tab:px-12 pc:px-20',
-        className,
-      )}
-    >
-      <div className="flex min-w-0 flex-1 items-center justify-between gap-3">
-        <span className="truncate text-sm leading-[1.5] font-medium text-neutral-700">{text}</span>
+    <Link href={href} className="block border-y border-neutral-300 bg-white">
+      <Container className={cn('flex items-center justify-between gap-3 py-2', className)}>
+        <span className="min-w-0 truncate text-sm leading-[1.5] font-medium text-neutral-700">
+          {text}
+        </span>
         <span className="hidden h-8 shrink-0 items-center justify-center rounded-lg bg-neutral-850 px-2 text-sm leading-[1.5] font-semibold text-neutral-50 tab:flex">
           {buttonText}
         </span>
-      </div>
+      </Container>
     </Link>
   )
 }

--- a/src/shared/ui/ListingCardGrid.tsx
+++ b/src/shared/ui/ListingCardGrid.tsx
@@ -5,8 +5,8 @@ const listingCardGrid = tv({
   base: 'grid grid-cols-2',
   variants: {
     layout: {
-      /** 탐색·저장목록 — tab 2열 유지, PC 는 좌우 margin */
-      explore: 'gap-4 tab:mx-[2.75rem] tab:gap-5 pc:mx-[2.875rem] pc:grid-cols-4',
+      /** 탐색·저장목록 — tab 2열 유지, PC 4열. 좌우 여백은 Container가 담당한다 */
+      explore: 'gap-4 tab:gap-5 pc:grid-cols-4',
       /** 즐겨찾기 브리더·브리더 홈 분양목록 (Figma 1023-38692) — tab 3열, PC 1188px 가운데 정렬 */
       compact:
         'gap-x-2.5 gap-y-4 tab:grid-cols-3 tab:gap-5 pc:mx-auto pc:max-w-[74.25rem] pc:grid-cols-4',


### PR DESCRIPTION
Closes #279

## 문제
`InputUpload`가 `Container` 대신 `px-4 tab:px-12 pc:px-20`을 직접 들고 있고 `max-w-[90rem] mx-auto`가 없었다. 뷰포트 1453px 기준으로 주변 콘텐츠는 22.5px에서 시작하는데 작성 바 문구는 80px에서 시작해 좌우가 어긋났다.

## 변경
- 보더·배경은 풀블리드로 유지하고 내용만 `Container`로 감쌈 — 폭/여백이 주변 콘텐츠와 자동으로 같아짐
- `className`을 내용 행에 적용해 소비처가 주변 여백에 맞출 수 있게 함 (기존에 className을 넘기던 소비처는 없음)
- 마이홈은 주변 Container가 `px-4`를 쓰므로 동일하게 전달. 분양 페이지는 기본 여백(20/48/80)이라 그대로

시각 스타일은 건드리지 않음. type-check / lint 통과.