### PR TITLE
feat(auth): SSO 탈퇴 계정 복구 플로우 연동

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,5 +1,5 @@
 import { Suspense } from 'react'
-import { SocialLoginList } from '@/features/auth'
+import { ReactivateAccountPrompt, SocialLoginList } from '@/features/auth'
 import { RESPONSIVE_SHELL_CLASS } from '@/shared/config'
 import { AlertMessage } from '@/shared/ui'
 import { CheckRoundedIcon } from '@/shared/assets'
@@ -21,6 +21,10 @@ import { LogoButton } from '@/widgets/gnb'
  *
  * ?signup=completed 로 들어오면 "가입은 끝났는데 토큰 쿠키 저장만 실패한" 경우다.
  *   (온보딩 마지막 단계의 saveAuthTokens 가 false 를 반환하면 여기로 보낸다)
+ *
+ * ?type=deleted_account 로 들어오면 탈퇴 계정으로 소셜 로그인한 경우다.
+ *   - reactivationToken 이 함께 오면 → 복구 확인 모달 (ReactivateAccountPrompt)
+ *   - 없으면(정지 계정 등 복구 불가) → error 사유만 안내
  *
  * Figma: PC 3414:750712 / Tablet 3414:751419 / Mobile 3414:751420
  * 원본의 이메일·비밀번호 안내와 별도 회원가입 링크는 현재 소셜 전용 인증 계약에 맞게
@@ -68,6 +72,11 @@ const LoginPage = async ({ searchParams }: { searchParams: Promise<{ signup?: st
                 className="justify-center"
               />
             )}
+
+            {/* 탈퇴 계정 복구 안내 — useSearchParams 를 쓰므로 Suspense 필요 (Next 16) */}
+            <Suspense fallback={null}>
+              <ReactivateAccountPrompt />
+            </Suspense>
 
             {/* SocialLoginList 는 useSearchParams(returnUrl) 를 쓰므로 Suspense 로 감싼다 (Next 16 요구사항) */}
             <Suspense fallback={<SocialLoginFallback />}>

--- a/src/features/auth/api/auth.api.ts
+++ b/src/features/auth/api/auth.api.ts
@@ -1,6 +1,6 @@
 import { apiClient, API_VERSION, unwrap } from '@/shared/api'
 import type { ApiRequestConfig } from '@/shared/api'
-import type { ApiResponse } from '@/shared/types'
+import type { ApiResponse, ReactivateAccountResponse } from '@/shared/types'
 
 export const logout = async (): Promise<{ message: string; loggedOutAt: string }> => {
   try {
@@ -17,3 +17,23 @@ export const logout = async (): Promise<{ message: string; loggedOutAt: string }
     throw error
   }
 }
+
+/**
+ * 탈퇴 계정 복구 (재가입이 아니라 기존 계정 되살리기 — 계정 _id 가 유지된다)
+ *
+ * 소셜 콜백이 /login 쿼리로 넘겨준 reactivationToken(유효 10분) 으로만 호출할 수 있다.
+ * - skipAuth: 비로그인 상태에서 부르므로 Authorization 헤더를 싣지 않는다.
+ * - skipAuthRefresh: 이 API 의 401 은 인증 실패가 아니라 "복구 토큰이 유효하지 않다"는
+ *   도메인 에러다. refresh 를 타면 서버 문구가 '세션이 만료되었습니다' 로 덮이고
+ *   쿠키까지 지워지므로 자동 갱신을 건너뛴다.
+ */
+export const reactivateAccount = async (
+  reactivationToken: string,
+): Promise<ReactivateAccountResponse> =>
+  apiClient
+    .post<ApiResponse<ReactivateAccountResponse>>(
+      `${API_VERSION}/auth/reactivate`,
+      { reactivationToken },
+      { skipAuth: true, skipAuthRefresh: true } as ApiRequestConfig,
+    )
+    .then((res) => unwrap(res, '계정 복구에 실패했습니다.'))

--- a/src/features/auth/api/auth.mutations.ts
+++ b/src/features/auth/api/auth.mutations.ts
@@ -1,6 +1,13 @@
 'use client'
 
 import { useMutation } from '@tanstack/react-query'
-import { logout } from './auth.api'
+import { logout, reactivateAccount } from './auth.api'
 
 export const useLogout = () => useMutation({ mutationFn: logout })
+
+/**
+ * 탈퇴 계정 복구 — 성공하면 소셜 로그인과 동일한 토큰 세트를 돌려준다.
+ * 호출부에서 saveAuthTokens 로 쿠키에 심어야 로그인 상태가 된다.
+ */
+export const useReactivateAccount = () =>
+  useMutation({ mutationFn: (reactivationToken: string) => reactivateAccount(reactivationToken) })

--- a/src/features/auth/index.ts
+++ b/src/features/auth/index.ts
@@ -1,5 +1,6 @@
 export * from './api/auth.mutations'
 export * from './ui/SocialLoginList'
+export * from './ui/ReactivateAccountPrompt'
 export * from './ui/SocialSignupCapture'
 export * from './lib/useAuthStatus'
 export * from './lib/useLoginGuard'

--- a/src/features/auth/ui/ReactivateAccountPrompt.tsx
+++ b/src/features/auth/ui/ReactivateAccountPrompt.tsx
@@ -1,0 +1,170 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { normalizeApiError } from '@/shared/api'
+import { formatDate } from '@/shared/lib/formatDate'
+import { normalizeReturnUrl } from '@/shared/lib/normalizeReturnUrl'
+import { saveAuthTokens } from '@/shared/lib/saveAuthTokens'
+import { AlertMessage, CtaModal } from '@/shared/ui'
+import { AlertCircleIcon } from '@/shared/assets'
+import { useReactivateAccount } from '../api/auth.mutations'
+
+/**
+ * 탈퇴 계정 복구 확인 (소셜 로그인 콜백 → /login)
+ *
+ * 탈퇴한 계정으로 다시 소셜 로그인하면 백엔드가 차단 대신 복구 토큰을 실어 되돌려보낸다:
+ *   /login?type=deleted_account&reactivationToken=<JWT>&expiresIn=600
+ *         &message=...&role=...&email=...&name=...&deletedAt=...&returnUrl=...
+ *
+ * 여기서 확인을 받고 POST /api/v2/auth/reactivate 로 계정을 되살린다.
+ * 새 계정을 만드는 게 아니라 기존 계정을 그대로 복구하는 것이라 계정 id 가 유지되고
+ * 채팅방·입양신청·후기·즐겨찾기가 함께 살아난다 — 문구도 "재가입"이 아닌 "복구"로 쓴다.
+ *
+ * 복구 대상이 아닌 차단(정지 계정 등)은 기존처럼 reactivationToken 없이
+ * `error` 파라미터만 실려 오므로, 그 경우엔 사유만 안내하고 끝낸다.
+ */
+
+/** 복구 토큰 유효시간 기본값 — 콜백이 expiresIn 을 안 실어줄 때만 사용 */
+const DEFAULT_EXPIRES_IN_SEC = 600
+
+const EXPIRED_MESSAGE = '복구 요청이 만료되었습니다. 다시 로그인해주세요.'
+
+/** 서버에 닿지 못했을 때 — axios 의 'Network Error' 가 그대로 노출되는 것을 막는다 */
+const REQUEST_FAILED_MESSAGE = '계정 복구에 실패했습니다. 잠시 후 다시 시도해주세요.'
+
+const formatRemaining = (seconds: number) => {
+  const m = Math.floor(seconds / 60)
+  const s = seconds % 60
+  return `${m}:${String(s).padStart(2, '0')}`
+}
+
+const ErrorNotice = ({ text }: { text: string }) => (
+  <AlertMessage
+    status="error"
+    size="responsive"
+    icon={AlertCircleIcon}
+    message={text}
+    className="justify-center"
+  />
+)
+
+const ReactivateAccountPrompt = () => {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const reactivate = useReactivateAccount()
+
+  const isDeletedAccount = searchParams.get('type') === 'deleted_account'
+  const reactivationToken = searchParams.get('reactivationToken')
+  // 복구 안내는 message, 복구 불가 차단 사유는 error 로 온다 (백엔드 콜백 규약)
+  const message = searchParams.get('message')
+  const blockedReason = searchParams.get('error')
+  const email = searchParams.get('email')
+  const name = searchParams.get('name')
+  const deletedAt = searchParams.get('deletedAt')
+  const returnUrl = normalizeReturnUrl(searchParams.get('returnUrl'))
+
+  const canReactivate = isDeletedAccount && Boolean(reactivationToken)
+
+  const [dismissed, setDismissed] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  // 남은 시간 — 콜백 직후 진입이라 페이지 진입 시각을 토큰 발급 시각으로 본다.
+  const initialRemaining = useMemo(() => {
+    const parsed = Number(searchParams.get('expiresIn'))
+    return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : DEFAULT_EXPIRES_IN_SEC
+  }, [searchParams])
+  const [remaining, setRemaining] = useState(initialRemaining)
+
+  useEffect(() => {
+    if (!canReactivate) return
+    // 0 에서는 같은 값을 반환해 리렌더를 멈춘다
+    const timer = setInterval(() => setRemaining((prev) => (prev > 0 ? prev - 1 : prev)), 1000)
+    return () => clearInterval(timer)
+  }, [canReactivate])
+
+  // 만료·에러 상태는 effect 없이 파생시킨다 (서버도 같은 시점부터 401 을 준다)
+  const isExpired = canReactivate && remaining <= 0
+  const displayError = errorMessage ?? (isExpired ? EXPIRED_MESSAGE : null)
+  const open = canReactivate && !dismissed && !displayError
+
+  /** 복구 토큰을 URL 에 남겨두지 않는다 — 새로고침 시 재확인·유출 방지 */
+  const handleCancel = () => {
+    setDismissed(true)
+    router.replace('/login')
+  }
+
+  const handleConfirm = async () => {
+    if (!reactivationToken || reactivate.isPending) return
+
+    try {
+      const { accessToken, refreshToken } = await reactivate.mutateAsync(reactivationToken)
+      const saved = await saveAuthTokens({ accessToken, refreshToken })
+
+      setDismissed(true)
+      // 복구는 됐는데 쿠키 저장만 실패한 경우 — 계정은 살아났으니 로그인만 다시 시킨다
+      router.replace(saved ? returnUrl : '/login')
+    } catch (error) {
+      // 서버가 준 도메인 에러(토큰 만료·정지 계정 등)는 그대로 보여준다.
+      // 반면 네트워크 실패는 status 가 없고 axios 가 'Network Error' 를 message 에 넣어
+      // 영문이 그대로 노출되므로, 그때만 안내 문구로 갈아끼운다.
+      const apiError = normalizeApiError(error, REQUEST_FAILED_MESSAGE)
+      setErrorMessage(apiError.status ? apiError.message : REQUEST_FAILED_MESSAGE)
+    }
+  }
+
+  // 복구 대상이 아닌 차단(정지 계정 등) — 사유만 알린다
+  if (isDeletedAccount && !reactivationToken) {
+    return <ErrorNotice text={blockedReason ?? message ?? '이 계정으로는 로그인할 수 없습니다.'} />
+  }
+
+  if (!canReactivate) return null
+
+  return (
+    <>
+      {displayError && <ErrorNotice text={displayError} />}
+
+      <CtaModal
+        open={open}
+        onOpenChange={(next) => {
+          if (!next) handleCancel()
+        }}
+        showClose={false}
+        direction="responsive-reverse"
+        title="탈퇴한 계정이에요. 복구할까요?"
+        description={
+          <span className="flex flex-col gap-2">
+            <span>
+              {message ?? '탈퇴한 계정입니다. 복구 후 이용하시겠습니까?'}
+              <br />
+              복구하면 이전에 쓰던 채팅·입양신청·후기가 그대로 살아나요.
+            </span>
+
+            {(name || email || deletedAt) && (
+              <span className="flex flex-col text-sm text-neutral-700">
+                {name && <span>{name}</span>}
+                {email && <span>{email}</span>}
+                {deletedAt && <span>탈퇴일 {formatDate(deletedAt)}</span>}
+              </span>
+            )}
+
+            <span className="text-sm text-neutral-700">
+              남은 시간 {formatRemaining(remaining)} — 지나면 다시 로그인해야 해요.
+            </span>
+          </span>
+        }
+        actions={[
+          { label: '취소', variant: 'outline', onClick: handleCancel },
+          {
+            label: reactivate.isPending ? '복구 중...' : '복구하기',
+            variant: 'fill',
+            onClick: handleConfirm,
+            disabled: reactivate.isPending,
+          },
+        ]}
+      />
+    </>
+  )
+}
+
+export { ReactivateAccountPrompt }

--- a/src/features/auth/ui/SocialLoginList.tsx
+++ b/src/features/auth/ui/SocialLoginList.tsx
@@ -69,15 +69,20 @@ export const SocialLoginList = () => {
   const hasAccessToken = () =>
     document.cookie.split(';').some((c) => c.trim().startsWith('accessToken='))
 
+  // 탈퇴 계정 복구 안내로 들어온 경우엔 자동 이탈시키지 않는다.
+  // 지난 세션의 accessToken 쿠키가 남아 있으면 복구 확인 모달을 보기도 전에 튕겨 나가고,
+  // 그 사이 유효시간 10분짜리 reactivationToken 이 URL 과 함께 유실된다.
+  const isReactivationPrompt = searchParams.get('type') === 'deleted_account'
+
   // 이미 로그인된 상태로 /login 에 진입하면(뒤로가기 등) 즉시 벗어난다 — 로그인 페이지 트랩 방지.
   // replace 로 이동해 /login 이 히스토리에 남지 않게 한다.
   useEffect(() => {
-    if (hasAccessToken()) router.replace(returnUrl)
-  }, [router, returnUrl])
+    if (!isReactivationPrompt && hasAccessToken()) router.replace(returnUrl)
+  }, [router, returnUrl, isReactivationPrompt])
 
   // 버튼 클릭 시점에도 한 번 더 확인 (마운트 이후 다른 탭에서 로그인된 경우 등)
   const redirectIfLoggedIn = (): boolean => {
-    if (hasAccessToken()) {
+    if (!isReactivationPrompt && hasAccessToken()) {
       router.replace(returnUrl)
       return true
     }

--- a/src/shared/types/AuthTypes.ts
+++ b/src/shared/types/AuthTypes.ts
@@ -95,3 +95,40 @@ export interface LogoutResponseDto {
   message: string
   loggedOutAt: string
 }
+
+// ─── SSO 탈퇴 계정 복구 (POST /api/v2/auth/reactivate) ───
+
+/**
+ * 소셜 콜백이 탈퇴 계정 로그인 시 /login 쿼리로 넘겨주는 복구 안내 정보.
+ *
+ * 주의: 안내 문구는 `error` 가 아니라 `message` 파라미터로 온다.
+ *       (정지 계정처럼 복구 대상이 아닌 차단 케이스는 기존대로 `error` 로 온다)
+ */
+export interface ReactivationPrompt {
+  /** 소셜 콜백에서만 발급되는 단기 JWT — 이 값이 있어야 복구 확인 UI를 띄운다 */
+  reactivationToken: string
+  message?: string
+  email?: string
+  /** 입양자는 닉네임, 브리더는 상호명 */
+  name?: string
+  /** 탈퇴 일시 (ISO8601) — 백엔드가 못 채울 수 있다 */
+  deletedAt?: string
+  returnUrl?: string
+  /** 복구 토큰 유효시간(초). 콜백 기본값 600(10분) */
+  expiresIn: number
+}
+
+/** 복구 성공 응답 — 소셜 로그인 성공과 동일한 토큰 세트를 준다 */
+export interface ReactivateAccountResponse {
+  accessToken: string
+  refreshToken: string
+  accessTokenExpiresIn: number
+  refreshTokenExpiresIn: number
+  role: 'adopter' | 'breeder'
+  userInfo: {
+    userId: string
+    email: string
+    name: string
+    profileImage?: string
+  }
+}


### PR DESCRIPTION
## 배경

탈퇴한 계정으로 같은 소셜 계정으로 다시 로그인하면 지금까지는 영구 차단이었습니다. 이제 백엔드가 차단 대신 **복구 토큰을 실어 `/login` 으로 돌려보내고**, 프론트에서 확인을 받아 계정을 되살립니다.

재가입이 아니라 **기존 계정 복구**라 계정 `_id` 가 유지되고 이전 채팅방·입양신청·후기·즐겨찾기가 그대로 살아납니다. 문구도 그에 맞췄습니다.

백엔드 작업은 완료된 상태이고 이 PR 은 프론트 연동입니다.

## 콜백 규약

```
/login?type=deleted_account
  &message=탈퇴한 계정입니다. 복구 후 이용하시겠습니까?
  &reactivationToken=<JWT>  &expiresIn=600
  &role=adopter|breeder  &email=...  &name=...  &deletedAt=...  &returnUrl=...
```

- `type=deleted_account` 는 기존과 동일하고, `reactivationToken` 이 함께 올 때만 복구 확인 UI 를 띄웁니다.
- 안내 문구는 `error` 가 아니라 **`message`** 로 옵니다. 복구 불가 차단(정지 계정 등)만 기존대로 `error` 를 씁니다.

## 커밋

| 커밋 | 내용 |
|---|---|
| `feat(auth): 탈퇴 계정 복구 API 연동` | `POST /api/v2/auth/reactivate` + 타입 |
| `feat(auth): 탈퇴 계정 복구 확인 모달 추가` | `ReactivateAccountPrompt` + 로그인 페이지 연결 |
| `fix(auth): 복구 안내 진입 시 잔여 쿠키로 모달을 못 보고 튕기던 문제` | `SocialLoginList` 자동 이탈 가드 |

## 설계 메모

**`skipAuth` + `skipAuthRefresh` 로 호출합니다.** 이 API 의 401 은 인증 실패가 아니라 "복구 토큰이 유효하지 않다"는 도메인 에러입니다. 그냥 두면 refresh 인터셉터를 타서 서버 문구가 `세션이 만료되었습니다` 로 덮이고 쿠키까지 지워집니다.

**세 번째 커밋 (잔여 쿠키 이탈)** — `/login` 은 `accessToken` 쿠키가 있으면 트랩 방지를 위해 즉시 다른 화면으로 replace 합니다. 복구 안내로 들어온 경우에도 이게 먼저 걸려서, 지난 세션 쿠키가 남아 있으면 모달을 보기도 전에 쫓겨나고 **유효시간 10분짜리 `reactivationToken` 이 URL 과 함께 유실**됐습니다.

## 검증

로컬 백엔드(8080) 연동해 실제 브라우저로 확인했습니다.

| 케이스 | 결과 |
|---|---|
| 복구 성공 (실토큰) | 200 → 쿠키 세팅 → `returnUrl` 이동. `GET /profile/me` 200 이고 **userId 가 탈퇴 전과 동일** — 계정 `_id` 유지 확인 |
| 1회용 토큰 재사용 | `탈퇴 상태가 아닌 계정입니다.` 노출, 쿠키 안 심김 |
| 잘못된 토큰 | `유효하지 않은 복구 토큰입니다.` 그대로 노출. refresh·쿠키삭제 안 일어남 (네트워크 로그 확인) |
| 카운트다운 만료 | `복구 요청이 만료되었습니다. 다시 로그인해주세요.` |
| 정지 계정 차단 | 사유만 안내 |
| 취소 | URL 이 `/login` 으로 정리되며 토큰 폐기 |
| 서버 미응답 | `Network Error` 대신 한국어 안내 문구 |
| 잔여 쿠키 + 복구 링크 | 모달 정상 노출 (수정 전에는 튕김) |

`type-check` / `lint` / `lint:fsd` 전부 통과하고, 세 커밋이 각각 독립적으로도 타입체크를 통과합니다.

> 성공 경로는 백엔드가 `Set-Cookie` 를 제거한 최신 버전으로 재검증을 마쳤습니다. `reactivate` 200 응답에 `Set-Cookie` 가 없고, 쿠키는 BFF(`/api/auth/set-cookie`) 단독으로 심는 것을 네트워크 로그에서 확인했습니다.

## 별건 — 이 PR 범위 밖

작업 중 **프로덕션 쿠키 중복 가능성**을 발견했습니다. 프로덕션 로그인은 백엔드가 `.pawpong.kr` 쿠키를 심고, 이후 첫 토큰 refresh 때 BFF 가 host-only 쿠키를 추가로 심어 같은 이름 쿠키가 2개 공존할 수 있습니다.

- `shared/api/token.ts` 는 첫 매칭을 집고 domain 을 구분하지 않습니다
- `app/api/auth/set-cookie/route.ts:48` 의 `res.cookies.delete('accessToken')` 은 domain 이 없어 `.pawpong.kr` 쿠키를 지우지 못합니다 (중복 방지 주석이 실제로는 동작하지 않음)
- 백엔드의 JWT 추출은 쿠키가 1순위이고, `cookie.parse` 는 **중복 이름이면 첫 항목만** 취합니다 (`cookie@0.7.2` 로 직접 확인)

프로덕션 인증 동작 변경이라 임의로 손대지 않았습니다. 실제 재현 확인과 방향 결정이 필요합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012LftRzoUGWJ1366H6Hf3Xz

