### PR TITLE
fix(gnb): 알림 벨 Figma 아이콘 교체와 헤더 배치·모바일 반응형 정리

### DIFF
--- a/src/widgets/gnb/ui/AuthActions.tsx
+++ b/src/widgets/gnb/ui/AuthActions.tsx
@@ -7,7 +7,7 @@ import { Button, buttonVariants } from '@/shared/ui'
 
 interface AuthActionsProps {
   className?: string
-  placement?: 'header' | 'menu-header' | 'menu-footer'
+  placement?: 'header' | 'header-mobile' | 'menu-header' | 'menu-footer'
 }
 
 const PILL =
@@ -24,7 +24,10 @@ const AuthActions = ({ className, placement = 'header' }: AuthActionsProps) => {
 
   // 서버 렌더는 항상 비로그인이라, 쿠키를 읽기 전에 그리면 로그인 사용자에게 버튼이 스쳤다 사라진다
   if (!isReady) return null
-  if (placement === 'menu-header' && isLoggedIn) return null
+  // 로그아웃 버튼은 pc 헤더(NavBar)와 전체메뉴 푸터에만 둔다. mo·tab 헤더와 전체메뉴 헤더는
+  // 로그인 사용자에게 아무것도 그리지 않는다 — 좁은 헤더를 밀어내고, 로그아웃은 메뉴 푸터에 있다.
+  const showsLogout = placement === 'header' || placement === 'menu-footer'
+  if (isLoggedIn && !showsLogout) return null
 
   if (isLoggedIn || placement === 'menu-footer') {
     return (

--- a/src/widgets/gnb/ui/Gnb.tsx
+++ b/src/widgets/gnb/ui/Gnb.tsx
@@ -28,15 +28,16 @@ const Gnb = () => {
           )}
         >
           <LogoButton />
-          {/* Figma 3349:1763537 — nav·로그인·메뉴 아이콘 사이 20px.
+          {/* Figma 3349:1763537 — pc 는 nav·로그인·메뉴 아이콘 사이 20px.
+              mo·tab 은 헤더가 좁아 12px 로 줄인다.
               비로그인은 nav 대신 로그인/회원가입 (Figma GNB '로그인' 상태) */}
-          <div className="flex items-center gap-5">
+          <div className="flex items-center gap-3 pc:gap-5">
             {/* [refactored] 노출 조건은 AuthActions 가 판단한다. PC 는 NavBar 안 마이홈 자리에서 렌더 */}
-            <AuthActions className="pc:hidden" />
+            <AuthActions placement="header-mobile" className="pc:hidden" />
             <NavBar className="hidden pc:flex" />
             {/* 알림은 상시 확인하는 정보라 메뉴 안에 숨기지 않고 헤더에 상주시킨다.
-                (드롭다운·안읽음 뱃지를 갖춘 NotificationBell 이 만들어져 있었는데 어디에도 붙어 있지 않았다) */}
-            <NotificationBell />
+                pc 는 NavBar 안 마이홈 옆에서 렌더하므로 여기는 pc 미만 전용 (AuthActions 와 같은 방식) */}
+            <NotificationBell className="pc:hidden" />
             {/* 햄버거 메뉴 — 탭·모바일은 nav 대체, 데스크탑은 보조 메뉴 (전 브레이크포인트) */}
             <button
               type="button"

--- a/src/widgets/gnb/ui/NavBar.tsx
+++ b/src/widgets/gnb/ui/NavBar.tsx
@@ -8,6 +8,7 @@ import { useNavigationGuardContext } from '@/shared/lib/NavigationGuardContext'
 import { HEADER_NAV } from '@/shared/config'
 import { useAuthStatus, useMe } from '@/features/auth'
 import { AuthActions } from './AuthActions'
+import { NotificationBell } from './NotificationBell'
 
 interface NavBarProps {
   className?: string
@@ -51,6 +52,8 @@ const NavBar = ({ className }: NavBarProps) => {
           {label}
         </Link>
       ))}
+      {/* 알림은 마이홈 옆에 붙인다 (비로그인이면 NotificationBell 이 스스로 null) */}
+      <NotificationBell />
       {/* [refactored] 노출 조건은 AuthActions 내부 판단 */}
       <AuthActions className="hidden pc:block" />
     </nav>

--- a/src/widgets/gnb/ui/NotificationBell.tsx
+++ b/src/widgets/gnb/ui/NotificationBell.tsx
@@ -11,25 +11,21 @@ import { useMarkAsRead, useMarkAllAsRead } from '@/features/notification'
 import type { NotificationResponseDto } from '@/shared/types'
 import { Button } from '@/shared/ui'
 
-// 전용 벨 아이콘이 없어 인라인 SVG 사용 (nav 아이콘 톤과 동일한 currentColor)
-const BellIcon = ({ className }: { className?: string }) => (
-  <svg viewBox="0 0 24 24" fill="none" className={className} aria-hidden>
-    <path
-      d="M12 3a6 6 0 0 0-6 6c0 3.5-.8 5.2-1.6 6.2-.4.5 0 1.3.7 1.3h13.8c.7 0 1.1-.8.7-1.3-.8-1-1.6-2.7-1.6-6.2a6 6 0 0 0-6-6Z"
-      stroke="currentColor"
-      strokeWidth="1.6"
-      strokeLinejoin="round"
-    />
-    <path
-      d="M9.5 19a2.5 2.5 0 0 0 5 0"
-      stroke="currentColor"
-      strokeWidth="1.6"
-      strokeLinecap="round"
-    />
+// Figma icon/ bell (1596:77455 세트, 1596:97271) — nav 아이콘과 같은 픽셀 글리프라 currentColor 로 그린다.
+// Figma 원본은 속이 찬 실루엣 하나뿐이라, nav 아이콘들처럼 비활성은 외곽선만 남기고
+// 안쪽 두 칸(2.5383 단위 그리드)을 evenodd 로 도려낸다. 열려 있을 때만 원본대로 채운다.
+const BELL_BODY =
+  'M13.615 5.2121H18.6917V7.75043H21.23V10.2888H23.7683V20.4421H26.3066V22.9804H6V20.4421H8.53833V10.2888H11.0767V7.75043H13.615V5.2121ZM12.3458 24.2496H19.9608V26.7879H12.3458V24.2496Z'
+const BELL_HOLLOW =
+  'M13.615 7.75043H18.6917V10.2888H13.615V7.75043ZM11.0767 10.2888H21.23V20.4421H11.0767V10.2888Z'
+
+const BellIcon = ({ className, filled }: { className?: string; filled?: boolean }) => (
+  <svg viewBox="0 0 32 32" fill="currentColor" className={className} aria-hidden>
+    <path d={filled ? BELL_BODY : BELL_BODY + BELL_HOLLOW} fillRule="evenodd" clipRule="evenodd" />
   </svg>
 )
 
-const NotificationBell = () => {
+const NotificationBell = ({ className }: { className?: string }) => {
   const router = useRouter()
   const { isLoggedIn } = useAuthStatus()
   const [open, setOpen] = useState(false)
@@ -81,31 +77,39 @@ const NotificationBell = () => {
   }
 
   return (
-    <div ref={rootRef} className="relative">
+    <div ref={rootRef} className={cn('relative', className)}>
       <button
         type="button"
         onClick={() => setOpen((prev) => !prev)}
         aria-label="알림"
         aria-expanded={open}
         className={cn(
-          'flex items-center text-[1rem] font-medium text-neutral-700 transition-colors',
-          open && 'font-semibold text-primary-500',
+          // 헤더 nav 항목(NavBar)과 동일한 톤·아이콘 크기·간격을 쓴다
+          'flex items-center rounded pr-1 text-sm leading-[1.5] font-medium whitespace-nowrap text-primary-500 transition-colors hover:text-primary-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-500',
+          open && 'font-semibold',
         )}
       >
-        <div className="relative flex size-[3rem] items-center justify-center">
-          <BellIcon className="size-[1.5rem]" />
+        <span className="relative flex size-7 items-center justify-center">
+          <BellIcon className="size-7" filled={open} />
           {unreadCount > 0 && (
-            <span className="absolute top-2 right-2 flex h-4 min-w-4 items-center justify-center rounded-full bg-error-500 px-1 text-[0.625rem] leading-none font-semibold text-white">
+            <span className="absolute -top-0.5 -right-0.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-error-500 px-1 text-[0.625rem] leading-none font-semibold text-white">
               {unreadCount > 99 ? '99+' : unreadCount}
             </span>
           )}
-        </div>
-        <div className="flex h-[3rem] items-center justify-center px-[0.625rem]">알림</div>
+        </span>
+        <span className="hidden pc:inline">알림</span>
       </button>
 
       {/* 전체 알림 화면과 같은 grouped-list 톤의 드롭다운 패널 */}
       {open && (
-        <div className="absolute top-full right-0 z-dropdown mt-1 w-[22.5rem] overflow-hidden rounded-xl border border-neutral-150 bg-white shadow-[0_8px_24px_rgba(73,45,20,0.14)]">
+        // mo·tab 은 벨 기준(right-0)으로 띄우면 오른쪽 햄버거 폭만큼 밀려 화면 왼쪽으로 넘친다.
+        // 헤더(h-12) 아래 뷰포트 좌우에 물려 띄우고, pc 에서만 벨 기준 드롭다운으로 되돌린다.
+        <div
+          className={cn(
+            'fixed top-12 right-4 left-4 z-dropdown overflow-hidden rounded-xl border border-neutral-150 bg-white shadow-[0_8px_24px_rgba(73,45,20,0.14)]',
+            'pc:absolute pc:top-full pc:right-0 pc:left-auto pc:mt-1 pc:w-[22.5rem]',
+          )}
+        >
           <div className="flex items-center justify-between border-b border-neutral-150 bg-primary-50/60 px-4 py-3">
             <span className="text-base font-semibold text-neutral-850">알림</span>
             {unreadCount > 0 && (
@@ -119,7 +123,7 @@ const NotificationBell = () => {
             )}
           </div>
 
-          <div className="max-h-[26rem] overflow-y-auto">
+          <div className="max-h-[min(26rem,60vh)] overflow-y-auto">
             {isLoading ? (
               <p className="px-4 py-10 text-center text-sm text-neutral-700">불러오는 중...</p>
             ) : isError ? (


### PR DESCRIPTION
Closes #286

## 변경 사항
- 임시로 그려두었던 벨 SVG를 Figma `icon/ bell` (1596:97271) 패스로 교체. Figma 원본은 속이 찬 실루엣 하나뿐이라, nav 아이콘 세트처럼 비활성은 2.5383 픽셀 그리드에 맞춰 안쪽을 `evenodd` 로 도려내고 드롭다운이 열렸을 때만 채운다
- pc: 벨을 `NavBar` 안 마이홈 옆으로 이동. `AuthActions` 가 쓰던 방식(pc 는 NavBar, 그 미만은 헤더 직속)을 그대로 따랐다
- mo·tab: "알림" 라벨을 숨겨 아이콘만 두고, 헤더 gap 을 20px → 12px 로 줄였다
- `AuthActions` 에 `header-mobile` placement 추가 — mo·tab 헤더에서는 로그인 사용자에게 로그아웃 버튼을 그리지 않는다 (전체메뉴 푸터에 이미 있고, 좁은 헤더를 밀어냈다). 비로그인 로그인 버튼은 유지
- 알림 드롭다운이 375px 에서 화면 왼쪽으로 44px 넘치던 문제 수정. 벨 기준 `right-0` 인데 오른쪽에 햄버거(40px)+gap+px-4 가 있어 밀려났다. mo·tab 은 헤더 아래 뷰포트 좌우에 물리고(`fixed top-12 right-4 left-4`), pc 에서만 기존 드롭다운으로 되돌린다. 목록 높이도 `max-h-[min(26rem,60vh)]` 로 잡아 작은 화면에서 푸터가 밀리지 않게 했다

## 확인 방법
1. 1440: 헤더 nav 에서 마이홈 오른쪽에 알림이 붙고, 글자 크기/색/아이콘 크기가 옆 항목들과 같은지
2. 375 / 768: 로그인 상태에서 헤더가 `로고 + 벨 + 햄버거` 로만 구성되고 넘치지 않는지
3. 375: 알림 드롭다운이 화면 밖으로 나가지 않고 좌우 16px 여백으로 뜨는지
4. 비로그인: mo·tab 헤더에 로그인 버튼이 그대로 있는지

## 남은 것
pc 미만에서 `/notifications` 전체 페이지 진입로가 드롭다운 안 "알림 전체 보기" 하나뿐입니다. 전체메뉴(`MOBILE_MENU_ITEMS`)에 알림 항목 추가는 별도로 논의가 필요해 이번 PR 범위에서 제외했습니다.