### PR TITLE
feat(home): 마이홈 작성 진입 줄과 게시글 목록을 커뮤니티 피드와 통일

### DIFF
--- a/src/app/(main)/adoption/my-listings/_ui/MyListingsContent.tsx
+++ b/src/app/(main)/adoption/my-listings/_ui/MyListingsContent.tsx
@@ -11,7 +11,7 @@ const MyListingsContent = () => (
   <div className="flex w-full flex-col pb-12">
     <NavigationBar title="분양 페이지" backHref="/home" />
 
-    <InputUpload text="분양할 동물 작성하러가기" href="/adoption/create" />
+    <InputUpload text="분양글 작성하기" href="/adoption/create" />
 
     <Container className="py-6 tab:py-10">
       <MyPetPostingList pageSize={PAGE_SIZE} showTotalCount />

--- a/src/app/(main)/home/_ui/MyHomeContent.tsx
+++ b/src/app/(main)/home/_ui/MyHomeContent.tsx
@@ -4,7 +4,7 @@ import { useLayoutEffect, useRef, useState } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useQuery } from '@tanstack/react-query'
-import { BookmarkIcon } from '@/shared/assets'
+import { ArrowRightIcon, BookmarkIcon } from '@/shared/assets'
 import { Container, CtaBanner, DeleteConfirmModal, NavigationBar, InputUpload } from '@/shared/ui'
 import { useGnbHeight } from '@/shared/lib/useGnbHeight'
 import { profileQueries } from '@/entities/profile'
@@ -56,11 +56,6 @@ const MyHomeContent = () => {
 
   const tabs = isBreeder ? BREEDER_MY_HOME_TABS : MY_HOME_TABS
   const defaultTab = isBreeder ? 'listings' : 'posts'
-  // [refactored] 작성 바 문구/링크를 역할별로 분리 — 단일 InputUpload 인스턴스로 렌더
-  const writeBar = isBreeder
-    ? { text: '분양할 동물 작성하러가기', href: '/adoption/create' }
-    : { text: '게시글을 올려보세요', href: '/community/write' }
-
   // 프로필 조회 전에는 역할을 모르므로 선택값을 비워두고, 조회 후 역할별 기본 탭을 사용한다.
   // useState(defaultTab)로 바로 시드하면 최초 adopter 기본값('posts')이 브리더에게도 고정된다.
   const [selectedTab, setSelectedTab] = useState<string | null>(null)
@@ -98,15 +93,13 @@ const MyHomeContent = () => {
         onTabChange={setSelectedTab}
         stickyTop={gnbH + navH}
       >
-        {/* 브리더: 분양글 작성 바 / 일반: 게시글 작성 바 (공통 InputUpload) */}
-        <InputUpload text={writeBar.text} href={writeBar.href} className="px-4" />
-
         {/* 분양 목록 탭 (브리더만) — 시안 3170-790275: 배너 -> 라벨+필터 -> 카드 4열 */}
         {isBreeder && (
           <TabsContent value="listings" className="mt-0">
-            {/* 배너는 콘텐츠 Container 밖의 독립 밴드 (시안 3170-800323) — 홈 CTA 스트립과 같은 배치.
-                위쪽은 작성 바(InputUpload)와 붙지 않게 여백을 더 준다 */}
-            <Container className="px-4 pt-10 pb-2">
+            <InputUpload text="분양글 작성하기" href="/adoption/create" className="px-4" />
+
+            {/* 배너는 콘텐츠 Container 밖의 독립 밴드 (시안 3170-800323) — 홈 CTA 스트립과 같은 배치 */}
+            <Container className="px-4 pt-4 pb-2">
               <CtaBanner text="분양 페이지 바로가기" href="/adoption" />
             </Container>
 
@@ -121,17 +114,31 @@ const MyHomeContent = () => {
 
         {/* 디자인: 모바일(1023-23241) px-16·py-24 / 탭·PC(2046-160971) px-48·80·py-40 */}
         <TabsContent value="posts" className="mt-0">
-          <Container className="px-4 py-6 tab:py-10">
-            {/* 임시저장이 있을 때만 노출 — 목록에서 이어서 작성 */}
-            {draftCount > 0 && (
-              <Link
-                href="/community/drafts"
-                className="mb-4 flex items-center justify-between rounded-lg border border-neutral-300 px-4 py-3 text-sm font-semibold text-neutral-850 tab:mx-auto tab:max-w-[59.25rem]"
-              >
-                <span>임시저장 {draftCount}개</span>
-                <span className="text-xs font-medium text-text-secondary">이어서 쓰기</span>
-              </Link>
-            )}
+          {/* 임시저장(보조)과 글 작성(주 액션)을 한 줄에 둬 진입점이 위아래로 쌓이지 않게 한다.
+              개수 칩만 포인트 컬러로 남겨 두 액션이 같은 갈래임을 드러낸다 */}
+          <InputUpload
+            text="글 작성하기"
+            href="/community/write"
+            className="px-4"
+            left={
+              draftCount > 0 && (
+                <Link
+                  href="/community/drafts"
+                  className="group inline-flex min-w-0 items-center gap-1.5 text-neutral-700 transition-colors hover:text-neutral-850"
+                >
+                  <span className="flex h-5 min-w-5 shrink-0 items-center justify-center rounded-full bg-point-500 px-1.5 text-[0.6875rem] leading-none font-semibold text-neutral-850">
+                    {draftCount}
+                  </span>
+                  <span className="truncate text-xs leading-[1.5] font-medium">
+                    임시저장 이어서 쓰기
+                  </span>
+                  <ArrowRightIcon className="size-3.5 shrink-0 transition-transform group-hover:translate-x-0.5" />
+                </Link>
+              )
+            }
+          />
+
+          <Container className="px-4 pt-2 pb-6 tab:pb-10">
             <PostList
               posts={posts}
               emptyText="내가 쓴 글이 없습니다."

--- a/src/app/(main)/home/_ui/PostList.tsx
+++ b/src/app/(main)/home/_ui/PostList.tsx
@@ -1,6 +1,6 @@
 import { Fragment } from 'react'
 import { toCommunityPreviewProps } from '@/entities/community'
-import { ConnectedPostCard } from '@/features/community'
+import { ConnectedFeedCard } from '@/features/community'
 import type { CommunityPostCard } from '@/shared/types'
 
 interface PostListProps {
@@ -12,8 +12,9 @@ interface PostListProps {
   onDelete?: (postId: string) => void
 }
 
-// 디자인(2046-160971): 모바일은 카드 stack(gap-20), 탭·PC는 #cacaca 보더 박스(rounded-8) + 구분선, 게시글 간 gap-32
-// 박스는 max-w-948(59.25rem) 중앙 정렬(frame items-center), 세로 여백(spacing-40)은 래퍼 Container의 py가 담당
+// 커뮤니티 피드(/community)와 같은 단일 컬럼 카드 — 다만 폭은 좁히지 않고 래퍼 Container를 그대로 채운다.
+// 내 글 목록은 어디까지가 한 글인지 바로 보여야 해서 카드 사이에 구분선을 남긴다
+// (gap을 커뮤니티의 절반으로 두어 구분선 포함 간격이 24/32/40으로 같아진다)
 const PostList = ({ posts, emptyText = '게시글이 없습니다.', onEdit, onDelete }: PostListProps) => {
   if (posts.length === 0) {
     return (
@@ -24,17 +25,17 @@ const PostList = ({ posts, emptyText = '게시글이 없습니다.', onEdit, onD
   }
 
   return (
-    <div className="flex flex-col gap-5 tab:mx-auto tab:max-w-[59.25rem] tab:gap-8 tab:rounded-lg tab:border tab:border-neutral-300 tab:p-3">
+    <div className="flex w-full min-w-0 flex-col gap-3 tab:gap-4 pc:gap-5">
       {posts.map((post, index) => (
         <Fragment key={post.postId}>
-          <ConnectedPostCard
+          <ConnectedFeedCard
             {...toCommunityPreviewProps(post)}
+            // 마이홈 카드는 Container 폭을 다 쓰므로 정사각 캐러셀 대신 가로 스크롤로 늘어놓는다
+            mediaLayout="row"
             onEdit={onEdit && (() => onEdit(post.postId))}
             onDelete={onDelete && (() => onDelete(post.postId))}
           />
-          {index < posts.length - 1 && (
-            <div className="hidden h-px w-full bg-neutral-300 tab:block" />
-          )}
+          {index < posts.length - 1 && <div className="h-px w-full bg-neutral-300" />}
         </Fragment>
       ))}
     </div>

--- a/src/entities/community/ui/CommunityFeedCard.tsx
+++ b/src/entities/community/ui/CommunityFeedCard.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useRef } from 'react'
+import Image from 'next/image'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { ImageCarousel, OwnerActionsMenu, ProfileAvatar } from '@/shared/ui'
@@ -18,6 +19,8 @@ interface CommunityFeedCardProps extends CommunityPreviewProps {
   /** 좋아요·북마크 토글 — features의 ConnectedFeedCard에서 주입 */
   onToggleLike?: () => void
   onToggleSave?: () => void
+  /** 이미지 표현 — 커뮤니티 피드는 1:1 캐러셀, 마이홈처럼 카드가 넓은 곳은 가로 스크롤 썸네일 */
+  mediaLayout?: 'carousel' | 'row'
   className?: string
 }
 
@@ -41,6 +44,7 @@ const CommunityFeedCard = ({
   onDelete,
   onToggleLike,
   onToggleSave,
+  mediaLayout = 'carousel',
   className,
 }: CommunityFeedCardProps) => {
   const href = detailHref ?? `/community/post/${postId}`
@@ -110,8 +114,31 @@ const CommunityFeedCard = ({
         )}
       </div>
 
-      {/* 미디어 — 카드 폭을 채우는 1:1 캐러셀 (여러 장이면 우상단에 장수 배지) */}
-      {hasImages ? (
+      {/* 미디어 — 기본은 카드 폭을 채우는 1:1 캐러셀 (여러 장이면 우상단에 장수 배지),
+          row 는 사진을 원래 비율 그대로 가로로 늘어놓고 넘치면 스크롤한다 */}
+      {hasImages && mediaLayout === 'row' && (
+        <Link href={href} prefetch={false} className="block px-3 pt-1">
+          <div className="flex gap-3 overflow-x-auto">
+            {images.map((src, index) => (
+              <div
+                key={index}
+                className="relative h-[13.1875rem] w-[17.5625rem] shrink-0 overflow-hidden rounded-lg bg-neutral-700 tab:h-60 tab:w-80"
+              >
+                {src && (
+                  <Image
+                    src={src}
+                    alt={`게시글 이미지 ${index + 1}`}
+                    fill
+                    className="object-cover"
+                  />
+                )}
+              </div>
+            ))}
+          </div>
+        </Link>
+      )}
+
+      {hasImages && mediaLayout === 'carousel' && (
         <div
           className="relative aspect-square w-full cursor-pointer overflow-hidden rounded-lg"
           onPointerDown={handleImagePointerDown}
@@ -131,7 +158,10 @@ const CommunityFeedCard = ({
             </span>
           )}
         </div>
-      ) : (
+      )}
+
+      {/* 사진이 없으면 본문을 큼직하게 (있으면 아래 캡션에서 보여준다) */}
+      {!hasImages && (
         <Link href={href} prefetch={false} className="block px-3 py-5">
           <p className="line-clamp-6 text-base leading-[1.5] font-semibold whitespace-pre-line text-neutral-850">
             {text}

--- a/src/shared/ui/InputUpload.tsx
+++ b/src/shared/ui/InputUpload.tsx
@@ -1,35 +1,40 @@
+import type { ReactNode } from 'react'
 import Link from 'next/link'
 import { cn } from '@/shared/lib/cn'
+import { buttonVariants } from './Button'
 import { Container } from './Container'
 
 interface InputUploadProps {
-  /** 안내 문구 (placeholder 역할) */
+  /** 버튼 문구 */
   text: string
-  /** 우측 버튼 라벨 (탭·PC에서만 노출) */
-  buttonText?: string
-  /** 이동 경로 (바 전체가 링크) */
+  /** 이동 경로 */
   href: string
-  /** 내용 행에 적용 — 좌우 여백을 주변 콘텐츠에 맞출 때 사용 */
+  /** 같은 줄 왼쪽에 놓을 보조 액션 (임시저장 이어쓰기 등) — 없으면 버튼만 오른쪽에 붙는다 */
+  left?: ReactNode
+  /** Container에 적용 — 좌우 여백을 주변 콘텐츠에 맞출 때 사용 */
   className?: string
 }
 
 /**
- * 게시글/분양글 작성 유도 바 (Figma node 818-110386 · InputUpload)
- * - 상·하 #cacaca 보더는 풀블리드, 내용은 Container 폭에 맞춘다 (주변 콘텐츠와 좌우 정렬)
- * - 모바일: 문구만, 탭·PC: 문구 + 작성하기 버튼
+ * 작성 진입 줄.
+ * 주 액션은 오른쪽 끝, 보조 액션은 같은 줄 왼쪽에 둬 진입점이 위아래로 쌓이지 않게 한다.
+ * 버튼은 입양 신청하기와 같은 공통 BaseButton primary(포인트 옐로우 알약)를 쓴다.
  */
-const InputUpload = ({ text, buttonText = '작성하기', href, className }: InputUploadProps) => {
+const InputUpload = ({ text, href, left, className }: InputUploadProps) => {
   return (
-    <Link href={href} className="block border-y border-neutral-300 bg-white">
-      <Container className={cn('flex items-center justify-between gap-3 py-2', className)}>
-        <span className="min-w-0 truncate text-sm leading-[1.5] font-medium text-neutral-700">
-          {text}
-        </span>
-        <span className="hidden h-8 shrink-0 items-center justify-center rounded-lg bg-neutral-850 px-2 text-sm leading-[1.5] font-semibold text-neutral-50 tab:flex">
-          {buttonText}
-        </span>
-      </Container>
-    </Link>
+    <Container className={cn('flex items-center justify-between gap-3 py-3', className)}>
+      {/* 보조 액션이 없어도 버튼이 오른쪽에 남도록 자리를 채운다 */}
+      {left ?? <span />}
+      <Link
+        href={href}
+        className={cn(
+          buttonVariants({ variant: 'primary', size: 'sm' }),
+          'shrink-0 px-4 whitespace-nowrap tab:h-10 tab:px-5 tab:text-base',
+        )}
+      >
+        {text}
+      </Link>
+    </Container>
   )
 }
 


### PR DESCRIPTION
Closes #281

마이홈의 작성 진입점과 게시글 목록이 커뮤니티(`/community`)와 다른 규칙을 쓰고 있어 맞춘다.

## Changes

### 작성 진입 줄 (`InputUpload`)
회색 안내문 + 검정 알약이 담긴 풀블리드 바였고, 임시저장 이어쓰기는 그 아래 별도 테두리 박스였다. 같은 성격의 진입점이 위아래로 쌓여 서로 경쟁했다.

```
전                                    후
──────────────────────────────
게시글을 올려보세요      [작성하기]      ① 임시저장 이어서 쓰기 →   [ 글 작성하기 ]
──────────────────────────────
┌────────────────────────────┐
│ 임시저장 1개      이어서 쓰기 │
└────────────────────────────┘
```

- 주 액션은 오른쪽 끝, 보조 액션은 같은 줄 왼쪽(`left` 슬롯). 보조가 없으면 버튼만 오른쪽에 남는다
- 버튼을 공통 `BaseButton` primary로 교체 — 입양 신청하기와 같은 토큰이라 버튼 스펙이 바뀌면 함께 따라간다
- 임시저장은 테두리를 걷어내고 인라인 링크로 낮췄다. 개수 칩만 포인트 컬러로 남겨 두 액션이 같은 갈래임을 드러낸다

### 작성 진입점을 탭 안으로
탭 바깥에 있을 때는 버튼 하나가 역할에 따라 목적지만 바뀌어, 브리더는 어느 탭에 있든 `분양글 작성`만 보였고 커뮤니티 글 진입점이 아예 없었다.

| 탭 | 작성 진입점 |
|---|---|
| 분양 목록 (브리더) | 분양글 작성하기 |
| 게시글 | 임시저장 이어서 쓰기 + 글 작성하기 |
| 즐겨찾는 브리더 | 없음 |

### 게시글 목록을 피드 카드로
커뮤니티는 단일 컬럼 피드 카드로 바뀌었는데 마이홈만 게시판형(`ConnectedPostCard` + 보더 박스)으로 남아 있었다. `ConnectedFeedCard`로 교체한다.

`CommunityFeedCard`에 `mediaLayout`을 추가했다. 마이홈 카드는 래퍼 폭을 다 쓰기 때문에 1:1 캐러셀을 그대로 쓰면 사진이 과하게 커진다.

- `carousel` (기본) — 커뮤니티 피드. 카드 폭을 채우는 1:1 캐러셀
- `row` — 마이홈. 사진을 원래 비율로 가로에 늘어놓고 넘치면 스크롤

내 글 목록은 어디까지가 한 글인지 바로 보여야 해서 카드 사이 구분선은 남기고, gap을 커뮤니티의 절반으로 두어 구분선을 포함한 간격이 같아지게 했다.

## 검증
- `pnpm type-check`, `pnpm build`, `pnpm exec eslint` 통과

## How to test
1. `/home` 게시글 탭 — 임시저장 링크와 글 작성하기 버튼이 한 줄에 좌우로 놓이는지
2. 임시저장이 없을 때 — 버튼만 오른쪽에 남는지
3. 브리더 계정 — 분양 목록 탭에 분양글 작성하기, 게시글 탭에 글 작성하기가 각각 뜨는지
4. 마이홈 게시글 카드가 커뮤니티 피드 카드와 같은 모양인지, 사진은 가로 스크롤인지
5. `/community` 피드는 기존대로 1:1 캐러셀인지
6. `/adoption/my-listings` 분양글 작성하기 버튼